### PR TITLE
Add terminal UI engine (stage 1): full-screen + inline rendering

### DIFF
--- a/app/examples/tui/inline_demo.dart
+++ b/app/examples/tui/inline_demo.dart
@@ -21,8 +21,16 @@ Future<void> main() async {
 
 // Braille spinner frames.
 const _spinner = [
-  0x280B, 0x2819, 0x2839, 0x2838, 0x283C,
-  0x2834, 0x2826, 0x2827, 0x2807, 0x280F,
+  0x280B,
+  0x2819,
+  0x2839,
+  0x2838,
+  0x283C,
+  0x2834,
+  0x2826,
+  0x2827,
+  0x2807,
+  0x280F,
 ];
 
 Future<void> _statusPanel(Terminal terminal) async {
@@ -44,8 +52,12 @@ Future<void> _statusPanel(Terminal terminal) async {
       final (label, color) = _phase(progress);
 
       // Row 1: spinner + phase label + progress bar + percentage.
-      b.set(1, 2,
-          Cell(rune: _spinner[frames % _spinner.length], fg: Color.brightYellow));
+      b.set(
+          1,
+          2,
+          Cell(
+              rune: _spinner[frames % _spinner.length],
+              fg: Color.brightYellow));
       b.writeAt(1, 4, label.padRight(15), style: TextStyle.bold, fg: color);
       final barStart = 20;
       final barEnd = w - 7;

--- a/app/examples/tui/inline_demo.dart
+++ b/app/examples/tui/inline_demo.dart
@@ -2,50 +2,110 @@ import 'dart:async';
 
 import 'package:flutterware_app/src/tui/tui.dart';
 
+/// Inline-mode showcase: a build-progress style status panel that coexists
+/// with normal shell output above it.
+///
+/// Exercises inline-mode rendering (anchored region, scrollback preserved),
+/// an animated progress bar, colors and styles, and timer-driven repaints
+/// through the encodeDiff origin offset.
 Future<void> main() async {
-  // Print some normal CLI output above the inline region first, so we can
-  // visually confirm the scrollback is preserved.
+  // Normal CLI output printed before the inline region — should remain
+  // visible in scrollback above the panel.
   print('--- preceding shell output (this should remain visible above) ---');
-  print('flutterware status:');
+  print('flutterware build:');
 
-  await Terminal.run((terminal) async {
-    var lastKey = '(none)';
-    var keyCount = 0;
-
-    void repaint() {
-      terminal.draw((b) {
-        final w = terminal.cols;
-        _drawBorder(b, 0, 0, terminal.rows, w);
-        b.writeAt(1, 2, 'Inline region: $w cols × ${terminal.rows} rows');
-        b.writeAt(2, 2, 'Last key: $lastKey (count: $keyCount)');
-        b.writeAt(3, 2, '(q to quit)');
-      });
-    }
-
-    repaint();
-    final resizeSub = terminal.resizes.listen((_) => repaint());
-
-    try {
-      await for (final event in terminal.keys) {
-        keyCount++;
-        lastKey = _describe(event);
-        if (event is CharKey && event.rune == 0x71 /* 'q' */) break;
-        if (event is CharKey &&
-            event.rune == 0x63 /* 'c' */ &&
-            event.modifiers.contains(Modifier.ctrl)) {
-          break;
-        }
-        repaint();
-      }
-    } finally {
-      await resizeSub.cancel();
-    }
-  }, mode: const InlineMode(rows: 5));
+  await Terminal.run(_statusPanel, mode: const InlineMode(rows: 5));
 
   print('--- inline region exited; back to normal shell output ---');
 }
 
-void _drawBorder(CellBuffer b, int row, int col, int rows, int cols) {
+// Braille spinner frames.
+const _spinner = [
+  0x280B, 0x2819, 0x2839, 0x2838, 0x283C,
+  0x2834, 0x2826, 0x2827, 0x2807, 0x280F,
+];
+
+Future<void> _statusPanel(Terminal terminal) async {
+  final start = DateTime.now();
+  var frames = 0;
+  var lastKey = '(none)';
+  var keyCount = 0;
+
+  void repaint() {
+    frames++;
+    terminal.draw((b) {
+      final w = terminal.cols;
+      _drawBorder(b, 0, 0, terminal.rows, w,
+          title: ' flutterware · inline status ');
+
+      final elapsed = DateTime.now().difference(start);
+      // Progress cycles 0..100 over ~8s so the bar visibly animates.
+      final progress = (elapsed.inMilliseconds ~/ 80) % 101;
+      final (label, color) = _phase(progress);
+
+      // Row 1: spinner + phase label + progress bar + percentage.
+      b.set(1, 2,
+          Cell(rune: _spinner[frames % _spinner.length], fg: Color.brightYellow));
+      b.writeAt(1, 4, label.padRight(15), style: TextStyle.bold, fg: color);
+      final barStart = 20;
+      final barEnd = w - 7;
+      final barWidth = (barEnd - barStart).clamp(0, w);
+      final filled = (barWidth * progress / 100).round();
+      for (var i = 0; i < barWidth; i++) {
+        b.set(
+          1,
+          barStart + i,
+          i < filled
+              ? Cell(rune: 0x2588, fg: color)
+              : const Cell(rune: 0x2591, fg: Color.brightBlack),
+        );
+      }
+      b.writeAt(1, barEnd + 1, '${progress.toString().padLeft(3)}%', fg: color);
+
+      // Row 2: elapsed time + most recent key.
+      b.writeAt(2, 2, 'Elapsed ${_fmtDuration(elapsed)}', fg: Color.brightCyan);
+      b.writeAt(2, 20, '· last key: $lastKey ($keyCount)',
+          style: TextStyle.dim);
+
+      // Row 3: quit hint.
+      b.writeAt(3, 2, 'press q to quit', style: TextStyle.dim);
+    });
+  }
+
+  repaint();
+  final resizeSub = terminal.resizes.listen((_) => repaint());
+  final ticker =
+      Timer.periodic(const Duration(milliseconds: 100), (_) => repaint());
+
+  try {
+    await for (final event in terminal.keys) {
+      keyCount++;
+      lastKey = _describe(event);
+      if (event is CharKey && event.rune == 0x71 /* 'q' */) break;
+      if (event is CharKey &&
+          event.rune == 0x63 /* 'c' */ &&
+          event.modifiers.contains(Modifier.ctrl)) {
+        break;
+      }
+      repaint();
+    }
+  } finally {
+    ticker.cancel();
+    await resizeSub.cancel();
+  }
+}
+
+/// Maps a 0..100 progress value to a build-phase label and accent color.
+(String, Color) _phase(int progress) {
+  if (progress >= 100) return ('Done', Color.brightGreen);
+  if (progress >= 75) return ('Optimizing', Color.brightMagenta);
+  if (progress >= 50) return ('Linking', Color.brightBlue);
+  if (progress >= 25) return ('Compiling', Color.brightYellow);
+  return ('Resolving deps', Color.brightCyan);
+}
+
+void _drawBorder(CellBuffer b, int row, int col, int rows, int cols,
+    {String? title}) {
   const tl = 0x250C, tr = 0x2510, bl = 0x2514, br = 0x2518;
   const h = 0x2500, v = 0x2502;
   b.set(row, col, const Cell(rune: tl));
@@ -60,6 +120,15 @@ void _drawBorder(CellBuffer b, int row, int col, int rows, int cols) {
     b.set(r, col, const Cell(rune: v));
     b.set(r, col + cols - 1, const Cell(rune: v));
   }
+  if (title != null) {
+    b.writeAt(row, col + 2, title, style: TextStyle.bold);
+  }
+}
+
+String _fmtDuration(Duration d) {
+  final m = d.inMinutes.toString().padLeft(2, '0');
+  final s = (d.inSeconds % 60).toString().padLeft(2, '0');
+  return '$m:$s';
 }
 
 String _describe(KeyEvent event) {
@@ -67,7 +136,8 @@ String _describe(KeyEvent event) {
       ? ''
       : '${event.modifiers.map((m) => m.name).join('+')}+';
   return switch (event) {
-    CharKey(:final rune) => '$mods${String.fromCharCode(rune)} (0x${rune.toRadixString(16)})',
+    CharKey(:final rune) =>
+      '$mods${String.fromCharCode(rune)} (0x${rune.toRadixString(16)})',
     SpecialKey(:final code) => '$mods${code.name}',
   };
 }

--- a/app/examples/tui/inline_demo.dart
+++ b/app/examples/tui/inline_demo.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 
-import '../tui.dart';
+import 'package:flutterware_app/src/tui/tui.dart';
 
 Future<void> main() async {
   // Print some normal CLI output above the inline region first, so we can

--- a/app/examples/tui/step1_demo.dart
+++ b/app/examples/tui/step1_demo.dart
@@ -31,8 +31,16 @@ const _ansiColors = <(String, Color)>[
 
 // Braille spinner frames.
 const _spinner = [
-  0x280B, 0x2819, 0x2839, 0x2838, 0x283C,
-  0x2834, 0x2826, 0x2827, 0x2807, 0x280F,
+  0x280B,
+  0x2819,
+  0x2839,
+  0x2838,
+  0x283C,
+  0x2834,
+  0x2826,
+  0x2827,
+  0x2807,
+  0x280F,
 ];
 
 Future<void> _showcase(Terminal terminal) async {
@@ -115,8 +123,12 @@ Future<void> _showcase(Terminal terminal) async {
       b.writeAt(row, 26, 'Frames:', style: TextStyle.bold);
       b.writeAt(row, 34, '$frames', fg: Color.brightCyan);
       b.writeAt(row, 46, 'Spinner:', style: TextStyle.bold);
-      b.set(row, 55,
-          Cell(rune: _spinner[frames % _spinner.length], fg: Color.brightYellow));
+      b.set(
+          row,
+          55,
+          Cell(
+              rune: _spinner[frames % _spinner.length],
+              fg: Color.brightYellow));
       row += 2;
 
       // Scrolling log of recent key events.

--- a/app/examples/tui/step1_demo.dart
+++ b/app/examples/tui/step1_demo.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 
-import '../tui.dart';
+import 'package:flutterware_app/src/tui/tui.dart';
 
 Future<void> main() async {
   await Terminal.run((terminal) async {

--- a/app/examples/tui/step1_demo.dart
+++ b/app/examples/tui/step1_demo.dart
@@ -2,48 +2,161 @@ import 'dart:async';
 
 import 'package:flutterware_app/src/tui/tui.dart';
 
+/// Full-screen feature showcase for the stage 1 TUI engine.
+///
+/// Exercises colors (ANSI + RGB), text styles, the encodeDiff style-reset
+/// path, live timer-driven repaints, resize handling, and key input.
 Future<void> main() async {
-  await Terminal.run((terminal) async {
-    var lastKey = '(none)';
-    var keyCount = 0;
-
-    void repaint() {
-      terminal.draw((b) {
-        final w = terminal.cols;
-        final h = terminal.rows;
-        const boxW = 36;
-        const boxH = 5;
-        final row = ((h - boxH) ~/ 2).clamp(0, h);
-        final col = ((w - boxW) ~/ 2).clamp(0, w);
-        _drawBorder(b, row, col, boxH, boxW);
-        b.writeAt(row + 1, col + 2, 'Size: $w × $h');
-        b.writeAt(row + 2, col + 2, 'Last key: $lastKey (count: $keyCount)');
-        b.writeAt(row + 3, col + 2, '(q to quit)');
-      });
-    }
-
-    repaint();
-    final resizeSub = terminal.resizes.listen((_) => repaint());
-
-    try {
-      await for (final event in terminal.keys) {
-        keyCount++;
-        lastKey = _describe(event);
-        if (event is CharKey && event.rune == 0x71 /* 'q' */) break;
-        if (event is CharKey &&
-            event.rune == 0x63 /* 'c' */ &&
-            event.modifiers.contains(Modifier.ctrl)) {
-          break;
-        }
-        repaint();
-      }
-    } finally {
-      await resizeSub.cancel();
-    }
-  });
+  await Terminal.run(_showcase);
 }
 
-void _drawBorder(CellBuffer b, int row, int col, int rows, int cols) {
+const _ansiColors = <(String, Color)>[
+  ('black', Color.black),
+  ('red', Color.red),
+  ('green', Color.green),
+  ('yellow', Color.yellow),
+  ('blue', Color.blue),
+  ('magenta', Color.magenta),
+  ('cyan', Color.cyan),
+  ('white', Color.white),
+  ('brightBlack', Color.brightBlack),
+  ('brightRed', Color.brightRed),
+  ('brightGreen', Color.brightGreen),
+  ('brightYellow', Color.brightYellow),
+  ('brightBlue', Color.brightBlue),
+  ('brightMagenta', Color.brightMagenta),
+  ('brightCyan', Color.brightCyan),
+  ('brightWhite', Color.brightWhite),
+];
+
+// Braille spinner frames.
+const _spinner = [
+  0x280B, 0x2819, 0x2839, 0x2838, 0x283C,
+  0x2834, 0x2826, 0x2827, 0x2807, 0x280F,
+];
+
+Future<void> _showcase(Terminal terminal) async {
+  final startTime = DateTime.now();
+  var frames = 0;
+  final recentKeys = <String>[];
+
+  void repaint() {
+    frames++;
+    terminal.draw((b) {
+      final w = terminal.cols;
+      final h = terminal.rows;
+      _drawBorder(b, 0, 0, h, w,
+          title: ' flutterware TUI engine — feature showcase ');
+
+      var row = 2;
+
+      // ANSI foreground swatches: a solid block in each of the 16 colors.
+      b.writeAt(row, 3, 'ANSI fg:', style: TextStyle.bold);
+      for (var i = 0; i < _ansiColors.length; i++) {
+        final c = Cell(rune: 0x2588, fg: _ansiColors[i].$2);
+        b.set(row, 13 + i * 2, c);
+        b.set(row, 13 + i * 2 + 1, c);
+      }
+      row++;
+
+      // ANSI background swatches: spaces painted with each background color.
+      b.writeAt(row, 3, 'ANSI bg:', style: TextStyle.bold);
+      for (var i = 0; i < _ansiColors.length; i++) {
+        final c = Cell(rune: 0x20, bg: _ansiColors[i].$2);
+        b.set(row, 13 + i * 2, c);
+        b.set(row, 13 + i * 2 + 1, c);
+      }
+      row += 2;
+
+      // 24-bit RGB gradient strip (red → green, constant blue).
+      b.writeAt(row, 3, 'RGB:', style: TextStyle.bold);
+      final stripWidth = (w - 16).clamp(0, 64);
+      for (var i = 0; i < stripWidth; i++) {
+        final t = stripWidth <= 1 ? 0.0 : i / (stripWidth - 1);
+        final color = Color.rgb(
+          (t * 255).round(),
+          ((1 - t) * 255).round(),
+          128,
+        );
+        b.set(row, 13 + i, Cell(rune: 0x2588, fg: color));
+      }
+      row += 2;
+
+      // Text styles — adjacent styled/unstyled cells exercise the
+      // encodeDiff style-reset branch.
+      b.writeAt(row, 3, 'Styles:', style: TextStyle.bold);
+      var c = 13;
+      for (final (label, style) in const [
+        ('Bold', TextStyle.bold),
+        ('Dim', TextStyle.dim),
+        ('Italic', TextStyle.italic),
+        ('Underline', TextStyle.underline),
+        ('Reverse', TextStyle.reverse),
+      ]) {
+        b.writeAt(row, c, label, style: style);
+        c += label.length + 2;
+      }
+      row += 2;
+
+      // Colored + styled combinations in one row.
+      b.writeAt(row, 3, 'Combo:', style: TextStyle.bold);
+      b.writeAt(row, 13, 'red+bold', fg: Color.red, style: TextStyle.bold);
+      b.writeAt(row, 24, 'green+underline',
+          fg: Color.brightGreen, style: TextStyle.underline);
+      b.writeAt(row, 42, ' white-on-blue ',
+          fg: Color.brightWhite, bg: Color.blue);
+      row += 2;
+
+      // Live stats — only these cells change between timer ticks, which
+      // proves encodeDiff repaints just the diff (no full-screen redraw).
+      final uptime = DateTime.now().difference(startTime);
+      b.writeAt(row, 3, 'Uptime:', style: TextStyle.bold);
+      b.writeAt(row, 13, _fmtDuration(uptime), fg: Color.brightCyan);
+      b.writeAt(row, 26, 'Frames:', style: TextStyle.bold);
+      b.writeAt(row, 34, '$frames', fg: Color.brightCyan);
+      b.writeAt(row, 46, 'Spinner:', style: TextStyle.bold);
+      b.set(row, 55,
+          Cell(rune: _spinner[frames % _spinner.length], fg: Color.brightYellow));
+      row += 2;
+
+      // Scrolling log of recent key events.
+      b.writeAt(row, 3, 'Recent keys:', style: TextStyle.bold);
+      row++;
+      for (var i = 0; i < recentKeys.length; i++) {
+        b.writeAt(row + i, 5, recentKeys[i], fg: Color.brightBlack);
+      }
+
+      b.writeAt(h - 2, 3, 'Press keys to test input · q to quit',
+          style: TextStyle.dim);
+    });
+  }
+
+  repaint();
+  final resizeSub = terminal.resizes.listen((_) => repaint());
+  // Drive repaints on a timer so the uptime/frames/spinner update live.
+  final ticker =
+      Timer.periodic(const Duration(milliseconds: 250), (_) => repaint());
+
+  try {
+    await for (final event in terminal.keys) {
+      recentKeys.insert(0, _describe(event));
+      if (recentKeys.length > 6) recentKeys.removeLast();
+      if (event is CharKey && event.rune == 0x71 /* 'q' */) break;
+      if (event is CharKey &&
+          event.rune == 0x63 /* 'c' */ &&
+          event.modifiers.contains(Modifier.ctrl)) {
+        break;
+      }
+      repaint();
+    }
+  } finally {
+    ticker.cancel();
+    await resizeSub.cancel();
+  }
+}
+
+void _drawBorder(CellBuffer b, int row, int col, int rows, int cols,
+    {String? title}) {
   const tl = 0x250C, tr = 0x2510, bl = 0x2514, br = 0x2518;
   const h = 0x2500, v = 0x2502;
   b.set(row, col, const Cell(rune: tl));
@@ -58,6 +171,15 @@ void _drawBorder(CellBuffer b, int row, int col, int rows, int cols) {
     b.set(r, col, const Cell(rune: v));
     b.set(r, col + cols - 1, const Cell(rune: v));
   }
+  if (title != null) {
+    b.writeAt(row, col + 2, title, style: TextStyle.bold);
+  }
+}
+
+String _fmtDuration(Duration d) {
+  final m = d.inMinutes.toString().padLeft(2, '0');
+  final s = (d.inSeconds % 60).toString().padLeft(2, '0');
+  return '$m:$s';
 }
 
 String _describe(KeyEvent event) {
@@ -65,7 +187,8 @@ String _describe(KeyEvent event) {
       ? ''
       : '${event.modifiers.map((m) => m.name).join('+')}+';
   return switch (event) {
-    CharKey(:final rune) => '$mods${String.fromCharCode(rune)} (0x${rune.toRadixString(16)})',
+    CharKey(:final rune) =>
+      '$mods${String.fromCharCode(rune)} (0x${rune.toRadixString(16)})',
     SpecialKey(:final code) => '$mods${code.name}',
   };
 }

--- a/app/lib/src/tui/README.md
+++ b/app/lib/src/tui/README.md
@@ -1,0 +1,94 @@
+# TUI engine
+
+A terminal UI engine in pure Dart — the foundation for a Flutter-style
+declarative UI that renders to a character grid instead of pixels.
+
+The long-term goal mirrors Flutter's three-tree pipeline
+(Widget → Element → RenderObject), but the render and engine layers are
+terminal-shaped rather than Skia-shaped. **This package is currently stage 1:
+the engine layer only.** There are no widgets, layout, or render objects yet —
+see [the roadmap](../../../../docs/superpowers/tui-roadmap.md) for the staged
+plan.
+
+## What's here
+
+| File | Responsibility |
+|------|----------------|
+| `cell.dart` | `Cell`, `Color` (default / 16 ANSI / 24-bit RGB), `TextStyle` bitfield |
+| `buffer.dart` | `CellBuffer` — a fixed-size, clipping, row-major grid of cells |
+| `ansi.dart` | ANSI escape constants, SGR encoders, and `encodeDiff` |
+| `input.dart` | `parseKeyEvents` — raw stdin bytes → `KeyEvent` stream |
+| `cursor_query.dart` | Cursor-position query (`ESC[6n`) used to anchor inline mode |
+| `terminal.dart` | `Terminal` — lifecycle, signal handling, double-buffered painting |
+| `tui.dart` | Barrel file: the public API surface |
+
+Examples live in `app/examples/tui/`.
+
+## Quick start
+
+```dart
+import 'package:flutterware_app/src/tui/tui.dart';
+
+Future<void> main() async {
+  await Terminal.run((terminal) async {
+    terminal.draw((buffer) {
+      buffer.writeAt(0, 0, 'Hello, terminal!', style: TextStyle.bold);
+      buffer.writeAt(1, 0, 'Press q to quit.', fg: Color.brightBlack);
+    });
+
+    await for (final event in terminal.keys) {
+      if (event is CharKey && event.rune == 0x71 /* 'q' */) break;
+    }
+  });
+}
+```
+
+`Terminal.run` enters a terminal session, runs your body, and restores the
+terminal on exit — including on uncaught errors and on SIGINT/SIGTERM/SIGHUP.
+
+- **`terminal.draw((buffer) { ... })`** — paint a frame. You always paint the
+  whole frame; the engine diffs it against the previous frame and emits only
+  the ANSI escapes needed for the changed cells.
+- **`terminal.keys`** — a broadcast stream of parsed `KeyEvent`s.
+- **`terminal.resizes`** — emits when the terminal is resized. You are
+  responsible for calling `draw` again in response.
+
+## Rendering modes
+
+```dart
+// Full-screen (default): takes over the terminal via the alt-screen buffer.
+await Terminal.run(body);
+await Terminal.run(body, mode: TerminalMode.fullScreen());
+
+// Inline: a fixed-height region anchored at the cursor's start position.
+// Normal scrollback above the region is preserved — good for status panels
+// and progress UIs that coexist with regular CLI output.
+await Terminal.run(body, mode: TerminalMode.inline(rows: 5));
+```
+
+## How painting works
+
+`CellBuffer` is a grid of immutable `Cell`s addressed by `(row, col)`. Writes
+that fall outside the buffer are silently clipped, so painting code never has
+to bounds-check.
+
+`Terminal` keeps two buffers — `front` (what is on screen) and `back` (what you
+just painted). `encodeDiff` walks both and emits ANSI escape sequences only for
+cells that changed, coalescing cursor moves and SGR (color/style) changes. This
+keeps redraws cheap and flicker-free even when only a few cells change between
+frames.
+
+## Current limitations
+
+Stage 1 is intentionally scoped. Not yet supported:
+
+- No layout, widgets, or render objects (stages 2–4).
+- No mouse input.
+- No wide-character / emoji width handling — every cell is one column.
+- Windows: compiles and runs, but signal-driven features (resize) are
+  Unix-only for now.
+- Non-tty stdin (e.g. piped input) throws on startup, before the alt-screen is
+  entered — no terminal damage, but not graceful.
+
+See [the roadmap](../../../../docs/superpowers/tui-roadmap.md) for what comes
+next and the detailed design specs in `docs/superpowers/specs/`.

--- a/app/lib/src/tui/ansi.dart
+++ b/app/lib/src/tui/ansi.dart
@@ -1,0 +1,66 @@
+import 'buffer.dart';
+import 'cell.dart';
+
+/// ANSI escape sequences used by the engine.
+///
+/// Naming convention: constants are static strings; functions build sequences
+/// from arguments. All cursor coordinates exposed by this module are 0-indexed
+/// (matching CellBuffer); the CSI conversion to 1-indexed happens here.
+class Ansi {
+  Ansi._();
+
+  static const String esc = '\x1b';
+  static const String csi = '\x1b[';
+
+  static const String enterAltScreen = '\x1b[?1049h';
+  static const String exitAltScreen = '\x1b[?1049l';
+  static const String hideCursor = '\x1b[?25l';
+  static const String showCursor = '\x1b[?25h';
+  static const String clearScreen = '\x1b[2J';
+  static const String resetStyle = '\x1b[0m';
+
+  /// 0-indexed row, col → CSI move sequence (1-indexed).
+  static String moveTo(int row, int col) => '$csi${row + 1};${col + 1}H';
+
+  /// SGR parameter for a foreground color. Returns the parameter string only
+  /// (e.g. `'31'` or `'38;2;10;20;30'`), without the CSI prefix or final `m`.
+  static String sgrForeground(Color c) {
+    if (c.isDefaultFg) return '39';
+    if (c.isAnsi) {
+      final i = c.ansiIndex;
+      return i < 8 ? '${30 + i}' : '${90 + (i - 8)}';
+    }
+    // rgb
+    return '38;2;${c.r};${c.g};${c.b}';
+  }
+
+  /// SGR parameter for a background color.
+  static String sgrBackground(Color c) {
+    if (c.isDefaultBg) return '49';
+    if (c.isAnsi) {
+      final i = c.ansiIndex;
+      return i < 8 ? '${40 + i}' : '${100 + (i - 8)}';
+    }
+    return '48;2;${c.r};${c.g};${c.b}';
+  }
+
+  /// SGR parameters for a style bitfield. Empty list if style == 0.
+  static List<String> sgrStyle(int style) {
+    final out = <String>[];
+    if (style & TextStyle.bold != 0) out.add('1');
+    if (style & TextStyle.dim != 0) out.add('2');
+    if (style & TextStyle.italic != 0) out.add('3');
+    if (style & TextStyle.underline != 0) out.add('4');
+    if (style & TextStyle.reverse != 0) out.add('7');
+    return out;
+  }
+}
+
+/// Encode the difference between [front] (current screen state) and [back]
+/// (desired state) as a string of ANSI escape sequences. Returns an empty
+/// string if there are no changes.
+///
+/// Defined in a later task.
+String encodeDiff(CellBuffer front, CellBuffer back) {
+  throw UnimplementedError('see Task 4');
+}

--- a/app/lib/src/tui/ansi.dart
+++ b/app/lib/src/tui/ansi.dart
@@ -57,10 +57,79 @@ class Ansi {
 }
 
 /// Encode the difference between [front] (current screen state) and [back]
-/// (desired state) as a string of ANSI escape sequences. Returns an empty
-/// string if there are no changes.
+/// (desired state) as a string of ANSI escape sequences.
 ///
-/// Defined in a later task.
+/// Optimizations:
+/// - Unchanged cells are skipped.
+/// - When the next changed cell is the immediate horizontal neighbor of the
+///   previous one, the cursor move is omitted (the cursor advances naturally
+///   after a character write).
+/// - Foreground, background, and style SGR are re-emitted only when they
+///   change between successive printed cells.
 String encodeDiff(CellBuffer front, CellBuffer back) {
-  throw UnimplementedError('see Task 4');
+  if (front.rows != back.rows || front.cols != back.cols) {
+    throw ArgumentError(
+        'size mismatch: ${front.rows}×${front.cols} vs ${back.rows}×${back.cols}');
+  }
+
+  final buf = StringBuffer();
+
+  // Track cursor position. -1 means "unknown / must emit move before next write".
+  int cursorRow = -1;
+  int cursorCol = -1;
+
+  // Track the last SGR state we wrote. null means "unknown".
+  Color? lastFg;
+  Color? lastBg;
+  int? lastStyle;
+
+  for (var r = 0; r < back.rows; r++) {
+    for (var c = 0; c < back.cols; c++) {
+      final f = front.get(r, c);
+      final b = back.get(r, c);
+      if (f == b) continue;
+
+      // Emit a cursor move if we are not already at this position.
+      if (cursorRow != r || cursorCol != c) {
+        buf.write(Ansi.moveTo(r, c));
+      }
+
+      // Emit SGR transitions only for what changed.
+      final params = <String>[];
+      if (lastFg == null || lastFg != b.fg) {
+        params.add(Ansi.sgrForeground(b.fg));
+      }
+      if (lastBg == null || lastBg != b.bg) {
+        params.add(Ansi.sgrBackground(b.bg));
+      }
+      if (lastStyle == null || lastStyle != b.style) {
+        // Style transitions are simplest when we reset and re-apply, otherwise
+        // we'd need to track which bits to turn off.
+        if (lastStyle != null && lastStyle != 0) {
+          params.insert(0, '0');
+          // After reset, fg/bg also reset — re-emit them.
+          if (!params.contains(Ansi.sgrForeground(b.fg))) {
+            params.add(Ansi.sgrForeground(b.fg));
+          }
+          if (!params.contains(Ansi.sgrBackground(b.bg))) {
+            params.add(Ansi.sgrBackground(b.bg));
+          }
+        }
+        params.addAll(Ansi.sgrStyle(b.style));
+      }
+      if (params.isNotEmpty) {
+        buf.write('${Ansi.csi}${params.join(';')}m');
+      }
+
+      buf.writeCharCode(b.rune);
+
+      lastFg = b.fg;
+      lastBg = b.bg;
+      lastStyle = b.style;
+      cursorRow = r;
+      cursorCol = c + 1; // cursor advances after a char write
+    }
+  }
+
+  return buf.toString();
 }

--- a/app/lib/src/tui/ansi.dart
+++ b/app/lib/src/tui/ansi.dart
@@ -75,8 +75,8 @@ String encodeDiff(CellBuffer front, CellBuffer back) {
   final buf = StringBuffer();
 
   // Track cursor position. -1 means "unknown / must emit move before next write".
-  int cursorRow = -1;
-  int cursorCol = -1;
+  var cursorRow = -1;
+  var cursorCol = -1;
 
   // Track the last SGR state we wrote. null means "unknown".
   Color? lastFg;

--- a/app/lib/src/tui/ansi.dart
+++ b/app/lib/src/tui/ansi.dart
@@ -66,7 +66,17 @@ class Ansi {
 ///   after a character write).
 /// - Foreground, background, and style SGR are re-emitted only when they
 ///   change between successive printed cells.
-String encodeDiff(CellBuffer front, CellBuffer back) {
+///
+/// The optional [originRow] and [originCol] are added to every absolute
+/// cursor move emitted. Pass them when rendering into a sub-region of the
+/// terminal (e.g. inline mode); the back buffer is still addressed from
+/// (0, 0) on the caller's side.
+String encodeDiff(
+  CellBuffer front,
+  CellBuffer back, {
+  int originRow = 0,
+  int originCol = 0,
+}) {
   if (front.rows != back.rows || front.cols != back.cols) {
     throw ArgumentError(
         'size mismatch: ${front.rows}×${front.cols} vs ${back.rows}×${back.cols}');
@@ -91,7 +101,7 @@ String encodeDiff(CellBuffer front, CellBuffer back) {
 
       // Emit a cursor move if we are not already at this position.
       if (cursorRow != r || cursorCol != c) {
-        buf.write(Ansi.moveTo(r, c));
+        buf.write(Ansi.moveTo(r + originRow, c + originCol));
       }
 
       // Emit SGR transitions only for what changed.

--- a/app/lib/src/tui/buffer.dart
+++ b/app/lib/src/tui/buffer.dart
@@ -62,7 +62,8 @@ class CellBuffer {
 
   void copyFrom(CellBuffer other) {
     if (other.rows != rows || other.cols != cols) {
-      throw ArgumentError('size mismatch: $rows×$cols vs ${other.rows}×${other.cols}');
+      throw ArgumentError(
+          'size mismatch: $rows×$cols vs ${other.rows}×${other.cols}');
     }
     for (var i = 0; i < _cells.length; i++) {
       _cells[i] = other._cells[i];

--- a/app/lib/src/tui/buffer.dart
+++ b/app/lib/src/tui/buffer.dart
@@ -1,0 +1,71 @@
+import 'cell.dart';
+
+/// A grid of cells, addressed by (row, col). Size is fixed at construction.
+/// All mutation methods silently clip to bounds.
+class CellBuffer {
+  final int rows;
+  final int cols;
+  final List<Cell> _cells;
+
+  CellBuffer(this.rows, this.cols)
+      : _cells = List<Cell>.filled(rows * cols, Cell.empty, growable: false);
+
+  bool inBounds(int row, int col) =>
+      row >= 0 && row < rows && col >= 0 && col < cols;
+
+  Cell get(int row, int col) {
+    if (!inBounds(row, col)) return Cell.empty;
+    return _cells[row * cols + col];
+  }
+
+  void set(int row, int col, Cell cell) {
+    if (!inBounds(row, col)) return;
+    _cells[row * cols + col] = cell;
+  }
+
+  void writeAt(
+    int row,
+    int col,
+    String text, {
+    Color fg = Color.defaultFg,
+    Color bg = Color.defaultBg,
+    int style = 0,
+  }) {
+    var c = col;
+    for (final rune in text.runes) {
+      if (inBounds(row, c)) {
+        _cells[row * cols + c] = Cell(rune: rune, fg: fg, bg: bg, style: style);
+      }
+      c++;
+    }
+  }
+
+  void fill(Cell cell) {
+    for (var i = 0; i < _cells.length; i++) {
+      _cells[i] = cell;
+    }
+  }
+
+  void fillRect(int row, int col, int rowCount, int colCount, Cell cell) {
+    final r0 = row.clamp(0, rows);
+    final r1 = (row + rowCount).clamp(0, rows);
+    final c0 = col.clamp(0, cols);
+    final c1 = (col + colCount).clamp(0, cols);
+    for (var r = r0; r < r1; r++) {
+      for (var c = c0; c < c1; c++) {
+        _cells[r * cols + c] = cell;
+      }
+    }
+  }
+
+  void clear() => fill(Cell.empty);
+
+  void copyFrom(CellBuffer other) {
+    if (other.rows != rows || other.cols != cols) {
+      throw ArgumentError('size mismatch: $rows×$cols vs ${other.rows}×${other.cols}');
+    }
+    for (var i = 0; i < _cells.length; i++) {
+      _cells[i] = other._cells[i];
+    }
+  }
+}

--- a/app/lib/src/tui/cell.dart
+++ b/app/lib/src/tui/cell.dart
@@ -14,10 +14,10 @@ class TextStyle {
 /// or 24-bit RGB. Equality is structural.
 class Color {
   final int _kind; // 0 = default, 1 = ansi, 2 = rgb
-  final int ansiIndex; // valid when _kind == 1; 0..15
+  final int _ansiIndex; // valid when _kind == 1; 0..15
   final int r, g, b; // valid when _kind == 2
 
-  const Color._(this._kind, this.ansiIndex, this.r, this.g, this.b);
+  const Color._(this._kind, this._ansiIndex, this.r, this.g, this.b);
 
   static const Color defaultFg = Color._(0, 0, 0, 0, 0);
   static const Color defaultBg = Color._(0, 1, 0, 0, 0); // sentinel distinct from defaultFg
@@ -41,25 +41,30 @@ class Color {
   static const Color brightWhite = Color._(1, 15, 0, 0, 0);
 
   const factory Color.rgb(int r, int g, int b) = Color._rgb;
-  const Color._rgb(this.r, this.g, this.b) : _kind = 2, ansiIndex = 0;
+  const Color._rgb(this.r, this.g, this.b) : _kind = 2, _ansiIndex = 0;
+
+  int get ansiIndex {
+    assert(_kind == 1, 'ansiIndex is only valid for ANSI colors (kind=1), got kind=$_kind');
+    return _ansiIndex;
+  }
 
   bool get isDefault => _kind == 0;
   bool get isAnsi => _kind == 1;
   bool get isRgb => _kind == 2;
-  bool get isDefaultFg => _kind == 0 && ansiIndex == 0;
-  bool get isDefaultBg => _kind == 0 && ansiIndex == 1;
+  bool get isDefaultFg => _kind == 0 && _ansiIndex == 0;
+  bool get isDefaultBg => _kind == 0 && _ansiIndex == 1;
 
   @override
   bool operator ==(Object other) =>
       other is Color &&
       _kind == other._kind &&
-      ansiIndex == other.ansiIndex &&
+      _ansiIndex == other._ansiIndex &&
       r == other.r &&
       g == other.g &&
       b == other.b;
 
   @override
-  int get hashCode => Object.hash(_kind, ansiIndex, r, g, b);
+  int get hashCode => Object.hash(_kind, _ansiIndex, r, g, b);
 }
 
 /// A single terminal cell. Immutable.

--- a/app/lib/src/tui/cell.dart
+++ b/app/lib/src/tui/cell.dart
@@ -1,0 +1,94 @@
+/// Text style bitfield. Combine with bitwise OR.
+class TextStyle {
+  static const int bold = 1 << 0;
+  static const int dim = 1 << 1;
+  static const int italic = 1 << 2;
+  static const int underline = 1 << 3;
+  static const int reverse = 1 << 4;
+
+  // not instantiable
+  TextStyle._();
+}
+
+/// Color in one of three encodings: terminal default, ANSI named (16-color),
+/// or 24-bit RGB. Equality is structural.
+class Color {
+  final int _kind; // 0 = default, 1 = ansi, 2 = rgb
+  final int ansiIndex; // valid when _kind == 1; 0..15
+  final int r, g, b; // valid when _kind == 2
+
+  const Color._(this._kind, this.ansiIndex, this.r, this.g, this.b);
+
+  static const Color defaultFg = Color._(0, 0, 0, 0, 0);
+  static const Color defaultBg = Color._(0, 1, 0, 0, 0); // sentinel distinct from defaultFg
+
+  // 16 ANSI named colors (indices match the ANSI SGR convention).
+  static const Color black = Color._(1, 0, 0, 0, 0);
+  static const Color red = Color._(1, 1, 0, 0, 0);
+  static const Color green = Color._(1, 2, 0, 0, 0);
+  static const Color yellow = Color._(1, 3, 0, 0, 0);
+  static const Color blue = Color._(1, 4, 0, 0, 0);
+  static const Color magenta = Color._(1, 5, 0, 0, 0);
+  static const Color cyan = Color._(1, 6, 0, 0, 0);
+  static const Color white = Color._(1, 7, 0, 0, 0);
+  static const Color brightBlack = Color._(1, 8, 0, 0, 0);
+  static const Color brightRed = Color._(1, 9, 0, 0, 0);
+  static const Color brightGreen = Color._(1, 10, 0, 0, 0);
+  static const Color brightYellow = Color._(1, 11, 0, 0, 0);
+  static const Color brightBlue = Color._(1, 12, 0, 0, 0);
+  static const Color brightMagenta = Color._(1, 13, 0, 0, 0);
+  static const Color brightCyan = Color._(1, 14, 0, 0, 0);
+  static const Color brightWhite = Color._(1, 15, 0, 0, 0);
+
+  const factory Color.rgb(int r, int g, int b) = Color._rgb;
+  const Color._rgb(this.r, this.g, this.b) : _kind = 2, ansiIndex = 0;
+
+  bool get isDefault => _kind == 0;
+  bool get isAnsi => _kind == 1;
+  bool get isRgb => _kind == 2;
+  bool get isDefaultFg => _kind == 0 && ansiIndex == 0;
+  bool get isDefaultBg => _kind == 0 && ansiIndex == 1;
+
+  @override
+  bool operator ==(Object other) =>
+      other is Color &&
+      _kind == other._kind &&
+      ansiIndex == other.ansiIndex &&
+      r == other.r &&
+      g == other.g &&
+      b == other.b;
+
+  @override
+  int get hashCode => Object.hash(_kind, ansiIndex, r, g, b);
+}
+
+/// A single terminal cell. Immutable.
+class Cell {
+  final int rune;
+  final Color fg;
+  final Color bg;
+  final int style;
+  final int width; // 1 for stage 1; reserved for wide-char support later
+
+  const Cell({
+    required this.rune,
+    this.fg = Color.defaultFg,
+    this.bg = Color.defaultBg,
+    this.style = 0,
+    this.width = 1,
+  });
+
+  static const Cell empty = Cell(rune: 0x20);
+
+  @override
+  bool operator ==(Object other) =>
+      other is Cell &&
+      rune == other.rune &&
+      fg == other.fg &&
+      bg == other.bg &&
+      style == other.style &&
+      width == other.width;
+
+  @override
+  int get hashCode => Object.hash(rune, fg, bg, style, width);
+}

--- a/app/lib/src/tui/cell.dart
+++ b/app/lib/src/tui/cell.dart
@@ -20,7 +20,8 @@ class Color {
   const Color._(this._kind, this._ansiIndex, this.r, this.g, this.b);
 
   static const Color defaultFg = Color._(0, 0, 0, 0, 0);
-  static const Color defaultBg = Color._(0, 1, 0, 0, 0); // sentinel distinct from defaultFg
+  static const Color defaultBg =
+      Color._(0, 1, 0, 0, 0); // sentinel distinct from defaultFg
 
   // 16 ANSI named colors (indices match the ANSI SGR convention).
   static const Color black = Color._(1, 0, 0, 0, 0);
@@ -41,10 +42,13 @@ class Color {
   static const Color brightWhite = Color._(1, 15, 0, 0, 0);
 
   const factory Color.rgb(int r, int g, int b) = Color._rgb;
-  const Color._rgb(this.r, this.g, this.b) : _kind = 2, _ansiIndex = 0;
+  const Color._rgb(this.r, this.g, this.b)
+      : _kind = 2,
+        _ansiIndex = 0;
 
   int get ansiIndex {
-    assert(_kind == 1, 'ansiIndex is only valid for ANSI colors (kind=1), got kind=$_kind');
+    assert(_kind == 1,
+        'ansiIndex is only valid for ANSI colors (kind=1), got kind=$_kind');
     return _ansiIndex;
   }
 

--- a/app/lib/src/tui/cursor_query.dart
+++ b/app/lib/src/tui/cursor_query.dart
@@ -1,0 +1,174 @@
+import 'dart:async';
+
+/// Result of a [queryCursorPosition] call.
+///
+/// [row] and [col] are 0-indexed.
+/// [leftoverBytes] are any bytes received during the query that were NOT
+/// part of the position response (typically keystrokes the user typed
+/// while the query was in flight). Callers should forward these to their
+/// regular input pipeline.
+class CursorPositionResult {
+  final int row;
+  final int col;
+  final List<int> leftoverBytes;
+  const CursorPositionResult({
+    required this.row,
+    required this.col,
+    required this.leftoverBytes,
+  });
+}
+
+/// Query the terminal for the current cursor position.
+///
+/// Writes `CSI 6n` via [write], then consumes bytes from [bytes] until a
+/// `CSI <row>;<col> R` response arrives. Returns 0-indexed coordinates.
+///
+/// If the terminal does not respond within [timeout], returns a result with
+/// [CursorPositionResult.row] equal to [fallbackRow] and any bytes received
+/// during the wait forwarded as `leftoverBytes`.
+///
+/// The query writes its own bytes and reads from the provided stream — it
+/// does not touch `stdin` or `stdout` directly, which makes it unit-testable
+/// without a real terminal.
+Future<CursorPositionResult> queryCursorPosition({
+  required Stream<List<int>> bytes,
+  required void Function(List<int>) write,
+  required int fallbackRow,
+  Duration timeout = const Duration(milliseconds: 200),
+}) async {
+  final completer = Completer<CursorPositionResult>();
+  final leftover = <int>[];
+
+  // Parser state: looking for ESC [ <digits> ; <digits> R
+  // _State values:
+  //   0 = scanning for ESC
+  //   1 = saw ESC, expect [
+  //   2 = saw ESC[, expect first digit of row
+  //   3 = in row digits (>=1 already consumed), expect more digits or ;
+  //   4 = saw ;, expect first digit of col
+  //   5 = in col digits, expect more digits or R
+  var state = 0;
+  var row = 0;
+  var col = 0;
+  // Bytes that we tentatively consumed as part of a possible response.
+  // If parsing bails out, these are flushed back to [leftover].
+  final pending = <int>[];
+
+  void rollback(int trailingByte) {
+    leftover.addAll(pending);
+    leftover.add(trailingByte);
+    pending.clear();
+    state = 0;
+    row = 0;
+    col = 0;
+  }
+
+  late StreamSubscription<List<int>> sub;
+  sub = bytes.listen(
+    (chunk) {
+      if (completer.isCompleted) {
+        leftover.addAll(chunk);
+        return;
+      }
+      for (final byte in chunk) {
+        if (completer.isCompleted) {
+          leftover.add(byte);
+          continue;
+        }
+        switch (state) {
+          case 0:
+            if (byte == 0x1b /* ESC */) {
+              pending.add(byte);
+              state = 1;
+            } else {
+              leftover.add(byte);
+            }
+            break;
+          case 1:
+            if (byte == 0x5b /* [ */) {
+              pending.add(byte);
+              state = 2;
+            } else {
+              rollback(byte);
+            }
+            break;
+          case 2:
+            if (byte >= 0x30 && byte <= 0x39) {
+              pending.add(byte);
+              row = byte - 0x30;
+              state = 3;
+            } else {
+              rollback(byte);
+            }
+            break;
+          case 3:
+            if (byte >= 0x30 && byte <= 0x39) {
+              pending.add(byte);
+              row = row * 10 + (byte - 0x30);
+            } else if (byte == 0x3b /* ; */) {
+              pending.add(byte);
+              state = 4;
+            } else {
+              rollback(byte);
+            }
+            break;
+          case 4:
+            if (byte >= 0x30 && byte <= 0x39) {
+              pending.add(byte);
+              col = byte - 0x30;
+              state = 5;
+            } else {
+              rollback(byte);
+            }
+            break;
+          case 5:
+            if (byte >= 0x30 && byte <= 0x39) {
+              pending.add(byte);
+              col = col * 10 + (byte - 0x30);
+            } else if (byte == 0x52 /* R */) {
+              // Response complete.
+              completer.complete(CursorPositionResult(
+                row: row - 1,
+                col: col - 1,
+                leftoverBytes: List.unmodifiable(leftover),
+              ));
+            } else {
+              rollback(byte);
+            }
+            break;
+        }
+      }
+    },
+    onError: (Object error, StackTrace stack) {
+      if (!completer.isCompleted) {
+        completer.completeError(error, stack);
+      }
+    },
+    onDone: () {
+      if (!completer.isCompleted) {
+        // Stream closed before a response arrived. Treat as timeout-like.
+        completer.complete(CursorPositionResult(
+          row: fallbackRow,
+          col: 0,
+          leftoverBytes: List.unmodifiable(leftover),
+        ));
+      }
+    },
+  );
+
+  write('\x1b[6n'.codeUnits);
+
+  try {
+    final result = await completer.future.timeout(
+      timeout,
+      onTimeout: () => CursorPositionResult(
+        row: fallbackRow,
+        col: 0,
+        leftoverBytes: List.unmodifiable(leftover),
+      ),
+    );
+    return result;
+  } finally {
+    await sub.cancel();
+  }
+}

--- a/app/lib/src/tui/cursor_query.dart
+++ b/app/lib/src/tui/cursor_query.dart
@@ -147,6 +147,10 @@ Future<CursorPositionResult> queryCursorPosition({
     onDone: () {
       if (!completer.isCompleted) {
         // Stream closed before a response arrived. Treat as timeout-like.
+        if (pending.isNotEmpty) {
+          leftover.addAll(pending);
+          pending.clear();
+        }
         completer.complete(CursorPositionResult(
           row: fallbackRow,
           col: 0,
@@ -161,11 +165,17 @@ Future<CursorPositionResult> queryCursorPosition({
   try {
     final result = await completer.future.timeout(
       timeout,
-      onTimeout: () => CursorPositionResult(
-        row: fallbackRow,
-        col: 0,
-        leftoverBytes: List.unmodifiable(leftover),
-      ),
+      onTimeout: () {
+        if (pending.isNotEmpty) {
+          leftover.addAll(pending);
+          pending.clear();
+        }
+        return CursorPositionResult(
+          row: fallbackRow,
+          col: 0,
+          leftoverBytes: List.unmodifiable(leftover),
+        );
+      },
     );
     return result;
   } finally {

--- a/app/lib/src/tui/example/inline_demo.dart
+++ b/app/lib/src/tui/example/inline_demo.dart
@@ -1,0 +1,73 @@
+import 'dart:async';
+
+import '../tui.dart';
+
+Future<void> main() async {
+  // Print some normal CLI output above the inline region first, so we can
+  // visually confirm the scrollback is preserved.
+  print('--- preceding shell output (this should remain visible above) ---');
+  print('flutterware status:');
+
+  await Terminal.run((terminal) async {
+    var lastKey = '(none)';
+    var keyCount = 0;
+
+    void repaint() {
+      terminal.draw((b) {
+        final w = terminal.cols;
+        _drawBorder(b, 0, 0, terminal.rows, w);
+        b.writeAt(1, 2, 'Inline region: $w cols × ${terminal.rows} rows');
+        b.writeAt(2, 2, 'Last key: $lastKey (count: $keyCount)');
+        b.writeAt(3, 2, '(q to quit)');
+      });
+    }
+
+    repaint();
+    final resizeSub = terminal.resizes.listen((_) => repaint());
+
+    try {
+      await for (final event in terminal.keys) {
+        keyCount++;
+        lastKey = _describe(event);
+        if (event is CharKey && event.rune == 0x71 /* 'q' */) break;
+        if (event is CharKey &&
+            event.rune == 0x63 /* 'c' */ &&
+            event.modifiers.contains(Modifier.ctrl)) {
+          break;
+        }
+        repaint();
+      }
+    } finally {
+      await resizeSub.cancel();
+    }
+  }, mode: const InlineMode(rows: 5));
+
+  print('--- inline region exited; back to normal shell output ---');
+}
+
+void _drawBorder(CellBuffer b, int row, int col, int rows, int cols) {
+  const tl = 0x250C, tr = 0x2510, bl = 0x2514, br = 0x2518;
+  const h = 0x2500, v = 0x2502;
+  b.set(row, col, const Cell(rune: tl));
+  b.set(row, col + cols - 1, const Cell(rune: tr));
+  b.set(row + rows - 1, col, const Cell(rune: bl));
+  b.set(row + rows - 1, col + cols - 1, const Cell(rune: br));
+  for (var c = col + 1; c < col + cols - 1; c++) {
+    b.set(row, c, const Cell(rune: h));
+    b.set(row + rows - 1, c, const Cell(rune: h));
+  }
+  for (var r = row + 1; r < row + rows - 1; r++) {
+    b.set(r, col, const Cell(rune: v));
+    b.set(r, col + cols - 1, const Cell(rune: v));
+  }
+}
+
+String _describe(KeyEvent event) {
+  final mods = event.modifiers.isEmpty
+      ? ''
+      : '${event.modifiers.map((m) => m.name).join('+')}+';
+  return switch (event) {
+    CharKey(:final rune) => '$mods${String.fromCharCode(rune)} (0x${rune.toRadixString(16)})',
+    SpecialKey(:final code) => '$mods${code.name}',
+  };
+}

--- a/app/lib/src/tui/example/step1_demo.dart
+++ b/app/lib/src/tui/example/step1_demo.dart
@@ -1,9 +1,6 @@
 import 'dart:async';
 
-import '../buffer.dart';
-import '../cell.dart';
-import '../input.dart';
-import '../terminal.dart';
+import '../tui.dart';
 
 Future<void> main() async {
   await Terminal.run((terminal) async {

--- a/app/lib/src/tui/example/step1_demo.dart
+++ b/app/lib/src/tui/example/step1_demo.dart
@@ -1,0 +1,74 @@
+import 'dart:async';
+
+import '../buffer.dart';
+import '../cell.dart';
+import '../input.dart';
+import '../terminal.dart';
+
+Future<void> main() async {
+  await Terminal.run((terminal) async {
+    var lastKey = '(none)';
+    var keyCount = 0;
+
+    void repaint() {
+      terminal.draw((b) {
+        final w = terminal.cols;
+        final h = terminal.rows;
+        const boxW = 36;
+        const boxH = 5;
+        final row = ((h - boxH) ~/ 2).clamp(0, h);
+        final col = ((w - boxW) ~/ 2).clamp(0, w);
+        _drawBorder(b, row, col, boxH, boxW);
+        b.writeAt(row + 1, col + 2, 'Size: $w × $h');
+        b.writeAt(row + 2, col + 2, 'Last key: $lastKey (count: $keyCount)');
+        b.writeAt(row + 3, col + 2, '(q to quit)');
+      });
+    }
+
+    repaint();
+    final resizeSub = terminal.resizes.listen((_) => repaint());
+
+    try {
+      await for (final event in terminal.keys) {
+        keyCount++;
+        lastKey = _describe(event);
+        if (event is CharKey && event.rune == 0x71 /* 'q' */) break;
+        if (event is CharKey &&
+            event.rune == 0x63 /* 'c' */ &&
+            event.modifiers.contains(Modifier.ctrl)) {
+          break;
+        }
+        repaint();
+      }
+    } finally {
+      await resizeSub.cancel();
+    }
+  });
+}
+
+void _drawBorder(CellBuffer b, int row, int col, int rows, int cols) {
+  const tl = 0x250C, tr = 0x2510, bl = 0x2514, br = 0x2518;
+  const h = 0x2500, v = 0x2502;
+  b.set(row, col, const Cell(rune: tl));
+  b.set(row, col + cols - 1, const Cell(rune: tr));
+  b.set(row + rows - 1, col, const Cell(rune: bl));
+  b.set(row + rows - 1, col + cols - 1, const Cell(rune: br));
+  for (var c = col + 1; c < col + cols - 1; c++) {
+    b.set(row, c, const Cell(rune: h));
+    b.set(row + rows - 1, c, const Cell(rune: h));
+  }
+  for (var r = row + 1; r < row + rows - 1; r++) {
+    b.set(r, col, const Cell(rune: v));
+    b.set(r, col + cols - 1, const Cell(rune: v));
+  }
+}
+
+String _describe(KeyEvent event) {
+  final mods = event.modifiers.isEmpty
+      ? ''
+      : '${event.modifiers.map((m) => m.name).join('+')}+';
+  return switch (event) {
+    CharKey(:final rune) => '$mods${String.fromCharCode(rune)} (0x${rune.toRadixString(16)})',
+    SpecialKey(:final code) => '$mods${code.name}',
+  };
+}

--- a/app/lib/src/tui/input.dart
+++ b/app/lib/src/tui/input.dart
@@ -254,7 +254,7 @@ KeyEvent _interpretCsi(List<int> paramBytes, int finalByte) {
   // Modifier param (xterm convention: 1=none, 2=shift, 3=alt, 4=shift+alt,
   // 5=ctrl, 6=ctrl+shift, 7=ctrl+alt, 8=ctrl+shift+alt). Apparent in
   // sequences like `ESC [1;<mod><final>` or `ESC [<n>;<mod>~`.
-  Set<Modifier> mods = const {};
+  var mods = const <Modifier>{};
   if (params.length >= 2) {
     mods = _xtermModifiers(params[1]);
   }

--- a/app/lib/src/tui/input.dart
+++ b/app/lib/src/tui/input.dart
@@ -18,7 +18,18 @@ enum SpecialKeyCode {
   pageDown,
   delete,
   insert,
-  f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12,
+  f1,
+  f2,
+  f3,
+  f4,
+  f5,
+  f6,
+  f7,
+  f8,
+  f9,
+  f10,
+  f11,
+  f12,
 }
 
 sealed class KeyEvent {
@@ -205,7 +216,8 @@ KeyEvent? _consumeCsi(Queue<int> bytes, {required bool streamClosed}) {
   // and finally one final byte (0x40–0x7e).
   final paramBytes = <int>[];
   var idx = 0;
-  while (idx < snapshot.length && snapshot[idx] >= 0x30 && snapshot[idx] <= 0x3f) {
+  while (
+      idx < snapshot.length && snapshot[idx] >= 0x30 && snapshot[idx] <= 0x3f) {
     paramBytes.add(snapshot[idx]);
     idx++;
   }

--- a/app/lib/src/tui/input.dart
+++ b/app/lib/src/tui/input.dart
@@ -78,7 +78,267 @@ int _setHash(Set s) {
   return h;
 }
 
-/// Defined in Task 6.
-Stream<KeyEvent> parseKeyEvents(Stream<List<int>> bytes) {
-  throw UnimplementedError('see Task 6');
+/// Parse a raw byte stream into a stream of [KeyEvent]s.
+///
+/// Recognized sequences:
+/// - ASCII 0x20–0x7e → printable [CharKey].
+/// - ASCII 0x01–0x1a (except 0x09, 0x0a, 0x0d) → ctrl-letter [CharKey].
+/// - 0x09 → tab; 0x0a / 0x0d → enter; 0x7f → backspace.
+/// - 0x1b alone (stream ends or no more bytes available) → escape.
+/// - 0x1b 0x5b … (CSI) → arrows, home/end, page up/down, with optional
+///   modifier params (`ESC [1;<mod>A`).
+/// - 0x1b 0x4f X (SS3) → arrows (some terminals send these in app mode).
+/// - 0xc0–0xfd start of a UTF-8 multi-byte sequence → one [CharKey] with the
+///   decoded code point.
+///
+/// Sequences split across chunk boundaries are reassembled internally.
+Stream<KeyEvent> parseKeyEvents(Stream<List<int>> bytes) async* {
+  final pending = Queue<int>();
+  await for (final chunk in bytes) {
+    pending.addAll(chunk);
+    while (pending.isNotEmpty) {
+      // Attempt to consume one event from the front of [pending]. If the
+      // available bytes are an incomplete prefix of a multi-byte sequence,
+      // _consume returns null and we break to await more input.
+      final result = _consume(pending, streamClosed: false);
+      if (result == null) break;
+      yield result;
+    }
+  }
+  // Stream closed. Drain any pending bytes; treat lone ESC as escape.
+  while (pending.isNotEmpty) {
+    final result = _consume(pending, streamClosed: true);
+    if (result == null) break;
+    yield result;
+  }
+}
+
+/// Try to consume one [KeyEvent] from the front of [bytes]. Returns null if
+/// the bytes form an incomplete sequence and [streamClosed] is false.
+/// When [streamClosed] is true, ambiguous prefixes are resolved as best-effort
+/// (e.g. lone ESC → escape).
+KeyEvent? _consume(Queue<int> bytes, {required bool streamClosed}) {
+  final first = bytes.first;
+
+  // --- Special single-byte cases ---
+  if (first == 0x1b) {
+    // ESC: could be standalone escape, or the start of CSI/SS3.
+    if (bytes.length == 1) {
+      if (!streamClosed) return null;
+      bytes.removeFirst();
+      return const SpecialKey(code: SpecialKeyCode.escape, modifiers: {});
+    }
+    final second = bytes.elementAt(1);
+    if (second == 0x5b /* [ */) {
+      return _consumeCsi(bytes, streamClosed: streamClosed);
+    }
+    if (second == 0x4f /* O */) {
+      return _consumeSs3(bytes, streamClosed: streamClosed);
+    }
+    // Anything else after ESC: treat ESC as standalone for stage 1.
+    bytes.removeFirst();
+    return const SpecialKey(code: SpecialKeyCode.escape, modifiers: {});
+  }
+
+  if (first == 0x09) {
+    bytes.removeFirst();
+    return const SpecialKey(code: SpecialKeyCode.tab, modifiers: {});
+  }
+  if (first == 0x0a || first == 0x0d) {
+    bytes.removeFirst();
+    return const SpecialKey(code: SpecialKeyCode.enter, modifiers: {});
+  }
+  if (first == 0x7f) {
+    bytes.removeFirst();
+    return const SpecialKey(code: SpecialKeyCode.backspace, modifiers: {});
+  }
+
+  // --- ctrl-letter (0x01–0x1a, excluding the specials above) ---
+  if (first >= 0x01 && first <= 0x1a) {
+    bytes.removeFirst();
+    // 0x01 = ctrl-A → rune 'a' (0x61). General: rune = 0x60 + first.
+    return CharKey(rune: 0x60 + first, modifiers: const {Modifier.ctrl});
+  }
+
+  // --- Plain ASCII printable ---
+  if (first >= 0x20 && first <= 0x7e) {
+    bytes.removeFirst();
+    return CharKey(rune: first, modifiers: const {});
+  }
+
+  // --- UTF-8 multi-byte ---
+  if (first >= 0xc0 && first < 0xf8) {
+    final byteLen = first < 0xe0 ? 2 : (first < 0xf0 ? 3 : 4);
+    if (bytes.length < byteLen) {
+      if (!streamClosed) return null;
+      bytes.clear();
+      return const CharKey(rune: 0xFFFD /* replacement */, modifiers: {});
+    }
+    var rune = first & (0xff >> (byteLen + 1));
+    final consumed = <int>[bytes.removeFirst()];
+    for (var i = 1; i < byteLen; i++) {
+      final next = bytes.removeFirst();
+      consumed.add(next);
+      rune = (rune << 6) | (next & 0x3f);
+    }
+    return CharKey(rune: rune, modifiers: const {});
+  }
+
+  // --- Anything else (continuation bytes appearing alone, 0xfe/0xff, etc.) ---
+  // Drop the byte to avoid an infinite loop.
+  bytes.removeFirst();
+  return CharKey(rune: 0xFFFD, modifiers: const {});
+}
+
+/// Consume an `ESC [ ...` CSI sequence. Called with [bytes] starting at 0x1b 0x5b.
+/// Returns null if more bytes are needed and the stream is still open.
+KeyEvent? _consumeCsi(Queue<int> bytes, {required bool streamClosed}) {
+  // We need at least ESC, [, and one final byte.
+  if (bytes.length < 3 && !streamClosed) return null;
+
+  // Snapshot the bytes so we can roll back if incomplete.
+  final snapshot = bytes.toList();
+  // Consume ESC and [.
+  snapshot.removeAt(0);
+  snapshot.removeAt(0);
+
+  // Read parameter bytes (0x30–0x3f), intermediate bytes (0x20–0x2f),
+  // and finally one final byte (0x40–0x7e).
+  final paramBytes = <int>[];
+  var idx = 0;
+  while (idx < snapshot.length && snapshot[idx] >= 0x30 && snapshot[idx] <= 0x3f) {
+    paramBytes.add(snapshot[idx]);
+    idx++;
+  }
+  if (idx >= snapshot.length) {
+    return streamClosed ? _csiUnknown(bytes) : null;
+  }
+  final finalByte = snapshot[idx];
+  if (finalByte < 0x40 || finalByte > 0x7e) {
+    return streamClosed ? _csiUnknown(bytes) : null;
+  }
+
+  // Successful parse — actually consume from [bytes].
+  // Total consumed = 2 (ESC, [) + paramBytes.length + 1 (final).
+  final totalConsumed = 2 + paramBytes.length + 1;
+  for (var i = 0; i < totalConsumed; i++) {
+    bytes.removeFirst();
+  }
+
+  return _interpretCsi(paramBytes, finalByte);
+}
+
+KeyEvent _csiUnknown(Queue<int> bytes) {
+  // Stream closed mid-sequence. Drain ESC and [ at least, and emit escape.
+  bytes.removeFirst(); // ESC
+  if (bytes.isNotEmpty) bytes.removeFirst(); // [
+  return const SpecialKey(code: SpecialKeyCode.escape, modifiers: {});
+}
+
+KeyEvent _interpretCsi(List<int> paramBytes, int finalByte) {
+  // Parse parameters: bytes 0x30–0x39 are digits, 0x3b is separator.
+  final params = <int>[];
+  var cur = 0;
+  var any = false;
+  for (final b in paramBytes) {
+    if (b >= 0x30 && b <= 0x39) {
+      cur = cur * 10 + (b - 0x30);
+      any = true;
+    } else if (b == 0x3b /* ; */) {
+      params.add(any ? cur : 0);
+      cur = 0;
+      any = false;
+    }
+  }
+  if (any) params.add(cur);
+
+  // Modifier param (xterm convention: 1=none, 2=shift, 3=alt, 4=shift+alt,
+  // 5=ctrl, 6=ctrl+shift, 7=ctrl+alt, 8=ctrl+shift+alt). Apparent in
+  // sequences like `ESC [1;<mod><final>` or `ESC [<n>;<mod>~`.
+  Set<Modifier> mods = const {};
+  if (params.length >= 2) {
+    mods = _xtermModifiers(params[1]);
+  }
+
+  switch (finalByte) {
+    case 0x41: // A
+      return SpecialKey(code: SpecialKeyCode.up, modifiers: mods);
+    case 0x42: // B
+      return SpecialKey(code: SpecialKeyCode.down, modifiers: mods);
+    case 0x43: // C
+      return SpecialKey(code: SpecialKeyCode.right, modifiers: mods);
+    case 0x44: // D
+      return SpecialKey(code: SpecialKeyCode.left, modifiers: mods);
+    case 0x48: // H
+      return SpecialKey(code: SpecialKeyCode.home, modifiers: mods);
+    case 0x46: // F
+      return SpecialKey(code: SpecialKeyCode.end, modifiers: mods);
+    case 0x7e: // ~
+      // First param identifies the key. Common values:
+      // 2=insert, 3=delete, 5=pgUp, 6=pgDn, 15=F5, 17=F6, 18=F7, 19=F8,
+      // 20=F9, 21=F10, 23=F11, 24=F12.
+      final keyId = params.isNotEmpty ? params[0] : 0;
+      final code = switch (keyId) {
+        2 => SpecialKeyCode.insert,
+        3 => SpecialKeyCode.delete,
+        5 => SpecialKeyCode.pageUp,
+        6 => SpecialKeyCode.pageDown,
+        15 => SpecialKeyCode.f5,
+        17 => SpecialKeyCode.f6,
+        18 => SpecialKeyCode.f7,
+        19 => SpecialKeyCode.f8,
+        20 => SpecialKeyCode.f9,
+        21 => SpecialKeyCode.f10,
+        23 => SpecialKeyCode.f11,
+        24 => SpecialKeyCode.f12,
+        _ => null,
+      };
+      if (code != null) return SpecialKey(code: code, modifiers: mods);
+      return const SpecialKey(code: SpecialKeyCode.escape, modifiers: {});
+    default:
+      return const SpecialKey(code: SpecialKeyCode.escape, modifiers: {});
+  }
+}
+
+Set<Modifier> _xtermModifiers(int param) {
+  // xterm encodes modifiers as (param - 1) treated as a bitfield:
+  // bit 0 = shift, bit 1 = alt, bit 2 = ctrl.
+  final m = (param - 1).clamp(0, 7);
+  final out = <Modifier>{};
+  if (m & 1 != 0) out.add(Modifier.shift);
+  if (m & 2 != 0) out.add(Modifier.alt);
+  if (m & 4 != 0) out.add(Modifier.ctrl);
+  return out;
+}
+
+KeyEvent? _consumeSs3(Queue<int> bytes, {required bool streamClosed}) {
+  // ESC O X — we need 3 bytes.
+  if (bytes.length < 3) {
+    return streamClosed
+        ? (bytes.removeFirst(), const SpecialKey(code: SpecialKeyCode.escape, modifiers: {})).$2
+        : null;
+  }
+  bytes.removeFirst(); // ESC
+  bytes.removeFirst(); // O
+  final final_ = bytes.removeFirst();
+  switch (final_) {
+    case 0x41:
+      return const SpecialKey(code: SpecialKeyCode.up, modifiers: {});
+    case 0x42:
+      return const SpecialKey(code: SpecialKeyCode.down, modifiers: {});
+    case 0x43:
+      return const SpecialKey(code: SpecialKeyCode.right, modifiers: {});
+    case 0x44:
+      return const SpecialKey(code: SpecialKeyCode.left, modifiers: {});
+    case 0x50:
+      return const SpecialKey(code: SpecialKeyCode.f1, modifiers: {});
+    case 0x51:
+      return const SpecialKey(code: SpecialKeyCode.f2, modifiers: {});
+    case 0x52:
+      return const SpecialKey(code: SpecialKeyCode.f3, modifiers: {});
+    case 0x53:
+      return const SpecialKey(code: SpecialKeyCode.f4, modifiers: {});
+    default:
+      return const SpecialKey(code: SpecialKeyCode.escape, modifiers: {});
+  }
 }

--- a/app/lib/src/tui/input.dart
+++ b/app/lib/src/tui/input.dart
@@ -175,10 +175,9 @@ KeyEvent? _consume(Queue<int> bytes, {required bool streamClosed}) {
       return const CharKey(rune: 0xFFFD /* replacement */, modifiers: {});
     }
     var rune = first & (0xff >> (byteLen + 1));
-    final consumed = <int>[bytes.removeFirst()];
+    bytes.removeFirst();
     for (var i = 1; i < byteLen; i++) {
       final next = bytes.removeFirst();
-      consumed.add(next);
       rune = (rune << 6) | (next & 0x3f);
     }
     return CharKey(rune: rune, modifiers: const {});
@@ -314,9 +313,10 @@ Set<Modifier> _xtermModifiers(int param) {
 KeyEvent? _consumeSs3(Queue<int> bytes, {required bool streamClosed}) {
   // ESC O X — we need 3 bytes.
   if (bytes.length < 3) {
-    return streamClosed
-        ? (bytes.removeFirst(), const SpecialKey(code: SpecialKeyCode.escape, modifiers: {})).$2
-        : null;
+    if (!streamClosed) return null;
+    bytes.removeFirst(); // ESC
+    if (bytes.isNotEmpty) bytes.removeFirst(); // O
+    return const SpecialKey(code: SpecialKeyCode.escape, modifiers: {});
   }
   bytes.removeFirst(); // ESC
   bytes.removeFirst(); // O

--- a/app/lib/src/tui/input.dart
+++ b/app/lib/src/tui/input.dart
@@ -1,0 +1,84 @@
+import 'dart:async';
+import 'dart:collection';
+
+enum Modifier { shift, ctrl, alt }
+
+enum SpecialKeyCode {
+  up,
+  down,
+  left,
+  right,
+  enter,
+  tab,
+  backspace,
+  escape,
+  home,
+  end,
+  pageUp,
+  pageDown,
+  delete,
+  insert,
+  f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12,
+}
+
+sealed class KeyEvent {
+  final Set<Modifier> modifiers;
+  const KeyEvent(this.modifiers);
+}
+
+class CharKey extends KeyEvent {
+  final int rune;
+  const CharKey({required this.rune, required Set<Modifier> modifiers})
+      : super(modifiers);
+
+  @override
+  bool operator ==(Object other) =>
+      other is CharKey &&
+      other.rune == rune &&
+      _setEq(other.modifiers, modifiers);
+
+  @override
+  int get hashCode => Object.hash(rune, _setHash(modifiers));
+
+  @override
+  String toString() => 'CharKey(0x${rune.toRadixString(16)}, $modifiers)';
+}
+
+class SpecialKey extends KeyEvent {
+  final SpecialKeyCode code;
+  const SpecialKey({required this.code, required Set<Modifier> modifiers})
+      : super(modifiers);
+
+  @override
+  bool operator ==(Object other) =>
+      other is SpecialKey &&
+      other.code == code &&
+      _setEq(other.modifiers, modifiers);
+
+  @override
+  int get hashCode => Object.hash(code, _setHash(modifiers));
+
+  @override
+  String toString() => 'SpecialKey($code, $modifiers)';
+}
+
+bool _setEq(Set a, Set b) {
+  if (a.length != b.length) return false;
+  for (final x in a) {
+    if (!b.contains(x)) return false;
+  }
+  return true;
+}
+
+int _setHash(Set s) {
+  var h = 0;
+  for (final x in s) {
+    h ^= x.hashCode;
+  }
+  return h;
+}
+
+/// Defined in Task 6.
+Stream<KeyEvent> parseKeyEvents(Stream<List<int>> bytes) {
+  throw UnimplementedError('see Task 6');
+}

--- a/app/lib/src/tui/terminal.dart
+++ b/app/lib/src/tui/terminal.dart
@@ -36,13 +36,18 @@ class Terminal {
   bool _restored = false;
 
   final _resizeController = StreamController<void>.broadcast();
-  final _keysController = StreamController<KeyEvent>();
+  final _keysController = StreamController<KeyEvent>.broadcast();
   StreamSubscription<KeyEvent>? _keysSub;
   final _subs = <StreamSubscription>[];
 
   int get rows => _rows;
   int get cols => _cols;
+  /// Emits when the terminal is resized. The caller is responsible for
+  /// calling [draw] in response — the engine clears the screen on resize
+  /// but does not repaint until asked.
   Stream<void> get resizes => _resizeController.stream;
+
+  /// Stream of parsed key events. Broadcast, so multiple listeners are OK.
   Stream<KeyEvent> get keys => _keysController.stream;
 
   Future<void> _run(FutureOr<void> Function(Terminal) body) async {

--- a/app/lib/src/tui/terminal.dart
+++ b/app/lib/src/tui/terminal.dart
@@ -5,6 +5,26 @@ import 'ansi.dart';
 import 'buffer.dart';
 import 'input.dart';
 
+/// Rendering mode for a [Terminal] session.
+sealed class TerminalMode {
+  const TerminalMode();
+}
+
+/// Take over the whole terminal via the alt-screen buffer. The default.
+final class FullScreenMode extends TerminalMode {
+  const FullScreenMode();
+}
+
+/// Render into a fixed-height region anchored at the cursor's position
+/// when [Terminal.run] starts. Normal scrollback above the region is
+/// preserved. Suitable for status panels and dashboards that coexist with
+/// regular CLI output.
+final class InlineMode extends TerminalMode {
+  /// Height of the region in rows. Must be > 0.
+  final int rows;
+  const InlineMode({required this.rows}) : assert(rows > 0);
+}
+
 /// Owns the terminal lifecycle: alt-screen entry/exit, raw-mode stdin,
 /// signal handling, double-buffered painting, and crash-safe restore.
 ///
@@ -19,12 +39,18 @@ class Terminal {
   /// Run [body] inside an active terminal session. The terminal is restored
   /// to its previous state on normal completion, on uncaught error, and on
   /// SIGINT/SIGTERM/SIGHUP.
-  static Future<void> run(FutureOr<void> Function(Terminal terminal) body) async {
-    final terminal = Terminal._();
+  static Future<void> run(
+    FutureOr<void> Function(Terminal terminal) body, {
+    TerminalMode mode = const FullScreenMode(),
+  }) async {
+    final terminal = Terminal._(mode);
     await terminal._run(body);
   }
 
-  Terminal._();
+  Terminal._(this._mode);
+
+  // ignore: unused_field — wired up in Task 4 (inline-mode branching)
+  final TerminalMode _mode;
 
   int _rows = 0;
   int _cols = 0;

--- a/app/lib/src/tui/terminal.dart
+++ b/app/lib/src/tui/terminal.dart
@@ -66,7 +66,7 @@ class Terminal {
   StreamSubscription<KeyEvent>? _keysSub;
   final _subs = <StreamSubscription>[];
 
-  final _stdinController = StreamController<List<int>>();
+  final _stdinController = StreamController<List<int>>.broadcast();
   StreamSubscription<List<int>>? _stdinSub;
   int _originRow = 0;
   int _originCol = 0;
@@ -114,6 +114,7 @@ class Terminal {
       onDone: _stdinController.close,
     );
 
+    var pendingLeftover = const <int>[];
     final mode = _mode;
     if (mode is InlineMode) {
       stdout.write(Ansi.hideCursor);
@@ -128,10 +129,7 @@ class Terminal {
       _originRow = result.row;
       _originCol = 0;
       _anchored = true;
-      // Replay leftover bytes so the key parser sees them next.
-      if (result.leftoverBytes.isNotEmpty) {
-        _stdinController.add(result.leftoverBytes);
-      }
+      pendingLeftover = result.leftoverBytes;
 
       _rows = mode.rows;
       _cols = stdout.terminalColumns;
@@ -156,6 +154,11 @@ class Terminal {
       onError: _keysController.addError,
       onDone: _keysController.close,
     );
+    // Replay leftover bytes from the cursor-position query now that the parser
+    // is subscribed and ready to receive them.
+    if (pendingLeftover.isNotEmpty) {
+      _stdinController.add(pendingLeftover);
+    }
 
     // SIGWINCH — Unix only.
     try {

--- a/app/lib/src/tui/terminal.dart
+++ b/app/lib/src/tui/terminal.dart
@@ -74,6 +74,7 @@ class Terminal {
 
   int get rows => _rows;
   int get cols => _cols;
+
   /// Emits when the terminal is resized. The caller is responsible for
   /// calling [draw] in response — the engine clears the screen on resize
   /// but does not repaint until asked.
@@ -214,7 +215,8 @@ class Terminal {
   void draw(void Function(CellBuffer buffer) paint) {
     _back.clear();
     paint(_back);
-    final diff = encodeDiff(_front, _back, originRow: _originRow, originCol: _originCol);
+    final diff =
+        encodeDiff(_front, _back, originRow: _originRow, originCol: _originCol);
     if (diff.isNotEmpty) {
       stdout.write(diff);
     }

--- a/app/lib/src/tui/terminal.dart
+++ b/app/lib/src/tui/terminal.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 
 import 'ansi.dart';
 import 'buffer.dart';
+import 'cursor_query.dart';
 import 'input.dart';
 
 /// Rendering mode for a [Terminal] session.
@@ -49,7 +50,6 @@ class Terminal {
 
   Terminal._(this._mode);
 
-  // ignore: unused_field — wired up in Task 4 (inline-mode branching)
   final TerminalMode _mode;
 
   int _rows = 0;
@@ -66,6 +66,12 @@ class Terminal {
   StreamSubscription<KeyEvent>? _keysSub;
   final _subs = <StreamSubscription>[];
 
+  final _stdinController = StreamController<List<int>>();
+  StreamSubscription<List<int>>? _stdinSub;
+  int _originRow = 0;
+  int _originCol = 0;
+  bool _anchored = false;
+
   int get rows => _rows;
   int get cols => _cols;
   /// Emits when the terminal is resized. The caller is responsible for
@@ -78,7 +84,7 @@ class Terminal {
 
   Future<void> _run(FutureOr<void> Function(Terminal) body) async {
     _installSignalHandlers();
-    _enter();
+    await _enter();
     try {
       await runZonedGuarded(() async {
         await body(this);
@@ -93,47 +99,92 @@ class Terminal {
     }
   }
 
-  void _enter() {
+  Future<void> _enter() async {
     _wasEcho = stdin.echoMode;
     _wasLine = stdin.lineMode;
     stdin.echoMode = false;
     stdin.lineMode = false;
 
-    stdout.write(Ansi.enterAltScreen);
-    stdout.write(Ansi.hideCursor);
-    stdout.write(Ansi.clearScreen);
-    stdout.write(Ansi.moveTo(0, 0));
+    // Pipe stdin into our internal controller. Both the cursor-position query
+    // (briefly, during inline-mode entry) and the key parser (for the rest of
+    // the session) consume from _stdinController.stream.
+    _stdinSub = stdin.listen(
+      _stdinController.add,
+      onError: _stdinController.addError,
+      onDone: _stdinController.close,
+    );
 
-    _rows = stdout.terminalLines;
-    _cols = stdout.terminalColumns;
+    final mode = _mode;
+    if (mode is InlineMode) {
+      stdout.write(Ansi.hideCursor);
+      stdout.write('\n' * mode.rows);
+      stdout.write('\x1b[${mode.rows}F'); // CPL: cursor previous line × rows
+
+      final result = await queryCursorPosition(
+        bytes: _stdinController.stream,
+        write: stdout.add,
+        fallbackRow: stdout.terminalLines - mode.rows,
+      );
+      _originRow = result.row;
+      _originCol = 0;
+      _anchored = true;
+      // Replay leftover bytes so the key parser sees them next.
+      if (result.leftoverBytes.isNotEmpty) {
+        _stdinController.add(result.leftoverBytes);
+      }
+
+      _rows = mode.rows;
+      _cols = stdout.terminalColumns;
+    } else {
+      stdout.write(Ansi.enterAltScreen);
+      stdout.write(Ansi.hideCursor);
+      stdout.write(Ansi.clearScreen);
+      stdout.write(Ansi.moveTo(0, 0));
+      _originRow = 0;
+      _originCol = 0;
+      _anchored = true;
+      _rows = stdout.terminalLines;
+      _cols = stdout.terminalColumns;
+    }
+
     _front = CellBuffer(_rows, _cols);
     _back = CellBuffer(_rows, _cols);
 
-    // Pipe parsed key events into the public stream.
-    _keysSub = parseKeyEvents(stdin).listen(
+    // Hook up the key parser to the (now free) _stdinController.stream.
+    _keysSub = parseKeyEvents(_stdinController.stream).listen(
       _keysController.add,
       onError: _keysController.addError,
       onDone: _keysController.close,
     );
 
-    // SIGWINCH — Unix only. Errors silently ignored on platforms without it.
+    // SIGWINCH — Unix only.
     try {
       _subs.add(ProcessSignal.sigwinch.watch().listen((_) => _onResize()));
     } catch (_) {/* not supported on this platform */}
   }
 
   void _onResize() {
-    final newRows = stdout.terminalLines;
     final newCols = stdout.terminalColumns;
-    if (newRows == _rows && newCols == _cols) return;
-    _rows = newRows;
-    _cols = newCols;
-    _front = CellBuffer(_rows, _cols);
-    _back = CellBuffer(_rows, _cols);
-    // Force a full repaint by clearing the screen; the caller will redraw
-    // on the next resizes event and the diff will show every cell as changed.
-    stdout.write(Ansi.clearScreen);
-    stdout.write(Ansi.moveTo(0, 0));
+    final mode = _mode;
+    if (mode is InlineMode) {
+      if (newCols == _cols) return; // height is fixed; only columns can change
+      _cols = newCols;
+      _front = CellBuffer(_rows, _cols);
+      _back = CellBuffer(_rows, _cols);
+      // Do NOT clearScreen — that would wipe scrollback content above the
+      // inline region. Callers should repaint in response to the resizes
+      // event; the new (empty) _front means every cell will appear changed
+      // and be repainted.
+    } else {
+      final newRows = stdout.terminalLines;
+      if (newRows == _rows && newCols == _cols) return;
+      _rows = newRows;
+      _cols = newCols;
+      _front = CellBuffer(_rows, _cols);
+      _back = CellBuffer(_rows, _cols);
+      stdout.write(Ansi.clearScreen);
+      stdout.write(Ansi.moveTo(0, 0));
+    }
     _resizeController.add(null);
   }
 
@@ -160,7 +211,7 @@ class Terminal {
   void draw(void Function(CellBuffer buffer) paint) {
     _back.clear();
     paint(_back);
-    final diff = encodeDiff(_front, _back);
+    final diff = encodeDiff(_front, _back, originRow: _originRow, originCol: _originCol);
     if (diff.isNotEmpty) {
       stdout.write(diff);
     }
@@ -176,15 +227,26 @@ class Terminal {
     }
     _subs.clear();
     _keysSub?.cancel();
+    _stdinSub?.cancel();
     if (!_keysController.isClosed) _keysController.close();
     if (!_resizeController.isClosed) _resizeController.close();
+    if (!_stdinController.isClosed) _stdinController.close();
 
     // Write restore sequences synchronously so they reach the terminal even
     // on the way out of the process.
     try {
       stdout.write(Ansi.resetStyle);
-      stdout.write(Ansi.showCursor);
-      stdout.write(Ansi.exitAltScreen);
+      if (_mode is InlineMode) {
+        if (_anchored) {
+          stdout.write(Ansi.moveTo(_originRow, 0));
+          stdout.write('\x1b[J'); // clear to end of screen
+        }
+        stdout.write(Ansi.showCursor);
+        stdout.write('\n'); // next prompt on a fresh line
+      } else {
+        stdout.write(Ansi.showCursor);
+        stdout.write(Ansi.exitAltScreen);
+      }
     } catch (_) {/* stdout may already be closed */}
 
     try {

--- a/app/lib/src/tui/terminal.dart
+++ b/app/lib/src/tui/terminal.dart
@@ -1,0 +1,164 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'ansi.dart';
+import 'buffer.dart';
+import 'input.dart';
+
+/// Owns the terminal lifecycle: alt-screen entry/exit, raw-mode stdin,
+/// signal handling, double-buffered painting, and crash-safe restore.
+///
+/// Usage:
+/// ```dart
+/// await Terminal.run((terminal) async {
+///   terminal.draw((buffer) { ... });
+///   await for (final event in terminal.keys) { ... }
+/// });
+/// ```
+class Terminal {
+  /// Run [body] inside an active terminal session. The terminal is restored
+  /// to its previous state on normal completion, on uncaught error, and on
+  /// SIGINT/SIGTERM/SIGHUP.
+  static Future<void> run(FutureOr<void> Function(Terminal terminal) body) async {
+    final terminal = Terminal._();
+    await terminal._run(body);
+  }
+
+  Terminal._();
+
+  int _rows = 0;
+  int _cols = 0;
+  late CellBuffer _front;
+  late CellBuffer _back;
+
+  bool _wasEcho = false;
+  bool _wasLine = false;
+  bool _restored = false;
+
+  final _resizeController = StreamController<void>.broadcast();
+  final _keysController = StreamController<KeyEvent>();
+  StreamSubscription<KeyEvent>? _keysSub;
+  final _subs = <StreamSubscription>[];
+
+  int get rows => _rows;
+  int get cols => _cols;
+  Stream<void> get resizes => _resizeController.stream;
+  Stream<KeyEvent> get keys => _keysController.stream;
+
+  Future<void> _run(FutureOr<void> Function(Terminal) body) async {
+    _installSignalHandlers();
+    _enter();
+    try {
+      await runZonedGuarded(() async {
+        await body(this);
+      }, (error, stack) {
+        _restore();
+        stderr.writeln('Unhandled error in Terminal.run: $error');
+        stderr.writeln(stack);
+        exitCode = 1;
+      });
+    } finally {
+      _restore();
+    }
+  }
+
+  void _enter() {
+    _wasEcho = stdin.echoMode;
+    _wasLine = stdin.lineMode;
+    stdin.echoMode = false;
+    stdin.lineMode = false;
+
+    stdout.write(Ansi.enterAltScreen);
+    stdout.write(Ansi.hideCursor);
+    stdout.write(Ansi.clearScreen);
+    stdout.write(Ansi.moveTo(0, 0));
+
+    _rows = stdout.terminalLines;
+    _cols = stdout.terminalColumns;
+    _front = CellBuffer(_rows, _cols);
+    _back = CellBuffer(_rows, _cols);
+
+    // Pipe parsed key events into the public stream.
+    _keysSub = parseKeyEvents(stdin).listen(
+      _keysController.add,
+      onError: _keysController.addError,
+      onDone: _keysController.close,
+    );
+
+    // SIGWINCH — Unix only. Errors silently ignored on platforms without it.
+    try {
+      _subs.add(ProcessSignal.sigwinch.watch().listen((_) => _onResize()));
+    } catch (_) {/* not supported on this platform */}
+  }
+
+  void _onResize() {
+    final newRows = stdout.terminalLines;
+    final newCols = stdout.terminalColumns;
+    if (newRows == _rows && newCols == _cols) return;
+    _rows = newRows;
+    _cols = newCols;
+    _front = CellBuffer(_rows, _cols);
+    _back = CellBuffer(_rows, _cols);
+    // Force a full repaint by clearing the screen; the caller will redraw
+    // on the next resizes event and the diff will show every cell as changed.
+    stdout.write(Ansi.clearScreen);
+    stdout.write(Ansi.moveTo(0, 0));
+    _resizeController.add(null);
+  }
+
+  void _installSignalHandlers() {
+    void onTermSignal(int code) {
+      _restore();
+      exit(code);
+    }
+
+    try {
+      _subs.add(ProcessSignal.sigint.watch().listen((_) => onTermSignal(130)));
+    } catch (_) {}
+    try {
+      _subs.add(ProcessSignal.sigterm.watch().listen((_) => onTermSignal(143)));
+    } catch (_) {}
+    try {
+      _subs.add(ProcessSignal.sighup.watch().listen((_) => onTermSignal(129)));
+    } catch (_) {}
+  }
+
+  /// Compute and emit the diff between the current back buffer and the
+  /// caller's freshly-painted back buffer. The user's [paint] function
+  /// receives a cleared back buffer.
+  void draw(void Function(CellBuffer buffer) paint) {
+    _back.clear();
+    paint(_back);
+    final diff = encodeDiff(_front, _back);
+    if (diff.isNotEmpty) {
+      stdout.write(diff);
+    }
+    _front.copyFrom(_back);
+  }
+
+  void _restore() {
+    if (_restored) return;
+    _restored = true;
+
+    for (final sub in _subs) {
+      sub.cancel();
+    }
+    _subs.clear();
+    _keysSub?.cancel();
+    if (!_keysController.isClosed) _keysController.close();
+    if (!_resizeController.isClosed) _resizeController.close();
+
+    // Write restore sequences synchronously so they reach the terminal even
+    // on the way out of the process.
+    try {
+      stdout.write(Ansi.resetStyle);
+      stdout.write(Ansi.showCursor);
+      stdout.write(Ansi.exitAltScreen);
+    } catch (_) {/* stdout may already be closed */}
+
+    try {
+      stdin.echoMode = _wasEcho;
+      stdin.lineMode = _wasLine;
+    } catch (_) {}
+  }
+}

--- a/app/lib/src/tui/tui.dart
+++ b/app/lib/src/tui/tui.dart
@@ -1,0 +1,8 @@
+/// Public surface of the stage 1 TUI engine.
+library;
+
+export 'ansi.dart' show Ansi, encodeDiff;
+export 'buffer.dart';
+export 'cell.dart';
+export 'input.dart';
+export 'terminal.dart';

--- a/app/lib/src/tui/tui.dart
+++ b/app/lib/src/tui/tui.dart
@@ -4,5 +4,6 @@ library;
 export 'ansi.dart' show Ansi;
 export 'buffer.dart' show CellBuffer;
 export 'cell.dart' show Cell, Color, TextStyle;
-export 'input.dart' show KeyEvent, CharKey, SpecialKey, SpecialKeyCode, Modifier;
+export 'input.dart'
+    show KeyEvent, CharKey, SpecialKey, SpecialKeyCode, Modifier;
 export 'terminal.dart' show Terminal, TerminalMode, FullScreenMode, InlineMode;

--- a/app/lib/src/tui/tui.dart
+++ b/app/lib/src/tui/tui.dart
@@ -5,4 +5,4 @@ export 'ansi.dart' show Ansi;
 export 'buffer.dart' show CellBuffer;
 export 'cell.dart' show Cell, Color, TextStyle;
 export 'input.dart' show KeyEvent, CharKey, SpecialKey, SpecialKeyCode, Modifier;
-export 'terminal.dart' show Terminal;
+export 'terminal.dart' show Terminal, TerminalMode, FullScreenMode, InlineMode;

--- a/app/lib/src/tui/tui.dart
+++ b/app/lib/src/tui/tui.dart
@@ -1,8 +1,8 @@
 /// Public surface of the stage 1 TUI engine.
 library;
 
-export 'ansi.dart' show Ansi, encodeDiff;
-export 'buffer.dart';
-export 'cell.dart';
-export 'input.dart';
-export 'terminal.dart';
+export 'ansi.dart' show Ansi;
+export 'buffer.dart' show CellBuffer;
+export 'cell.dart' show Cell, Color, TextStyle;
+export 'input.dart' show KeyEvent, CharKey, SpecialKey, SpecialKeyCode, Modifier;
+export 'terminal.dart' show Terminal;

--- a/app/test/tui/ansi_test.dart
+++ b/app/test/tui/ansi_test.dart
@@ -165,6 +165,39 @@ void main() {
       expect(() => encodeDiff(front, back), throwsA(isA<ArgumentError>()));
     });
 
+    test('originRow shifts all cursor moves down', () {
+      final front = CellBuffer(1, 2);
+      final back = CellBuffer(1, 2);
+      back.set(0, 0, Cell(rune: 0x41));
+      back.set(0, 1, Cell(rune: 0x42));
+      final out = encodeDiff(front, back, originRow: 5);
+      // The single cursor move for the first cell should target row 5+0=5
+      // (1-indexed: 6), col 0 (1-indexed: 1).
+      expect(out, contains('\x1b[6;1H'));
+      expect(out, contains('AB'));
+    });
+
+    test('originCol shifts all cursor moves right', () {
+      final front = CellBuffer(1, 1);
+      final back = CellBuffer(1, 1);
+      back.set(0, 0, Cell(rune: 0x41));
+      final out = encodeDiff(front, back, originCol: 10);
+      // Move target: row 0+0=0 (1-indexed: 1), col 0+10=10 (1-indexed: 11).
+      expect(out, contains('\x1b[1;11H'));
+    });
+
+    test('default origin (0, 0) preserves existing behavior', () {
+      // Regression guard: omitting the new params must produce identical output
+      // to the pre-extension version.
+      final front = CellBuffer(1, 1);
+      final back = CellBuffer(1, 1);
+      back.set(0, 0, Cell(rune: 0x41));
+      final withDefault = encodeDiff(front, back);
+      final withExplicit = encodeDiff(front, back, originRow: 0, originCol: 0);
+      expect(withDefault, withExplicit);
+      expect(withDefault, contains('\x1b[1;1H'));
+    });
+
     test('style-to-zero with unchanged color re-emits fg/bg after reset', () {
       // Two cells: first is bold red 'A'; second is plain red 'B'.
       // When the encoder prints 'A', lastStyle becomes TextStyle.bold.

--- a/app/test/tui/ansi_test.dart
+++ b/app/test/tui/ansi_test.dart
@@ -1,0 +1,82 @@
+import 'package:flutterware_app/src/tui/ansi.dart';
+import 'package:flutterware_app/src/tui/cell.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('ansi constants', () {
+    test('alt-screen sequences', () {
+      expect(Ansi.enterAltScreen, '\x1b[?1049h');
+      expect(Ansi.exitAltScreen, '\x1b[?1049l');
+    });
+
+    test('cursor visibility', () {
+      expect(Ansi.hideCursor, '\x1b[?25l');
+      expect(Ansi.showCursor, '\x1b[?25h');
+    });
+
+    test('moveTo is 1-indexed', () {
+      // ANSI cursor positioning is 1-indexed; our API takes 0-indexed.
+      expect(Ansi.moveTo(0, 0), '\x1b[1;1H');
+      expect(Ansi.moveTo(4, 9), '\x1b[5;10H');
+    });
+
+    test('clearScreen', () {
+      expect(Ansi.clearScreen, '\x1b[2J');
+    });
+
+    test('resetStyle', () {
+      expect(Ansi.resetStyle, '\x1b[0m');
+    });
+  });
+
+  group('sgrForeground', () {
+    test('default fg', () {
+      expect(Ansi.sgrForeground(Color.defaultFg), '39');
+    });
+
+    test('named ansi fg (0-7)', () {
+      expect(Ansi.sgrForeground(Color.red), '31');
+      expect(Ansi.sgrForeground(Color.white), '37');
+    });
+
+    test('bright named ansi fg (8-15)', () {
+      expect(Ansi.sgrForeground(Color.brightRed), '91');
+      expect(Ansi.sgrForeground(Color.brightWhite), '97');
+    });
+
+    test('rgb fg', () {
+      expect(Ansi.sgrForeground(Color.rgb(10, 20, 30)), '38;2;10;20;30');
+    });
+  });
+
+  group('sgrBackground', () {
+    test('default bg', () {
+      expect(Ansi.sgrBackground(Color.defaultBg), '49');
+    });
+
+    test('named ansi bg', () {
+      expect(Ansi.sgrBackground(Color.blue), '44');
+      expect(Ansi.sgrBackground(Color.brightCyan), '106');
+    });
+
+    test('rgb bg', () {
+      expect(Ansi.sgrBackground(Color.rgb(255, 0, 128)), '48;2;255;0;128');
+    });
+  });
+
+  group('sgrStyle', () {
+    test('no style', () {
+      expect(Ansi.sgrStyle(0), <String>[]);
+    });
+
+    test('bold', () {
+      expect(Ansi.sgrStyle(TextStyle.bold), ['1']);
+    });
+
+    test('combined', () {
+      final s = Ansi.sgrStyle(TextStyle.bold | TextStyle.underline | TextStyle.reverse);
+      expect(s, containsAll(['1', '4', '7']));
+      expect(s.length, 3);
+    });
+  });
+}

--- a/app/test/tui/ansi_test.dart
+++ b/app/test/tui/ansi_test.dart
@@ -75,7 +75,8 @@ void main() {
     });
 
     test('combined', () {
-      final s = Ansi.sgrStyle(TextStyle.bold | TextStyle.underline | TextStyle.reverse);
+      final s = Ansi.sgrStyle(
+          TextStyle.bold | TextStyle.underline | TextStyle.reverse);
       expect(s, containsAll(['1', '4', '7']));
       expect(s.length, 3);
     });

--- a/app/test/tui/ansi_test.dart
+++ b/app/test/tui/ansi_test.dart
@@ -107,7 +107,6 @@ void main() {
       final out = encodeDiff(front, back);
       // First move to (0,1) = CSI 1;2H. After writing 'A', the cursor is at
       // (0,2), so the next 'B' should follow without another CSI move.
-      final moves = '\x1b['.allMatches(out).length;
       // We expect: one CSI for move + at most SGR transitions. With both
       // cells default colored from empty state, SGR may or may not appear.
       // The number of move sequences (matching CSI <num>;<num>H) must be 1.
@@ -164,6 +163,40 @@ void main() {
       final front = CellBuffer(2, 2);
       final back = CellBuffer(3, 3);
       expect(() => encodeDiff(front, back), throwsA(isA<ArgumentError>()));
+    });
+
+    test('style-to-zero with unchanged color re-emits fg/bg after reset', () {
+      // Two cells: first is bold red 'A'; second is plain red 'B'.
+      // When the encoder prints 'A', lastStyle becomes TextStyle.bold.
+      // When it then prints 'B' (style 0, same red fg), it must emit a reset
+      // (0) followed by red fg again — otherwise the reset would clear the
+      // color to terminal default.
+      final front = CellBuffer(1, 2);
+      final back = CellBuffer(1, 2);
+      back.set(0, 0, Cell(rune: 0x41, fg: Color.red, style: TextStyle.bold));
+      back.set(0, 1, Cell(rune: 0x42, fg: Color.red /* style: 0 */));
+      final out = encodeDiff(front, back);
+      // Must include a reset ('0') and re-apply red ('31') for the second cell.
+      expect(out, contains('0'));
+      expect(out, contains('31'));
+      expect(out, contains('A'));
+      expect(out, contains('B'));
+    });
+
+    test('non-zero style transitions to a different non-zero style', () {
+      // Two cells: first is bold 'A'; second is italic 'B'. After printing 'A',
+      // lastStyle becomes TextStyle.bold. For 'B' the style differs, so the
+      // encoder must reset (emit '0') then apply italic ('3').
+      final front = CellBuffer(1, 2);
+      final back = CellBuffer(1, 2);
+      back.set(0, 0, Cell(rune: 0x41, style: TextStyle.bold));
+      back.set(0, 1, Cell(rune: 0x42, style: TextStyle.italic));
+      final out = encodeDiff(front, back);
+      // Reset is emitted before 'B'; italic param '3' appears; both runes present.
+      expect(out, contains('0'));
+      expect(out, contains('3'));
+      expect(out, contains('A'));
+      expect(out, contains('B'));
     });
   });
 }

--- a/app/test/tui/ansi_test.dart
+++ b/app/test/tui/ansi_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutterware_app/src/tui/ansi.dart';
+import 'package:flutterware_app/src/tui/buffer.dart';
 import 'package:flutterware_app/src/tui/cell.dart';
 import 'package:test/test.dart';
 
@@ -77,6 +78,92 @@ void main() {
       final s = Ansi.sgrStyle(TextStyle.bold | TextStyle.underline | TextStyle.reverse);
       expect(s, containsAll(['1', '4', '7']));
       expect(s.length, 3);
+    });
+  });
+
+  group('encodeDiff', () {
+    test('no changes produces empty string', () {
+      final front = CellBuffer(2, 2);
+      final back = CellBuffer(2, 2);
+      expect(encodeDiff(front, back), '');
+    });
+
+    test('single cell change emits move + SGR + rune', () {
+      final front = CellBuffer(2, 4);
+      final back = CellBuffer(2, 4);
+      back.set(1, 2, Cell(rune: 0x41 /* A */));
+      final out = encodeDiff(front, back);
+      // Expected: move to (1,2) in 0-indexed = CSI 2;3H, default colors,
+      // then "A".
+      expect(out, contains('\x1b[2;3H'));
+      expect(out, contains('A'));
+    });
+
+    test('two adjacent changes in same row skip second move', () {
+      final front = CellBuffer(1, 5);
+      final back = CellBuffer(1, 5);
+      back.set(0, 1, Cell(rune: 0x41));
+      back.set(0, 2, Cell(rune: 0x42));
+      final out = encodeDiff(front, back);
+      // First move to (0,1) = CSI 1;2H. After writing 'A', the cursor is at
+      // (0,2), so the next 'B' should follow without another CSI move.
+      final moves = '\x1b['.allMatches(out).length;
+      // We expect: one CSI for move + at most SGR transitions. With both
+      // cells default colored from empty state, SGR may or may not appear.
+      // The number of move sequences (matching CSI <num>;<num>H) must be 1.
+      final moveRegex = RegExp(r'\x1b\[\d+;\d+H');
+      expect(moveRegex.allMatches(out).length, 1);
+      expect(out, contains('AB'));
+    });
+
+    test('change at start of new row emits a move', () {
+      final front = CellBuffer(2, 3);
+      final back = CellBuffer(2, 3);
+      back.set(0, 0, Cell(rune: 0x41));
+      back.set(1, 0, Cell(rune: 0x42));
+      final out = encodeDiff(front, back);
+      final moveRegex = RegExp(r'\x1b\[\d+;\d+H');
+      expect(moveRegex.allMatches(out).length, 2);
+    });
+
+    test('fg change emits SGR', () {
+      final front = CellBuffer(1, 2);
+      final back = CellBuffer(1, 2);
+      back.set(0, 0, Cell(rune: 0x41, fg: Color.red));
+      final out = encodeDiff(front, back);
+      expect(out, contains('31'));
+      expect(out, contains('A'));
+    });
+
+    test('consecutive cells with same color do not re-emit SGR', () {
+      final front = CellBuffer(1, 3);
+      final back = CellBuffer(1, 3);
+      back.set(0, 0, Cell(rune: 0x41, fg: Color.red));
+      back.set(0, 1, Cell(rune: 0x42, fg: Color.red));
+      back.set(0, 2, Cell(rune: 0x43, fg: Color.red));
+      final out = encodeDiff(front, back);
+      // The red SGR (parameter "31") should appear exactly once.
+      final redCount = '31'.allMatches(out).length;
+      expect(redCount, 1);
+      expect(out, contains('ABC'));
+    });
+
+    test('color reset emits default fg', () {
+      // front: red 'A'; back: default 'A' (rune unchanged but color is)
+      final front = CellBuffer(1, 1);
+      front.set(0, 0, Cell(rune: 0x41, fg: Color.red));
+      final back = CellBuffer(1, 1);
+      back.set(0, 0, Cell(rune: 0x41 /* default */));
+      // The cell is "different" (fg differs), so we emit something.
+      final out = encodeDiff(front, back);
+      expect(out, contains('39')); // default fg
+      expect(out, contains('A'));
+    });
+
+    test('size mismatch throws', () {
+      final front = CellBuffer(2, 2);
+      final back = CellBuffer(3, 3);
+      expect(() => encodeDiff(front, back), throwsA(isA<ArgumentError>()));
     });
   });
 }

--- a/app/test/tui/ansi_test.dart
+++ b/app/test/tui/ansi_test.dart
@@ -177,7 +177,9 @@ void main() {
       back.set(0, 1, Cell(rune: 0x42, fg: Color.red /* style: 0 */));
       final out = encodeDiff(front, back);
       // Must include a reset ('0') and re-apply red ('31') for the second cell.
-      expect(out, contains('0'));
+      // Match a `0` SGR param surrounded by either CSI `[` or `;` on the left
+      // and either `m` or `;` on the right — i.e. a real reset, not part of '31'.
+      expect(out, matches(RegExp(r'(\x1b\[|;)0(;|m)')));
       expect(out, contains('31'));
       expect(out, contains('A'));
       expect(out, contains('B'));
@@ -193,8 +195,11 @@ void main() {
       back.set(0, 1, Cell(rune: 0x42, style: TextStyle.italic));
       final out = encodeDiff(front, back);
       // Reset is emitted before 'B'; italic param '3' appears; both runes present.
-      expect(out, contains('0'));
-      expect(out, contains('3'));
+      // Match a `0` SGR param surrounded by either CSI `[` or `;` on the left
+      // and either `m` or `;` on the right — i.e. a real reset, not part of '31'.
+      expect(out, matches(RegExp(r'(\x1b\[|;)0(;|m)')));
+      // Italic SGR param '3' similarly bounded.
+      expect(out, matches(RegExp(r'(\x1b\[|;)3(;|m)')));
       expect(out, contains('A'));
       expect(out, contains('B'));
     });

--- a/app/test/tui/buffer_test.dart
+++ b/app/test/tui/buffer_test.dart
@@ -1,0 +1,133 @@
+import 'package:flutterware_app/src/tui/buffer.dart';
+import 'package:flutterware_app/src/tui/cell.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('CellBuffer', () {
+    test('new buffer is filled with Cell.empty', () {
+      final b = CellBuffer(3, 4);
+      expect(b.rows, 3);
+      expect(b.cols, 4);
+      for (var r = 0; r < 3; r++) {
+        for (var c = 0; c < 4; c++) {
+          expect(b.get(r, c), Cell.empty);
+        }
+      }
+    });
+
+    test('set and get round-trip', () {
+      final b = CellBuffer(2, 2);
+      final cell = Cell(rune: 0x41, fg: Color.red);
+      b.set(0, 1, cell);
+      expect(b.get(0, 1), cell);
+      expect(b.get(0, 0), Cell.empty);
+    });
+
+    test('writeAt writes a string left-to-right', () {
+      final b = CellBuffer(1, 10);
+      b.writeAt(0, 2, 'Hi');
+      expect(b.get(0, 0), Cell.empty);
+      expect(b.get(0, 1), Cell.empty);
+      expect(b.get(0, 2).rune, 0x48); // H
+      expect(b.get(0, 3).rune, 0x69); // i
+      expect(b.get(0, 4), Cell.empty);
+    });
+
+    test('writeAt applies fg/bg/style to all cells', () {
+      final b = CellBuffer(1, 5);
+      b.writeAt(0, 0, 'ab', fg: Color.red, style: TextStyle.bold);
+      expect(b.get(0, 0).fg, Color.red);
+      expect(b.get(0, 0).style, TextStyle.bold);
+      expect(b.get(0, 1).fg, Color.red);
+    });
+
+    test('writeAt clips silently past right edge', () {
+      final b = CellBuffer(1, 3);
+      b.writeAt(0, 1, 'hello');
+      expect(b.get(0, 0), Cell.empty);
+      expect(b.get(0, 1).rune, 0x68); // h
+      expect(b.get(0, 2).rune, 0x65); // e
+      // 'llo' silently dropped
+    });
+
+    test('writeAt with negative col is partially clipped', () {
+      final b = CellBuffer(1, 4);
+      b.writeAt(0, -2, 'hello');
+      // h,e at -2,-1 clipped; l,l,o at 0,1,2
+      expect(b.get(0, 0).rune, 0x6c); // l
+      expect(b.get(0, 1).rune, 0x6c); // l
+      expect(b.get(0, 2).rune, 0x6f); // o
+      expect(b.get(0, 3), Cell.empty);
+    });
+
+    test('set out of bounds is a no-op', () {
+      final b = CellBuffer(2, 2);
+      // Must not throw.
+      b.set(-1, 0, Cell(rune: 0x41));
+      b.set(0, 5, Cell(rune: 0x41));
+      b.set(10, 10, Cell(rune: 0x41));
+      expect(b.get(0, 0), Cell.empty);
+    });
+
+    test('get out of bounds returns Cell.empty', () {
+      final b = CellBuffer(2, 2);
+      expect(b.get(-1, 0), Cell.empty);
+      expect(b.get(0, 5), Cell.empty);
+    });
+
+    test('fill replaces every cell', () {
+      final b = CellBuffer(2, 2);
+      final c = Cell(rune: 0x41, fg: Color.blue);
+      b.fill(c);
+      expect(b.get(0, 0), c);
+      expect(b.get(1, 1), c);
+    });
+
+    test('fillRect fills only the given region', () {
+      final b = CellBuffer(4, 4);
+      final c = Cell(rune: 0x23); // #
+      b.fillRect(1, 1, 2, 2, c);
+      expect(b.get(0, 0), Cell.empty);
+      expect(b.get(1, 1), c);
+      expect(b.get(2, 2), c);
+      expect(b.get(3, 3), Cell.empty);
+    });
+
+    test('fillRect clips to buffer bounds', () {
+      final b = CellBuffer(2, 2);
+      final c = Cell(rune: 0x23);
+      b.fillRect(-1, -1, 5, 5, c); // overflows on all sides
+      // Every in-bounds cell should be c.
+      for (var r = 0; r < 2; r++) {
+        for (var col = 0; col < 2; col++) {
+          expect(b.get(r, col), c);
+        }
+      }
+    });
+
+    test('copyFrom copies all cells', () {
+      final a = CellBuffer(2, 2);
+      a.set(0, 0, Cell(rune: 0x41));
+      a.set(1, 1, Cell(rune: 0x42));
+      final b = CellBuffer(2, 2);
+      b.copyFrom(a);
+      expect(b.get(0, 0).rune, 0x41);
+      expect(b.get(1, 1).rune, 0x42);
+    });
+
+    test('copyFrom throws on size mismatch', () {
+      final a = CellBuffer(2, 2);
+      final b = CellBuffer(3, 3);
+      expect(() => b.copyFrom(a), throwsA(isA<ArgumentError>()));
+    });
+
+    test('inBounds', () {
+      final b = CellBuffer(2, 3);
+      expect(b.inBounds(0, 0), isTrue);
+      expect(b.inBounds(1, 2), isTrue);
+      expect(b.inBounds(-1, 0), isFalse);
+      expect(b.inBounds(0, 3), isFalse);
+      expect(b.inBounds(2, 0), isFalse);
+    });
+  });
+}

--- a/app/test/tui/cell_test.dart
+++ b/app/test/tui/cell_test.dart
@@ -1,0 +1,53 @@
+import 'package:flutterware_app/src/tui/cell.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Color', () {
+    test('named ANSI colors have stable indices', () {
+      expect(Color.red.ansiIndex, 1);
+      expect(Color.brightWhite.ansiIndex, 15);
+    });
+
+    test('rgb colors carry rgb values', () {
+      final c = Color.rgb(10, 20, 30);
+      expect(c.r, 10);
+      expect(c.g, 20);
+      expect(c.b, 30);
+    });
+
+    test('default colors are distinct from named black', () {
+      expect(Color.defaultFg, isNot(equals(Color.black)));
+      expect(Color.defaultBg, isNot(equals(Color.black)));
+    });
+
+    test('value equality', () {
+      expect(Color.rgb(1, 2, 3), equals(Color.rgb(1, 2, 3)));
+      expect(Color.red, equals(Color.red));
+      expect(Color.red, isNot(equals(Color.blue)));
+    });
+  });
+
+  group('Cell', () {
+    test('empty cell is a space with default colors', () {
+      expect(Cell.empty.rune, 0x20);
+      expect(Cell.empty.fg, Color.defaultFg);
+      expect(Cell.empty.bg, Color.defaultBg);
+      expect(Cell.empty.style, 0);
+      expect(Cell.empty.width, 1);
+    });
+
+    test('value equality', () {
+      final a = Cell(rune: 0x41, fg: Color.red, bg: Color.defaultBg, style: TextStyle.bold);
+      final b = Cell(rune: 0x41, fg: Color.red, bg: Color.defaultBg, style: TextStyle.bold);
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+    });
+
+    test('TextStyle bitfield combines', () {
+      final combined = TextStyle.bold | TextStyle.underline;
+      expect(combined & TextStyle.bold, isNot(0));
+      expect(combined & TextStyle.underline, isNot(0));
+      expect(combined & TextStyle.italic, 0);
+    });
+  });
+}

--- a/app/test/tui/cell_test.dart
+++ b/app/test/tui/cell_test.dart
@@ -50,4 +50,22 @@ void main() {
       expect(combined & TextStyle.italic, 0);
     });
   });
+
+  group('kind predicates', () {
+    test('kind predicates', () {
+      expect(Color.defaultFg.isDefault, isTrue);
+      expect(Color.defaultBg.isDefault, isTrue);
+      expect(Color.red.isAnsi, isTrue);
+      expect(Color.rgb(1, 2, 3).isRgb, isTrue);
+
+      expect(Color.defaultFg.isDefaultFg, isTrue);
+      expect(Color.defaultFg.isDefaultBg, isFalse);
+      expect(Color.defaultBg.isDefaultBg, isTrue);
+      expect(Color.defaultBg.isDefaultFg, isFalse);
+
+      // Cross checks: non-default isn't default
+      expect(Color.red.isDefault, isFalse);
+      expect(Color.rgb(0, 0, 0).isAnsi, isFalse);
+    });
+  });
 }

--- a/app/test/tui/cell_test.dart
+++ b/app/test/tui/cell_test.dart
@@ -37,8 +37,16 @@ void main() {
     });
 
     test('value equality', () {
-      final a = Cell(rune: 0x41, fg: Color.red, bg: Color.defaultBg, style: TextStyle.bold);
-      final b = Cell(rune: 0x41, fg: Color.red, bg: Color.defaultBg, style: TextStyle.bold);
+      final a = Cell(
+          rune: 0x41,
+          fg: Color.red,
+          bg: Color.defaultBg,
+          style: TextStyle.bold);
+      final b = Cell(
+          rune: 0x41,
+          fg: Color.red,
+          bg: Color.defaultBg,
+          style: TextStyle.bold);
       expect(a, equals(b));
       expect(a.hashCode, equals(b.hashCode));
     });

--- a/app/test/tui/cursor_query_test.dart
+++ b/app/test/tui/cursor_query_test.dart
@@ -1,0 +1,144 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutterware_app/src/tui/cursor_query.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('queryCursorPosition', () {
+    test('parses a clean response and returns 0-indexed row', () async {
+      final input = StreamController<List<int>>();
+      final outputBuf = <int>[];
+
+      final future = queryCursorPosition(
+        bytes: input.stream,
+        write: outputBuf.addAll,
+        fallbackRow: -1,
+      );
+
+      // Simulate terminal response: CSI 5;12R (row 5, col 12, 1-indexed).
+      input.add('\x1b[5;12R'.codeUnits);
+
+      final result = await future;
+      expect(result.row, 4); // 0-indexed
+      expect(result.col, 11);
+      expect(result.leftoverBytes, isEmpty);
+      // The query helper should have written CSI 6n.
+      expect(utf8.decode(outputBuf), '\x1b[6n');
+
+      await input.close();
+    });
+
+    test('response split across chunks', () async {
+      final input = StreamController<List<int>>();
+      final future = queryCursorPosition(
+        bytes: input.stream,
+        write: (_) {},
+        fallbackRow: -1,
+      );
+
+      input.add([0x1b, 0x5b]);
+      input.add('5'.codeUnits);
+      input.add(';12R'.codeUnits);
+
+      final result = await future;
+      expect(result.row, 4);
+      expect(result.col, 11);
+      expect(result.leftoverBytes, isEmpty);
+      await input.close();
+    });
+
+    test('non-response bytes before the response are forwarded as leftover', () async {
+      // The user typed 'A' before the response arrived.
+      final input = StreamController<List<int>>();
+      final future = queryCursorPosition(
+        bytes: input.stream,
+        write: (_) {},
+        fallbackRow: -1,
+      );
+
+      input.add([0x41]); // 'A'
+      input.add('\x1b[3;7R'.codeUnits);
+
+      final result = await future;
+      expect(result.row, 2);
+      expect(result.col, 6);
+      expect(result.leftoverBytes, [0x41]);
+      await input.close();
+    });
+
+    test('non-response bytes after the response are forwarded as leftover', () async {
+      // The user typed 'B' right after the response.
+      final input = StreamController<List<int>>();
+      final future = queryCursorPosition(
+        bytes: input.stream,
+        write: (_) {},
+        fallbackRow: -1,
+      );
+
+      input.add('\x1b[3;7R'.codeUnits);
+      input.add([0x42]); // 'B' — arrives in the same async tick
+
+      final result = await future;
+      expect(result.row, 2);
+      // 'B' arrived in a separate chunk after the helper had completed; it is
+      // NOT captured in leftoverBytes (the helper has already resolved).
+      expect(result.leftoverBytes, isEmpty);
+      await input.close();
+    });
+
+    test('interleaved escape-prefixed non-response bytes survive', () async {
+      // An up-arrow key '\x1b[A' interleaves: ESC, [, A. The parser must
+      // recognize that this isn't a position response (A isn't a digit after
+      // ESC [), discard its partial-parse state, and forward those 3 bytes
+      // to leftoverBytes. Then the real response comes through.
+      final input = StreamController<List<int>>();
+      final future = queryCursorPosition(
+        bytes: input.stream,
+        write: (_) {},
+        fallbackRow: -1,
+      );
+
+      input.add('\x1b[A'.codeUnits);     // arrow up — must NOT be consumed as response
+      input.add('\x1b[10;20R'.codeUnits); // real response
+
+      final result = await future;
+      expect(result.row, 9);
+      expect(result.col, 19);
+      expect(result.leftoverBytes, '\x1b[A'.codeUnits);
+      await input.close();
+    });
+
+    test('timeout returns fallback row and empty leftover', () async {
+      final input = StreamController<List<int>>();
+      final result = await queryCursorPosition(
+        bytes: input.stream,
+        write: (_) {},
+        fallbackRow: 42,
+        timeout: const Duration(milliseconds: 50),
+      );
+      expect(result.row, 42);
+      expect(result.col, 0);
+      expect(result.leftoverBytes, isEmpty);
+      await input.close();
+    });
+
+    test('timeout forwards any bytes received before timeout as leftover', () async {
+      final input = StreamController<List<int>>();
+      final future = queryCursorPosition(
+        bytes: input.stream,
+        write: (_) {},
+        fallbackRow: 42,
+        timeout: const Duration(milliseconds: 50),
+      );
+
+      input.add([0x58, 0x59]); // 'X', 'Y' — random non-response bytes
+      // No response ever comes.
+
+      final result = await future;
+      expect(result.row, 42);
+      expect(result.leftoverBytes, [0x58, 0x59]);
+      await input.close();
+    });
+  });
+}

--- a/app/test/tui/cursor_query_test.dart
+++ b/app/test/tui/cursor_query_test.dart
@@ -48,7 +48,8 @@ void main() {
       await input.close();
     });
 
-    test('non-response bytes before the response are forwarded as leftover', () async {
+    test('non-response bytes before the response are forwarded as leftover',
+        () async {
       // The user typed 'A' before the response arrived.
       final input = StreamController<List<int>>();
       final future = queryCursorPosition(
@@ -67,7 +68,8 @@ void main() {
       await input.close();
     });
 
-    test('non-response bytes after the response are forwarded as leftover', () async {
+    test('non-response bytes after the response are forwarded as leftover',
+        () async {
       // The user typed 'B' right after the response.
       final input = StreamController<List<int>>();
       final future = queryCursorPosition(
@@ -99,7 +101,8 @@ void main() {
         fallbackRow: -1,
       );
 
-      input.add('\x1b[A'.codeUnits);     // arrow up — must NOT be consumed as response
+      input.add(
+          '\x1b[A'.codeUnits); // arrow up — must NOT be consumed as response
       input.add('\x1b[10;20R'.codeUnits); // real response
 
       final result = await future;
@@ -123,7 +126,8 @@ void main() {
       await input.close();
     });
 
-    test('timeout forwards any bytes received before timeout as leftover', () async {
+    test('timeout forwards any bytes received before timeout as leftover',
+        () async {
       final input = StreamController<List<int>>();
       final future = queryCursorPosition(
         bytes: input.stream,
@@ -141,7 +145,8 @@ void main() {
       await input.close();
     });
 
-    test('timeout with mid-sequence pending bytes forwards them as leftover', () async {
+    test('timeout with mid-sequence pending bytes forwards them as leftover',
+        () async {
       // The terminal started sending what looked like a response but never
       // completed it. The bytes ESC [ 1 are "tentatively consumed" by the
       // parser; on timeout they must be forwarded as leftover, not dropped.

--- a/app/test/tui/cursor_query_test.dart
+++ b/app/test/tui/cursor_query_test.dart
@@ -140,5 +140,26 @@ void main() {
       expect(result.leftoverBytes, [0x58, 0x59]);
       await input.close();
     });
+
+    test('timeout with mid-sequence pending bytes forwards them as leftover', () async {
+      // The terminal started sending what looked like a response but never
+      // completed it. The bytes ESC [ 1 are "tentatively consumed" by the
+      // parser; on timeout they must be forwarded as leftover, not dropped.
+      final input = StreamController<List<int>>();
+      final future = queryCursorPosition(
+        bytes: input.stream,
+        write: (_) {},
+        fallbackRow: 7,
+        timeout: const Duration(milliseconds: 50),
+      );
+
+      input.add([0x1b, 0x5b, 0x31]); // ESC [ 1 — partial response
+      // No further bytes; timeout fires.
+
+      final result = await future;
+      expect(result.row, 7);
+      expect(result.leftoverBytes, [0x1b, 0x5b, 0x31]);
+      await input.close();
+    });
   });
 }

--- a/app/test/tui/input_test.dart
+++ b/app/test/tui/input_test.dart
@@ -33,4 +33,125 @@ void main() {
       expect(a, isNot(equals(b)));
     });
   });
+
+  group('parseKeyEvents', () {
+    Future<List<KeyEvent>> parse(List<List<int>> chunks) async {
+      final stream = Stream<List<int>>.fromIterable(chunks);
+      return parseKeyEvents(stream).toList();
+    }
+
+    test('ASCII printable becomes CharKey', () async {
+      final events = await parse([[0x41, 0x42]]); // 'A', 'B'
+      expect(events, [
+        const CharKey(rune: 0x41, modifiers: {}),
+        const CharKey(rune: 0x42, modifiers: {}),
+      ]);
+    });
+
+    test('ctrl-A through ctrl-Z become CharKey with ctrl modifier', () async {
+      final events = await parse([[0x01, 0x03, 0x1a]]); // ctrl-A, ctrl-C, ctrl-Z
+      expect(events.length, 3);
+      expect(events[0], CharKey(rune: 0x61, modifiers: {Modifier.ctrl})); // 'a'
+      expect(events[1], CharKey(rune: 0x63, modifiers: {Modifier.ctrl})); // 'c'
+      expect(events[2], CharKey(rune: 0x7a, modifiers: {Modifier.ctrl})); // 'z'
+    });
+
+    test('enter, tab, backspace', () async {
+      final events = await parse([[0x0d, 0x09, 0x7f]]);
+      expect(events, [
+        const SpecialKey(code: SpecialKeyCode.enter, modifiers: {}),
+        const SpecialKey(code: SpecialKeyCode.tab, modifiers: {}),
+        const SpecialKey(code: SpecialKeyCode.backspace, modifiers: {}),
+      ]);
+    });
+
+    test('newline (LF) is also enter', () async {
+      final events = await parse([[0x0a]]);
+      expect(events, [
+        const SpecialKey(code: SpecialKeyCode.enter, modifiers: {}),
+      ]);
+    });
+
+    test('CSI arrows', () async {
+      // ESC [ A/B/C/D
+      final events = await parse([
+        [0x1b, 0x5b, 0x41],
+        [0x1b, 0x5b, 0x42],
+        [0x1b, 0x5b, 0x43],
+        [0x1b, 0x5b, 0x44],
+      ]);
+      expect(events, [
+        const SpecialKey(code: SpecialKeyCode.up, modifiers: {}),
+        const SpecialKey(code: SpecialKeyCode.down, modifiers: {}),
+        const SpecialKey(code: SpecialKeyCode.right, modifiers: {}),
+        const SpecialKey(code: SpecialKeyCode.left, modifiers: {}),
+      ]);
+    });
+
+    test('SS3 arrows (ESC O A)', () async {
+      final events = await parse([[0x1b, 0x4f, 0x41]]); // ESC O A
+      expect(events, [
+        const SpecialKey(code: SpecialKeyCode.up, modifiers: {}),
+      ]);
+    });
+
+    test('CSI with modifier (ctrl-up = ESC [1;5A)', () async {
+      final events = await parse([[0x1b, 0x5b, 0x31, 0x3b, 0x35, 0x41]]);
+      expect(events, [
+        const SpecialKey(code: SpecialKeyCode.up, modifiers: {Modifier.ctrl}),
+      ]);
+    });
+
+    test('CSI shift-arrow (ESC [1;2A)', () async {
+      final events = await parse([[0x1b, 0x5b, 0x31, 0x3b, 0x32, 0x41]]);
+      expect(events, [
+        const SpecialKey(code: SpecialKeyCode.up, modifiers: {Modifier.shift}),
+      ]);
+    });
+
+    test('CSI Home/End/PgUp/PgDn (ESC [H, [F, [5~, [6~)', () async {
+      final events = await parse([
+        [0x1b, 0x5b, 0x48], // home
+        [0x1b, 0x5b, 0x46], // end
+        [0x1b, 0x5b, 0x35, 0x7e], // pgUp
+        [0x1b, 0x5b, 0x36, 0x7e], // pgDn
+      ]);
+      expect(events, [
+        const SpecialKey(code: SpecialKeyCode.home, modifiers: {}),
+        const SpecialKey(code: SpecialKeyCode.end, modifiers: {}),
+        const SpecialKey(code: SpecialKeyCode.pageUp, modifiers: {}),
+        const SpecialKey(code: SpecialKeyCode.pageDown, modifiers: {}),
+      ]);
+    });
+
+    test('bare escape (no follow-up bytes) emits escape', () async {
+      // A single chunk containing ONLY ESC, followed by stream end.
+      final events = await parse([[0x1b]]);
+      expect(events, [
+        const SpecialKey(code: SpecialKeyCode.escape, modifiers: {}),
+      ]);
+    });
+
+    test('UTF-8 multi-byte rune', () async {
+      // U+00E9 (é) in UTF-8 = C3 A9
+      final events = await parse([[0xc3, 0xa9]]);
+      expect(events, [
+        const CharKey(rune: 0x00e9, modifiers: {}),
+      ]);
+    });
+
+    test('UTF-8 split across chunks', () async {
+      final events = await parse([[0xc3], [0xa9]]);
+      expect(events, [
+        const CharKey(rune: 0x00e9, modifiers: {}),
+      ]);
+    });
+
+    test('CSI split across chunks', () async {
+      final events = await parse([[0x1b], [0x5b], [0x41]]);
+      expect(events, [
+        const SpecialKey(code: SpecialKeyCode.up, modifiers: {}),
+      ]);
+    });
+  });
 }

--- a/app/test/tui/input_test.dart
+++ b/app/test/tui/input_test.dart
@@ -1,0 +1,36 @@
+import 'package:flutterware_app/src/tui/input.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('KeyEvent types', () {
+    test('CharKey holds rune and modifiers', () {
+      const k = CharKey(rune: 0x41, modifiers: {});
+      expect(k.rune, 0x41);
+      expect(k.modifiers, isEmpty);
+    });
+
+    test('CharKey value equality', () {
+      const a = CharKey(rune: 0x61, modifiers: {Modifier.ctrl});
+      const b = CharKey(rune: 0x61, modifiers: {Modifier.ctrl});
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+    });
+
+    test('SpecialKey for arrows', () {
+      const k = SpecialKey(code: SpecialKeyCode.up, modifiers: {});
+      expect(k.code, SpecialKeyCode.up);
+    });
+
+    test('SpecialKey value equality with modifier set', () {
+      const a = SpecialKey(code: SpecialKeyCode.left, modifiers: {Modifier.shift});
+      const b = SpecialKey(code: SpecialKeyCode.left, modifiers: {Modifier.shift});
+      expect(a, equals(b));
+    });
+
+    test('different special keys are unequal', () {
+      const a = SpecialKey(code: SpecialKeyCode.up, modifiers: {});
+      const b = SpecialKey(code: SpecialKeyCode.down, modifiers: {});
+      expect(a, isNot(equals(b)));
+    });
+  });
+}

--- a/app/test/tui/input_test.dart
+++ b/app/test/tui/input_test.dart
@@ -22,8 +22,10 @@ void main() {
     });
 
     test('SpecialKey value equality with modifier set', () {
-      const a = SpecialKey(code: SpecialKeyCode.left, modifiers: {Modifier.shift});
-      const b = SpecialKey(code: SpecialKeyCode.left, modifiers: {Modifier.shift});
+      const a =
+          SpecialKey(code: SpecialKeyCode.left, modifiers: {Modifier.shift});
+      const b =
+          SpecialKey(code: SpecialKeyCode.left, modifiers: {Modifier.shift});
       expect(a, equals(b));
     });
 
@@ -41,7 +43,9 @@ void main() {
     }
 
     test('ASCII printable becomes CharKey', () async {
-      final events = await parse([[0x41, 0x42]]); // 'A', 'B'
+      final events = await parse([
+        [0x41, 0x42]
+      ]); // 'A', 'B'
       expect(events, [
         const CharKey(rune: 0x41, modifiers: {}),
         const CharKey(rune: 0x42, modifiers: {}),
@@ -49,7 +53,9 @@ void main() {
     });
 
     test('ctrl-A through ctrl-Z become CharKey with ctrl modifier', () async {
-      final events = await parse([[0x01, 0x03, 0x1a]]); // ctrl-A, ctrl-C, ctrl-Z
+      final events = await parse([
+        [0x01, 0x03, 0x1a]
+      ]); // ctrl-A, ctrl-C, ctrl-Z
       expect(events.length, 3);
       expect(events[0], CharKey(rune: 0x61, modifiers: {Modifier.ctrl})); // 'a'
       expect(events[1], CharKey(rune: 0x63, modifiers: {Modifier.ctrl})); // 'c'
@@ -57,7 +63,9 @@ void main() {
     });
 
     test('enter, tab, backspace', () async {
-      final events = await parse([[0x0d, 0x09, 0x7f]]);
+      final events = await parse([
+        [0x0d, 0x09, 0x7f]
+      ]);
       expect(events, [
         const SpecialKey(code: SpecialKeyCode.enter, modifiers: {}),
         const SpecialKey(code: SpecialKeyCode.tab, modifiers: {}),
@@ -66,7 +74,9 @@ void main() {
     });
 
     test('newline (LF) is also enter', () async {
-      final events = await parse([[0x0a]]);
+      final events = await parse([
+        [0x0a]
+      ]);
       expect(events, [
         const SpecialKey(code: SpecialKeyCode.enter, modifiers: {}),
       ]);
@@ -89,21 +99,27 @@ void main() {
     });
 
     test('SS3 arrows (ESC O A)', () async {
-      final events = await parse([[0x1b, 0x4f, 0x41]]); // ESC O A
+      final events = await parse([
+        [0x1b, 0x4f, 0x41]
+      ]); // ESC O A
       expect(events, [
         const SpecialKey(code: SpecialKeyCode.up, modifiers: {}),
       ]);
     });
 
     test('CSI with modifier (ctrl-up = ESC [1;5A)', () async {
-      final events = await parse([[0x1b, 0x5b, 0x31, 0x3b, 0x35, 0x41]]);
+      final events = await parse([
+        [0x1b, 0x5b, 0x31, 0x3b, 0x35, 0x41]
+      ]);
       expect(events, [
         const SpecialKey(code: SpecialKeyCode.up, modifiers: {Modifier.ctrl}),
       ]);
     });
 
     test('CSI shift-arrow (ESC [1;2A)', () async {
-      final events = await parse([[0x1b, 0x5b, 0x31, 0x3b, 0x32, 0x41]]);
+      final events = await parse([
+        [0x1b, 0x5b, 0x31, 0x3b, 0x32, 0x41]
+      ]);
       expect(events, [
         const SpecialKey(code: SpecialKeyCode.up, modifiers: {Modifier.shift}),
       ]);
@@ -126,7 +142,9 @@ void main() {
 
     test('bare escape (no follow-up bytes) emits escape', () async {
       // A single chunk containing ONLY ESC, followed by stream end.
-      final events = await parse([[0x1b]]);
+      final events = await parse([
+        [0x1b]
+      ]);
       expect(events, [
         const SpecialKey(code: SpecialKeyCode.escape, modifiers: {}),
       ]);
@@ -134,21 +152,30 @@ void main() {
 
     test('UTF-8 multi-byte rune', () async {
       // U+00E9 (é) in UTF-8 = C3 A9
-      final events = await parse([[0xc3, 0xa9]]);
+      final events = await parse([
+        [0xc3, 0xa9]
+      ]);
       expect(events, [
         const CharKey(rune: 0x00e9, modifiers: {}),
       ]);
     });
 
     test('UTF-8 split across chunks', () async {
-      final events = await parse([[0xc3], [0xa9]]);
+      final events = await parse([
+        [0xc3],
+        [0xa9]
+      ]);
       expect(events, [
         const CharKey(rune: 0x00e9, modifiers: {}),
       ]);
     });
 
     test('CSI split across chunks', () async {
-      final events = await parse([[0x1b], [0x5b], [0x41]]);
+      final events = await parse([
+        [0x1b],
+        [0x5b],
+        [0x41]
+      ]);
       expect(events, [
         const SpecialKey(code: SpecialKeyCode.up, modifiers: {}),
       ]);
@@ -157,16 +184,21 @@ void main() {
     test('incomplete SS3 at stream close drains both ESC and O', () async {
       // Only ESC and O delivered; stream then closes. Implementation must drain
       // both bytes and emit escape — NOT escape + CharKey('O').
-      final events = await parse([[0x1b, 0x4f]]);
+      final events = await parse([
+        [0x1b, 0x4f]
+      ]);
       expect(events, [
         const SpecialKey(code: SpecialKeyCode.escape, modifiers: {}),
       ]);
     });
 
-    test('incomplete UTF-8 at stream close yields replacement character', () async {
+    test('incomplete UTF-8 at stream close yields replacement character',
+        () async {
       // A 2-byte UTF-8 leading byte arrives but the second byte never does.
       // Stream closes. Implementation must emit U+FFFD.
-      final events = await parse([[0xc3]]);
+      final events = await parse([
+        [0xc3]
+      ]);
       expect(events, [
         const CharKey(rune: 0xFFFD, modifiers: {}),
       ]);

--- a/app/test/tui/input_test.dart
+++ b/app/test/tui/input_test.dart
@@ -153,5 +153,23 @@ void main() {
         const SpecialKey(code: SpecialKeyCode.up, modifiers: {}),
       ]);
     });
+
+    test('incomplete SS3 at stream close drains both ESC and O', () async {
+      // Only ESC and O delivered; stream then closes. Implementation must drain
+      // both bytes and emit escape — NOT escape + CharKey('O').
+      final events = await parse([[0x1b, 0x4f]]);
+      expect(events, [
+        const SpecialKey(code: SpecialKeyCode.escape, modifiers: {}),
+      ]);
+    });
+
+    test('incomplete UTF-8 at stream close yields replacement character', () async {
+      // A 2-byte UTF-8 leading byte arrives but the second byte never does.
+      // Stream closes. Implementation must emit U+FFFD.
+      final events = await parse([[0xc3]]);
+      expect(events, [
+        const CharKey(rune: 0xFFFD, modifiers: {}),
+      ]);
+    });
   });
 }

--- a/docs/superpowers/plans/2026-05-14-tui-step1-engine.md
+++ b/docs/superpowers/plans/2026-05-14-tui-step1-engine.md
@@ -1,0 +1,1838 @@
+# TUI Step 1 — Engine Foundation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the engine layer of a Flutter-style TUI framework: alt-screen lifecycle, CellBuffer + diff-to-ANSI, raw-stdin key parsing, resize handling, and crash-safe terminal restore. Deliverable is a working demo (`step1_demo.dart`) that draws a centered status box, updates on key/resize, and exits cleanly.
+
+**Architecture:** Five small Dart files under `app/lib/src/tui/`, each with one responsibility. `Cell` and `CellBuffer` are pure data; `ansi.dart` encodes buffer diffs as escape sequences; `input.dart` parses raw stdin bytes into `KeyEvent`s; `terminal.dart` owns lifecycle and signal handling. Zero pub dependencies — `dart:io` and `dart:async` only.
+
+**Tech Stack:** Dart 3.6+, `package:test` (already a dev dep of `flutterware_app`).
+
+**Spec:** [`docs/superpowers/specs/2026-05-14-tui-step1-engine-design.md`](../specs/2026-05-14-tui-step1-engine-design.md)
+
+---
+
+## File Structure
+
+```
+app/lib/src/tui/
+  cell.dart            # Cell, Color, TextStyle constants
+  buffer.dart          # CellBuffer (immutable size, mutable contents)
+  ansi.dart            # ANSI constants + encodeDiff(front, back)
+  input.dart           # KeyEvent sealed types + parseKeyEvents()
+  terminal.dart        # Terminal.run lifecycle
+  tui.dart             # barrel re-export
+  example/
+    step1_demo.dart    # the demo program
+
+app/test/tui/
+  cell_test.dart
+  buffer_test.dart
+  ansi_test.dart
+  input_test.dart
+```
+
+**Run commands from `app/` directory** (the package root). The plan assumes `cd app` was done once at the start of execution.
+
+---
+
+## Task 1: `Cell`, `Color`, `TextStyle`
+
+**Files:**
+- Create: `app/lib/src/tui/cell.dart`
+- Create: `app/test/tui/cell_test.dart`
+
+- [ ] **Step 1.1: Write the failing test**
+
+`app/test/tui/cell_test.dart`:
+
+```dart
+import 'package:flutterware_app/src/tui/cell.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Color', () {
+    test('named ANSI colors have stable indices', () {
+      expect(Color.red.ansiIndex, 1);
+      expect(Color.brightWhite.ansiIndex, 15);
+    });
+
+    test('rgb colors carry rgb values', () {
+      final c = Color.rgb(10, 20, 30);
+      expect(c.r, 10);
+      expect(c.g, 20);
+      expect(c.b, 30);
+    });
+
+    test('default colors are distinct from named black', () {
+      expect(Color.defaultFg, isNot(equals(Color.black)));
+      expect(Color.defaultBg, isNot(equals(Color.black)));
+    });
+
+    test('value equality', () {
+      expect(Color.rgb(1, 2, 3), equals(Color.rgb(1, 2, 3)));
+      expect(Color.red, equals(Color.red));
+      expect(Color.red, isNot(equals(Color.blue)));
+    });
+  });
+
+  group('Cell', () {
+    test('empty cell is a space with default colors', () {
+      expect(Cell.empty.rune, 0x20);
+      expect(Cell.empty.fg, Color.defaultFg);
+      expect(Cell.empty.bg, Color.defaultBg);
+      expect(Cell.empty.style, 0);
+      expect(Cell.empty.width, 1);
+    });
+
+    test('value equality', () {
+      final a = Cell(rune: 0x41, fg: Color.red, bg: Color.defaultBg, style: TextStyle.bold);
+      final b = Cell(rune: 0x41, fg: Color.red, bg: Color.defaultBg, style: TextStyle.bold);
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+    });
+
+    test('TextStyle bitfield combines', () {
+      final combined = TextStyle.bold | TextStyle.underline;
+      expect(combined & TextStyle.bold, isNot(0));
+      expect(combined & TextStyle.underline, isNot(0));
+      expect(combined & TextStyle.italic, 0);
+    });
+  });
+}
+```
+
+- [ ] **Step 1.2: Run test to verify it fails**
+
+```bash
+dart test test/tui/cell_test.dart
+```
+
+Expected: compilation error — `cell.dart` does not exist.
+
+- [ ] **Step 1.3: Write the implementation**
+
+`app/lib/src/tui/cell.dart`:
+
+```dart
+/// Text style bitfield. Combine with bitwise OR.
+class TextStyle {
+  static const int bold = 1 << 0;
+  static const int dim = 1 << 1;
+  static const int italic = 1 << 2;
+  static const int underline = 1 << 3;
+  static const int reverse = 1 << 4;
+
+  // not instantiable
+  TextStyle._();
+}
+
+/// Color in one of three encodings: terminal default, ANSI named (16-color),
+/// or 24-bit RGB. Equality is structural.
+class Color {
+  final int _kind; // 0 = default, 1 = ansi, 2 = rgb
+  final int ansiIndex; // valid when _kind == 1; 0..15
+  final int r, g, b; // valid when _kind == 2
+
+  const Color._(this._kind, this.ansiIndex, this.r, this.g, this.b);
+
+  static const Color defaultFg = Color._(0, 0, 0, 0, 0);
+  static const Color defaultBg = Color._(0, 1, 0, 0, 0); // sentinel distinct from defaultFg
+
+  // 16 ANSI named colors (indices match the ANSI SGR convention).
+  static const Color black = Color._(1, 0, 0, 0, 0);
+  static const Color red = Color._(1, 1, 0, 0, 0);
+  static const Color green = Color._(1, 2, 0, 0, 0);
+  static const Color yellow = Color._(1, 3, 0, 0, 0);
+  static const Color blue = Color._(1, 4, 0, 0, 0);
+  static const Color magenta = Color._(1, 5, 0, 0, 0);
+  static const Color cyan = Color._(1, 6, 0, 0, 0);
+  static const Color white = Color._(1, 7, 0, 0, 0);
+  static const Color brightBlack = Color._(1, 8, 0, 0, 0);
+  static const Color brightRed = Color._(1, 9, 0, 0, 0);
+  static const Color brightGreen = Color._(1, 10, 0, 0, 0);
+  static const Color brightYellow = Color._(1, 11, 0, 0, 0);
+  static const Color brightBlue = Color._(1, 12, 0, 0, 0);
+  static const Color brightMagenta = Color._(1, 13, 0, 0, 0);
+  static const Color brightCyan = Color._(1, 14, 0, 0, 0);
+  static const Color brightWhite = Color._(1, 15, 0, 0, 0);
+
+  const factory Color.rgb(int r, int g, int b) = Color._rgb;
+  const Color._rgb(this.r, this.g, this.b) : _kind = 2, ansiIndex = 0;
+
+  bool get isDefault => _kind == 0;
+  bool get isAnsi => _kind == 1;
+  bool get isRgb => _kind == 2;
+  bool get isDefaultFg => _kind == 0 && ansiIndex == 0;
+  bool get isDefaultBg => _kind == 0 && ansiIndex == 1;
+
+  @override
+  bool operator ==(Object other) =>
+      other is Color &&
+      _kind == other._kind &&
+      ansiIndex == other.ansiIndex &&
+      r == other.r &&
+      g == other.g &&
+      b == other.b;
+
+  @override
+  int get hashCode => Object.hash(_kind, ansiIndex, r, g, b);
+}
+
+/// A single terminal cell. Immutable.
+class Cell {
+  final int rune;
+  final Color fg;
+  final Color bg;
+  final int style;
+  final int width; // 1 for stage 1; reserved for wide-char support later
+
+  const Cell({
+    required this.rune,
+    this.fg = Color.defaultFg,
+    this.bg = Color.defaultBg,
+    this.style = 0,
+    this.width = 1,
+  });
+
+  static const Cell empty = Cell(rune: 0x20);
+
+  @override
+  bool operator ==(Object other) =>
+      other is Cell &&
+      rune == other.rune &&
+      fg == other.fg &&
+      bg == other.bg &&
+      style == other.style &&
+      width == other.width;
+
+  @override
+  int get hashCode => Object.hash(rune, fg, bg, style, width);
+}
+```
+
+- [ ] **Step 1.4: Run test to verify it passes**
+
+```bash
+dart test test/tui/cell_test.dart
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 1.5: Commit**
+
+```bash
+git add app/lib/src/tui/cell.dart app/test/tui/cell_test.dart
+git commit -m "Add TUI Cell, Color, TextStyle value types"
+```
+
+---
+
+## Task 2: `CellBuffer`
+
+**Files:**
+- Create: `app/lib/src/tui/buffer.dart`
+- Create: `app/test/tui/buffer_test.dart`
+
+- [ ] **Step 2.1: Write the failing test**
+
+`app/test/tui/buffer_test.dart`:
+
+```dart
+import 'package:flutterware_app/src/tui/buffer.dart';
+import 'package:flutterware_app/src/tui/cell.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('CellBuffer', () {
+    test('new buffer is filled with Cell.empty', () {
+      final b = CellBuffer(3, 4);
+      expect(b.rows, 3);
+      expect(b.cols, 4);
+      for (var r = 0; r < 3; r++) {
+        for (var c = 0; c < 4; c++) {
+          expect(b.get(r, c), Cell.empty);
+        }
+      }
+    });
+
+    test('set and get round-trip', () {
+      final b = CellBuffer(2, 2);
+      final cell = Cell(rune: 0x41, fg: Color.red);
+      b.set(0, 1, cell);
+      expect(b.get(0, 1), cell);
+      expect(b.get(0, 0), Cell.empty);
+    });
+
+    test('writeAt writes a string left-to-right', () {
+      final b = CellBuffer(1, 10);
+      b.writeAt(0, 2, 'Hi');
+      expect(b.get(0, 0), Cell.empty);
+      expect(b.get(0, 1), Cell.empty);
+      expect(b.get(0, 2).rune, 0x48); // H
+      expect(b.get(0, 3).rune, 0x69); // i
+      expect(b.get(0, 4), Cell.empty);
+    });
+
+    test('writeAt applies fg/bg/style to all cells', () {
+      final b = CellBuffer(1, 5);
+      b.writeAt(0, 0, 'ab', fg: Color.red, style: TextStyle.bold);
+      expect(b.get(0, 0).fg, Color.red);
+      expect(b.get(0, 0).style, TextStyle.bold);
+      expect(b.get(0, 1).fg, Color.red);
+    });
+
+    test('writeAt clips silently past right edge', () {
+      final b = CellBuffer(1, 3);
+      b.writeAt(0, 1, 'hello');
+      expect(b.get(0, 0), Cell.empty);
+      expect(b.get(0, 1).rune, 0x68); // h
+      expect(b.get(0, 2).rune, 0x65); // e
+      // 'llo' silently dropped
+    });
+
+    test('writeAt with negative col is partially clipped', () {
+      final b = CellBuffer(1, 4);
+      b.writeAt(0, -2, 'hello');
+      // h,e at -2,-1 clipped; l,l,o at 0,1,2
+      expect(b.get(0, 0).rune, 0x6c); // l
+      expect(b.get(0, 1).rune, 0x6c); // l
+      expect(b.get(0, 2).rune, 0x6f); // o
+      expect(b.get(0, 3), Cell.empty);
+    });
+
+    test('set out of bounds is a no-op', () {
+      final b = CellBuffer(2, 2);
+      // Must not throw.
+      b.set(-1, 0, Cell(rune: 0x41));
+      b.set(0, 5, Cell(rune: 0x41));
+      b.set(10, 10, Cell(rune: 0x41));
+      expect(b.get(0, 0), Cell.empty);
+    });
+
+    test('get out of bounds returns Cell.empty', () {
+      final b = CellBuffer(2, 2);
+      expect(b.get(-1, 0), Cell.empty);
+      expect(b.get(0, 5), Cell.empty);
+    });
+
+    test('fill replaces every cell', () {
+      final b = CellBuffer(2, 2);
+      final c = Cell(rune: 0x41, fg: Color.blue);
+      b.fill(c);
+      expect(b.get(0, 0), c);
+      expect(b.get(1, 1), c);
+    });
+
+    test('fillRect fills only the given region', () {
+      final b = CellBuffer(4, 4);
+      final c = Cell(rune: 0x23); // #
+      b.fillRect(1, 1, 2, 2, c);
+      expect(b.get(0, 0), Cell.empty);
+      expect(b.get(1, 1), c);
+      expect(b.get(2, 2), c);
+      expect(b.get(3, 3), Cell.empty);
+    });
+
+    test('fillRect clips to buffer bounds', () {
+      final b = CellBuffer(2, 2);
+      final c = Cell(rune: 0x23);
+      b.fillRect(-1, -1, 5, 5, c); // overflows on all sides
+      // Every in-bounds cell should be c.
+      for (var r = 0; r < 2; r++) {
+        for (var col = 0; col < 2; col++) {
+          expect(b.get(r, col), c);
+        }
+      }
+    });
+
+    test('copyFrom copies all cells', () {
+      final a = CellBuffer(2, 2);
+      a.set(0, 0, Cell(rune: 0x41));
+      a.set(1, 1, Cell(rune: 0x42));
+      final b = CellBuffer(2, 2);
+      b.copyFrom(a);
+      expect(b.get(0, 0).rune, 0x41);
+      expect(b.get(1, 1).rune, 0x42);
+    });
+
+    test('copyFrom throws on size mismatch', () {
+      final a = CellBuffer(2, 2);
+      final b = CellBuffer(3, 3);
+      expect(() => b.copyFrom(a), throwsA(isA<ArgumentError>()));
+    });
+
+    test('inBounds', () {
+      final b = CellBuffer(2, 3);
+      expect(b.inBounds(0, 0), isTrue);
+      expect(b.inBounds(1, 2), isTrue);
+      expect(b.inBounds(-1, 0), isFalse);
+      expect(b.inBounds(0, 3), isFalse);
+      expect(b.inBounds(2, 0), isFalse);
+    });
+  });
+}
+```
+
+- [ ] **Step 2.2: Run test to verify it fails**
+
+```bash
+dart test test/tui/buffer_test.dart
+```
+
+Expected: compilation error — `buffer.dart` does not exist.
+
+- [ ] **Step 2.3: Write the implementation**
+
+`app/lib/src/tui/buffer.dart`:
+
+```dart
+import 'cell.dart';
+
+/// A grid of cells, addressed by (row, col). Size is fixed at construction.
+/// All mutation methods silently clip to bounds.
+class CellBuffer {
+  final int rows;
+  final int cols;
+  final List<Cell> _cells;
+
+  CellBuffer(this.rows, this.cols)
+      : _cells = List<Cell>.filled(rows * cols, Cell.empty, growable: false);
+
+  bool inBounds(int row, int col) =>
+      row >= 0 && row < rows && col >= 0 && col < cols;
+
+  Cell get(int row, int col) {
+    if (!inBounds(row, col)) return Cell.empty;
+    return _cells[row * cols + col];
+  }
+
+  void set(int row, int col, Cell cell) {
+    if (!inBounds(row, col)) return;
+    _cells[row * cols + col] = cell;
+  }
+
+  void writeAt(
+    int row,
+    int col,
+    String text, {
+    Color fg = Color.defaultFg,
+    Color bg = Color.defaultBg,
+    int style = 0,
+  }) {
+    var c = col;
+    for (final rune in text.runes) {
+      if (inBounds(row, c)) {
+        _cells[row * cols + c] = Cell(rune: rune, fg: fg, bg: bg, style: style);
+      }
+      c++;
+    }
+  }
+
+  void fill(Cell cell) {
+    for (var i = 0; i < _cells.length; i++) {
+      _cells[i] = cell;
+    }
+  }
+
+  void fillRect(int row, int col, int rowCount, int colCount, Cell cell) {
+    final r0 = row.clamp(0, rows);
+    final r1 = (row + rowCount).clamp(0, rows);
+    final c0 = col.clamp(0, cols);
+    final c1 = (col + colCount).clamp(0, cols);
+    for (var r = r0; r < r1; r++) {
+      for (var c = c0; c < c1; c++) {
+        _cells[r * cols + c] = cell;
+      }
+    }
+  }
+
+  void clear() => fill(Cell.empty);
+
+  void copyFrom(CellBuffer other) {
+    if (other.rows != rows || other.cols != cols) {
+      throw ArgumentError('size mismatch: $rows×$cols vs ${other.rows}×${other.cols}');
+    }
+    for (var i = 0; i < _cells.length; i++) {
+      _cells[i] = other._cells[i];
+    }
+  }
+}
+```
+
+- [ ] **Step 2.4: Run test to verify it passes**
+
+```bash
+dart test test/tui/buffer_test.dart
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 2.5: Commit**
+
+```bash
+git add app/lib/src/tui/buffer.dart app/test/tui/buffer_test.dart
+git commit -m "Add TUI CellBuffer with clipping write/fill/copy"
+```
+
+---
+
+## Task 3: ANSI constants and color/style encoders
+
+This task covers the simple, deterministic parts of `ansi.dart`: escape sequence constants and the helpers that turn a `Color` / style int into SGR parameters. The diff encoder is a separate task because it warrants its own test suite.
+
+**Files:**
+- Create: `app/lib/src/tui/ansi.dart`
+- Create: `app/test/tui/ansi_test.dart`
+
+- [ ] **Step 3.1: Write the failing test**
+
+`app/test/tui/ansi_test.dart`:
+
+```dart
+import 'package:flutterware_app/src/tui/ansi.dart';
+import 'package:flutterware_app/src/tui/cell.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('ansi constants', () {
+    test('alt-screen sequences', () {
+      expect(Ansi.enterAltScreen, '\x1b[?1049h');
+      expect(Ansi.exitAltScreen, '\x1b[?1049l');
+    });
+
+    test('cursor visibility', () {
+      expect(Ansi.hideCursor, '\x1b[?25l');
+      expect(Ansi.showCursor, '\x1b[?25h');
+    });
+
+    test('moveTo is 1-indexed', () {
+      // ANSI cursor positioning is 1-indexed; our API takes 0-indexed.
+      expect(Ansi.moveTo(0, 0), '\x1b[1;1H');
+      expect(Ansi.moveTo(4, 9), '\x1b[5;10H');
+    });
+
+    test('clearScreen', () {
+      expect(Ansi.clearScreen, '\x1b[2J');
+    });
+
+    test('resetStyle', () {
+      expect(Ansi.resetStyle, '\x1b[0m');
+    });
+  });
+
+  group('sgrForeground', () {
+    test('default fg', () {
+      expect(Ansi.sgrForeground(Color.defaultFg), '39');
+    });
+
+    test('named ansi fg (0-7)', () {
+      expect(Ansi.sgrForeground(Color.red), '31');
+      expect(Ansi.sgrForeground(Color.white), '37');
+    });
+
+    test('bright named ansi fg (8-15)', () {
+      expect(Ansi.sgrForeground(Color.brightRed), '91');
+      expect(Ansi.sgrForeground(Color.brightWhite), '97');
+    });
+
+    test('rgb fg', () {
+      expect(Ansi.sgrForeground(Color.rgb(10, 20, 30)), '38;2;10;20;30');
+    });
+  });
+
+  group('sgrBackground', () {
+    test('default bg', () {
+      expect(Ansi.sgrBackground(Color.defaultBg), '49');
+    });
+
+    test('named ansi bg', () {
+      expect(Ansi.sgrBackground(Color.blue), '44');
+      expect(Ansi.sgrBackground(Color.brightCyan), '106');
+    });
+
+    test('rgb bg', () {
+      expect(Ansi.sgrBackground(Color.rgb(255, 0, 128)), '48;2;255;0;128');
+    });
+  });
+
+  group('sgrStyle', () {
+    test('no style', () {
+      expect(Ansi.sgrStyle(0), <String>[]);
+    });
+
+    test('bold', () {
+      expect(Ansi.sgrStyle(TextStyle.bold), ['1']);
+    });
+
+    test('combined', () {
+      final s = Ansi.sgrStyle(TextStyle.bold | TextStyle.underline | TextStyle.reverse);
+      expect(s, containsAll(['1', '4', '7']));
+      expect(s.length, 3);
+    });
+  });
+}
+```
+
+- [ ] **Step 3.2: Run test to verify it fails**
+
+```bash
+dart test test/tui/ansi_test.dart
+```
+
+Expected: compilation error — `ansi.dart` does not exist.
+
+- [ ] **Step 3.3: Write the implementation**
+
+`app/lib/src/tui/ansi.dart`:
+
+```dart
+import 'buffer.dart';
+import 'cell.dart';
+
+/// ANSI escape sequences used by the engine.
+///
+/// Naming convention: constants are static strings; functions build sequences
+/// from arguments. All cursor coordinates exposed by this module are 0-indexed
+/// (matching CellBuffer); the CSI conversion to 1-indexed happens here.
+class Ansi {
+  Ansi._();
+
+  static const String esc = '\x1b';
+  static const String csi = '\x1b[';
+
+  static const String enterAltScreen = '\x1b[?1049h';
+  static const String exitAltScreen = '\x1b[?1049l';
+  static const String hideCursor = '\x1b[?25l';
+  static const String showCursor = '\x1b[?25h';
+  static const String clearScreen = '\x1b[2J';
+  static const String resetStyle = '\x1b[0m';
+
+  /// 0-indexed row, col → CSI move sequence (1-indexed).
+  static String moveTo(int row, int col) => '$csi${row + 1};${col + 1}H';
+
+  /// SGR parameter for a foreground color. Returns the parameter string only
+  /// (e.g. `'31'` or `'38;2;10;20;30'`), without the CSI prefix or final `m`.
+  static String sgrForeground(Color c) {
+    if (c.isDefaultFg) return '39';
+    if (c.isAnsi) {
+      final i = c.ansiIndex;
+      return i < 8 ? '${30 + i}' : '${90 + (i - 8)}';
+    }
+    // rgb
+    return '38;2;${c.r};${c.g};${c.b}';
+  }
+
+  /// SGR parameter for a background color.
+  static String sgrBackground(Color c) {
+    if (c.isDefaultBg) return '49';
+    if (c.isAnsi) {
+      final i = c.ansiIndex;
+      return i < 8 ? '${40 + i}' : '${100 + (i - 8)}';
+    }
+    return '48;2;${c.r};${c.g};${c.b}';
+  }
+
+  /// SGR parameters for a style bitfield. Empty list if style == 0.
+  static List<String> sgrStyle(int style) {
+    final out = <String>[];
+    if (style & TextStyle.bold != 0) out.add('1');
+    if (style & TextStyle.dim != 0) out.add('2');
+    if (style & TextStyle.italic != 0) out.add('3');
+    if (style & TextStyle.underline != 0) out.add('4');
+    if (style & TextStyle.reverse != 0) out.add('7');
+    return out;
+  }
+}
+
+/// Encode the difference between [front] (current screen state) and [back]
+/// (desired state) as a string of ANSI escape sequences. Returns an empty
+/// string if there are no changes.
+///
+/// Defined in a later task.
+String encodeDiff(CellBuffer front, CellBuffer back) {
+  throw UnimplementedError('see Task 4');
+}
+```
+
+- [ ] **Step 3.4: Run test to verify it passes**
+
+```bash
+dart test test/tui/ansi_test.dart
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 3.5: Commit**
+
+```bash
+git add app/lib/src/tui/ansi.dart app/test/tui/ansi_test.dart
+git commit -m "Add ANSI escape constants and SGR encoders"
+```
+
+---
+
+## Task 4: `encodeDiff`
+
+**Files:**
+- Modify: `app/lib/src/tui/ansi.dart` (replace `encodeDiff` stub)
+- Modify: `app/test/tui/ansi_test.dart` (add new test group)
+
+- [ ] **Step 4.1: Add failing tests for `encodeDiff`**
+
+Append to `app/test/tui/ansi_test.dart` (inside `void main()`):
+
+```dart
+  group('encodeDiff', () {
+    test('no changes produces empty string', () {
+      final front = CellBuffer(2, 2);
+      final back = CellBuffer(2, 2);
+      expect(encodeDiff(front, back), '');
+    });
+
+    test('single cell change emits move + SGR + rune', () {
+      final front = CellBuffer(2, 4);
+      final back = CellBuffer(2, 4);
+      back.set(1, 2, Cell(rune: 0x41 /* A */));
+      final out = encodeDiff(front, back);
+      // Expected: move to (1,2) in 0-indexed = CSI 2;3H, default colors,
+      // then "A".
+      expect(out, contains('\x1b[2;3H'));
+      expect(out, contains('A'));
+    });
+
+    test('two adjacent changes in same row skip second move', () {
+      final front = CellBuffer(1, 5);
+      final back = CellBuffer(1, 5);
+      back.set(0, 1, Cell(rune: 0x41));
+      back.set(0, 2, Cell(rune: 0x42));
+      final out = encodeDiff(front, back);
+      // First move to (0,1) = CSI 1;2H. After writing 'A', the cursor is at
+      // (0,2), so the next 'B' should follow without another CSI move.
+      final moves = '\x1b['.allMatches(out).length;
+      // We expect: one CSI for move + at most SGR transitions. With both
+      // cells default colored from empty state, SGR may or may not appear.
+      // The number of move sequences (matching CSI <num>;<num>H) must be 1.
+      final moveRegex = RegExp(r'\x1b\[\d+;\d+H');
+      expect(moveRegex.allMatches(out).length, 1);
+      expect(out, contains('AB'));
+    });
+
+    test('change at start of new row emits a move', () {
+      final front = CellBuffer(2, 3);
+      final back = CellBuffer(2, 3);
+      back.set(0, 0, Cell(rune: 0x41));
+      back.set(1, 0, Cell(rune: 0x42));
+      final out = encodeDiff(front, back);
+      final moveRegex = RegExp(r'\x1b\[\d+;\d+H');
+      expect(moveRegex.allMatches(out).length, 2);
+    });
+
+    test('fg change emits SGR', () {
+      final front = CellBuffer(1, 2);
+      final back = CellBuffer(1, 2);
+      back.set(0, 0, Cell(rune: 0x41, fg: Color.red));
+      final out = encodeDiff(front, back);
+      expect(out, contains('31'));
+      expect(out, contains('A'));
+    });
+
+    test('consecutive cells with same color do not re-emit SGR', () {
+      final front = CellBuffer(1, 3);
+      final back = CellBuffer(1, 3);
+      back.set(0, 0, Cell(rune: 0x41, fg: Color.red));
+      back.set(0, 1, Cell(rune: 0x42, fg: Color.red));
+      back.set(0, 2, Cell(rune: 0x43, fg: Color.red));
+      final out = encodeDiff(front, back);
+      // The red SGR (parameter "31") should appear exactly once.
+      final redCount = '31'.allMatches(out).length;
+      expect(redCount, 1);
+      expect(out, contains('ABC'));
+    });
+
+    test('color reset emits default fg', () {
+      // front: red 'A'; back: default 'A' (rune unchanged but color is)
+      final front = CellBuffer(1, 1);
+      front.set(0, 0, Cell(rune: 0x41, fg: Color.red));
+      final back = CellBuffer(1, 1);
+      back.set(0, 0, Cell(rune: 0x41 /* default */));
+      // The cell is "different" (fg differs), so we emit something.
+      final out = encodeDiff(front, back);
+      expect(out, contains('39')); // default fg
+      expect(out, contains('A'));
+    });
+
+    test('size mismatch throws', () {
+      final front = CellBuffer(2, 2);
+      final back = CellBuffer(3, 3);
+      expect(() => encodeDiff(front, back), throwsA(isA<ArgumentError>()));
+    });
+  });
+}
+```
+
+Also add the import at the top of `ansi_test.dart` if not already present:
+
+```dart
+import 'package:flutterware_app/src/tui/buffer.dart';
+```
+
+- [ ] **Step 4.2: Run tests to verify they fail**
+
+```bash
+dart test test/tui/ansi_test.dart
+```
+
+Expected: the new `encodeDiff` group fails (stub throws `UnimplementedError`).
+
+- [ ] **Step 4.3: Implement `encodeDiff`**
+
+Replace the `encodeDiff` stub at the bottom of `app/lib/src/tui/ansi.dart`:
+
+```dart
+/// Encode the difference between [front] (current screen state) and [back]
+/// (desired state) as a string of ANSI escape sequences.
+///
+/// Optimizations:
+/// - Unchanged cells are skipped.
+/// - When the next changed cell is the immediate horizontal neighbor of the
+///   previous one, the cursor move is omitted (the cursor advances naturally
+///   after a character write).
+/// - Foreground, background, and style SGR are re-emitted only when they
+///   change between successive printed cells.
+String encodeDiff(CellBuffer front, CellBuffer back) {
+  if (front.rows != back.rows || front.cols != back.cols) {
+    throw ArgumentError(
+        'size mismatch: ${front.rows}×${front.cols} vs ${back.rows}×${back.cols}');
+  }
+
+  final buf = StringBuffer();
+
+  // Track cursor position. -1 means "unknown / must emit move before next write".
+  int cursorRow = -1;
+  int cursorCol = -1;
+
+  // Track the last SGR state we wrote. null means "unknown".
+  Color? lastFg;
+  Color? lastBg;
+  int? lastStyle;
+
+  for (var r = 0; r < back.rows; r++) {
+    for (var c = 0; c < back.cols; c++) {
+      final f = front.get(r, c);
+      final b = back.get(r, c);
+      if (f == b) continue;
+
+      // Emit a cursor move if we are not already at this position.
+      if (cursorRow != r || cursorCol != c) {
+        buf.write(Ansi.moveTo(r, c));
+      }
+
+      // Emit SGR transitions only for what changed.
+      final params = <String>[];
+      if (lastFg == null || lastFg != b.fg) {
+        params.add(Ansi.sgrForeground(b.fg));
+      }
+      if (lastBg == null || lastBg != b.bg) {
+        params.add(Ansi.sgrBackground(b.bg));
+      }
+      if (lastStyle == null || lastStyle != b.style) {
+        // Style transitions are simplest when we reset and re-apply, otherwise
+        // we'd need to track which bits to turn off.
+        if (lastStyle != null && lastStyle != 0) {
+          params.insert(0, '0');
+          // After reset, fg/bg also reset — re-emit them.
+          if (!params.contains(Ansi.sgrForeground(b.fg))) {
+            params.add(Ansi.sgrForeground(b.fg));
+          }
+          if (!params.contains(Ansi.sgrBackground(b.bg))) {
+            params.add(Ansi.sgrBackground(b.bg));
+          }
+        }
+        params.addAll(Ansi.sgrStyle(b.style));
+      }
+      if (params.isNotEmpty) {
+        buf.write('${Ansi.csi}${params.join(';')}m');
+      }
+
+      buf.writeCharCode(b.rune);
+
+      lastFg = b.fg;
+      lastBg = b.bg;
+      lastStyle = b.style;
+      cursorRow = r;
+      cursorCol = c + 1; // cursor advances after a char write
+    }
+  }
+
+  return buf.toString();
+}
+```
+
+- [ ] **Step 4.4: Run tests to verify they pass**
+
+```bash
+dart test test/tui/ansi_test.dart
+```
+
+Expected: all tests pass, including the new `encodeDiff` group.
+
+- [ ] **Step 4.5: Commit**
+
+```bash
+git add app/lib/src/tui/ansi.dart app/test/tui/ansi_test.dart
+git commit -m "Implement encodeDiff with cursor and SGR coalescing"
+```
+
+---
+
+## Task 5: `KeyEvent` types
+
+This task defines the sealed `KeyEvent` hierarchy and supporting enums. The parser comes in Task 6.
+
+**Files:**
+- Create: `app/lib/src/tui/input.dart`
+- Create: `app/test/tui/input_test.dart`
+
+- [ ] **Step 5.1: Write the failing test**
+
+`app/test/tui/input_test.dart`:
+
+```dart
+import 'package:flutterware_app/src/tui/input.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('KeyEvent types', () {
+    test('CharKey holds rune and modifiers', () {
+      const k = CharKey(rune: 0x41, modifiers: {});
+      expect(k.rune, 0x41);
+      expect(k.modifiers, isEmpty);
+    });
+
+    test('CharKey value equality', () {
+      const a = CharKey(rune: 0x61, modifiers: {Modifier.ctrl});
+      const b = CharKey(rune: 0x61, modifiers: {Modifier.ctrl});
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+    });
+
+    test('SpecialKey for arrows', () {
+      const k = SpecialKey(code: SpecialKeyCode.up, modifiers: {});
+      expect(k.code, SpecialKeyCode.up);
+    });
+
+    test('SpecialKey value equality with modifier set', () {
+      const a = SpecialKey(code: SpecialKeyCode.left, modifiers: {Modifier.shift});
+      const b = SpecialKey(code: SpecialKeyCode.left, modifiers: {Modifier.shift});
+      expect(a, equals(b));
+    });
+
+    test('different special keys are unequal', () {
+      const a = SpecialKey(code: SpecialKeyCode.up, modifiers: {});
+      const b = SpecialKey(code: SpecialKeyCode.down, modifiers: {});
+      expect(a, isNot(equals(b)));
+    });
+  });
+}
+```
+
+- [ ] **Step 5.2: Run test to verify it fails**
+
+```bash
+dart test test/tui/input_test.dart
+```
+
+Expected: compilation error — `input.dart` does not exist.
+
+- [ ] **Step 5.3: Write the implementation**
+
+`app/lib/src/tui/input.dart`:
+
+```dart
+import 'dart:async';
+import 'dart:collection';
+
+enum Modifier { shift, ctrl, alt }
+
+enum SpecialKeyCode {
+  up,
+  down,
+  left,
+  right,
+  enter,
+  tab,
+  backspace,
+  escape,
+  home,
+  end,
+  pageUp,
+  pageDown,
+  delete,
+  insert,
+  f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12,
+}
+
+sealed class KeyEvent {
+  final Set<Modifier> modifiers;
+  const KeyEvent(this.modifiers);
+}
+
+class CharKey extends KeyEvent {
+  final int rune;
+  const CharKey({required this.rune, required Set<Modifier> modifiers})
+      : super(modifiers);
+
+  @override
+  bool operator ==(Object other) =>
+      other is CharKey &&
+      other.rune == rune &&
+      _setEq(other.modifiers, modifiers);
+
+  @override
+  int get hashCode => Object.hash(rune, _setHash(modifiers));
+
+  @override
+  String toString() => 'CharKey(0x${rune.toRadixString(16)}, $modifiers)';
+}
+
+class SpecialKey extends KeyEvent {
+  final SpecialKeyCode code;
+  const SpecialKey({required this.code, required Set<Modifier> modifiers})
+      : super(modifiers);
+
+  @override
+  bool operator ==(Object other) =>
+      other is SpecialKey &&
+      other.code == code &&
+      _setEq(other.modifiers, modifiers);
+
+  @override
+  int get hashCode => Object.hash(code, _setHash(modifiers));
+
+  @override
+  String toString() => 'SpecialKey($code, $modifiers)';
+}
+
+bool _setEq(Set a, Set b) {
+  if (a.length != b.length) return false;
+  for (final x in a) {
+    if (!b.contains(x)) return false;
+  }
+  return true;
+}
+
+int _setHash(Set s) {
+  var h = 0;
+  for (final x in s) {
+    h ^= x.hashCode;
+  }
+  return h;
+}
+
+/// Defined in Task 6.
+Stream<KeyEvent> parseKeyEvents(Stream<List<int>> bytes) {
+  throw UnimplementedError('see Task 6');
+}
+```
+
+- [ ] **Step 5.4: Run test to verify it passes**
+
+```bash
+dart test test/tui/input_test.dart
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5.5: Commit**
+
+```bash
+git add app/lib/src/tui/input.dart app/test/tui/input_test.dart
+git commit -m "Add KeyEvent sealed types and Modifier enum"
+```
+
+---
+
+## Task 6: `parseKeyEvents`
+
+**Files:**
+- Modify: `app/lib/src/tui/input.dart` (replace `parseKeyEvents` stub)
+- Modify: `app/test/tui/input_test.dart` (add `parseKeyEvents` group)
+
+- [ ] **Step 6.1: Add failing tests for the parser**
+
+Append to `app/test/tui/input_test.dart` (inside `void main()`):
+
+```dart
+  group('parseKeyEvents', () {
+    Future<List<KeyEvent>> parse(List<List<int>> chunks) async {
+      final stream = Stream<List<int>>.fromIterable(chunks);
+      return parseKeyEvents(stream).toList();
+    }
+
+    test('ASCII printable becomes CharKey', () async {
+      final events = await parse([[0x41, 0x42]]); // 'A', 'B'
+      expect(events, [
+        const CharKey(rune: 0x41, modifiers: {}),
+        const CharKey(rune: 0x42, modifiers: {}),
+      ]);
+    });
+
+    test('ctrl-A through ctrl-Z become CharKey with ctrl modifier', () async {
+      final events = await parse([[0x01, 0x03, 0x1a]]); // ctrl-A, ctrl-C, ctrl-Z
+      expect(events.length, 3);
+      expect(events[0], CharKey(rune: 0x61, modifiers: {Modifier.ctrl})); // 'a'
+      expect(events[1], CharKey(rune: 0x63, modifiers: {Modifier.ctrl})); // 'c'
+      expect(events[2], CharKey(rune: 0x7a, modifiers: {Modifier.ctrl})); // 'z'
+    });
+
+    test('enter, tab, backspace', () async {
+      final events = await parse([[0x0d, 0x09, 0x7f]]);
+      expect(events, [
+        const SpecialKey(code: SpecialKeyCode.enter, modifiers: {}),
+        const SpecialKey(code: SpecialKeyCode.tab, modifiers: {}),
+        const SpecialKey(code: SpecialKeyCode.backspace, modifiers: {}),
+      ]);
+    });
+
+    test('newline (LF) is also enter', () async {
+      final events = await parse([[0x0a]]);
+      expect(events, [
+        const SpecialKey(code: SpecialKeyCode.enter, modifiers: {}),
+      ]);
+    });
+
+    test('CSI arrows', () async {
+      // ESC [ A/B/C/D
+      final events = await parse([
+        [0x1b, 0x5b, 0x41],
+        [0x1b, 0x5b, 0x42],
+        [0x1b, 0x5b, 0x43],
+        [0x1b, 0x5b, 0x44],
+      ]);
+      expect(events, [
+        const SpecialKey(code: SpecialKeyCode.up, modifiers: {}),
+        const SpecialKey(code: SpecialKeyCode.down, modifiers: {}),
+        const SpecialKey(code: SpecialKeyCode.right, modifiers: {}),
+        const SpecialKey(code: SpecialKeyCode.left, modifiers: {}),
+      ]);
+    });
+
+    test('SS3 arrows (ESC O A)', () async {
+      final events = await parse([[0x1b, 0x4f, 0x41]]); // ESC O A
+      expect(events, [
+        const SpecialKey(code: SpecialKeyCode.up, modifiers: {}),
+      ]);
+    });
+
+    test('CSI with modifier (ctrl-up = ESC [1;5A)', () async {
+      final events = await parse([[0x1b, 0x5b, 0x31, 0x3b, 0x35, 0x41]]);
+      expect(events, [
+        const SpecialKey(code: SpecialKeyCode.up, modifiers: {Modifier.ctrl}),
+      ]);
+    });
+
+    test('CSI shift-arrow (ESC [1;2A)', () async {
+      final events = await parse([[0x1b, 0x5b, 0x31, 0x3b, 0x32, 0x41]]);
+      expect(events, [
+        const SpecialKey(code: SpecialKeyCode.up, modifiers: {Modifier.shift}),
+      ]);
+    });
+
+    test('CSI Home/End/PgUp/PgDn (ESC [H, [F, [5~, [6~)', () async {
+      final events = await parse([
+        [0x1b, 0x5b, 0x48], // home
+        [0x1b, 0x5b, 0x46], // end
+        [0x1b, 0x5b, 0x35, 0x7e], // pgUp
+        [0x1b, 0x5b, 0x36, 0x7e], // pgDn
+      ]);
+      expect(events, [
+        const SpecialKey(code: SpecialKeyCode.home, modifiers: {}),
+        const SpecialKey(code: SpecialKeyCode.end, modifiers: {}),
+        const SpecialKey(code: SpecialKeyCode.pageUp, modifiers: {}),
+        const SpecialKey(code: SpecialKeyCode.pageDown, modifiers: {}),
+      ]);
+    });
+
+    test('bare escape (no follow-up bytes) emits escape', () async {
+      // A single chunk containing ONLY ESC, followed by stream end.
+      final events = await parse([[0x1b]]);
+      expect(events, [
+        const SpecialKey(code: SpecialKeyCode.escape, modifiers: {}),
+      ]);
+    });
+
+    test('UTF-8 multi-byte rune', () async {
+      // U+00E9 (é) in UTF-8 = C3 A9
+      final events = await parse([[0xc3, 0xa9]]);
+      expect(events, [
+        const CharKey(rune: 0x00e9, modifiers: {}),
+      ]);
+    });
+
+    test('UTF-8 split across chunks', () async {
+      final events = await parse([[0xc3], [0xa9]]);
+      expect(events, [
+        const CharKey(rune: 0x00e9, modifiers: {}),
+      ]);
+    });
+
+    test('CSI split across chunks', () async {
+      final events = await parse([[0x1b], [0x5b], [0x41]]);
+      expect(events, [
+        const SpecialKey(code: SpecialKeyCode.up, modifiers: {}),
+      ]);
+    });
+  });
+}
+```
+
+- [ ] **Step 6.2: Run tests to verify they fail**
+
+```bash
+dart test test/tui/input_test.dart
+```
+
+Expected: the `parseKeyEvents` group fails (stub throws `UnimplementedError`).
+
+- [ ] **Step 6.3: Implement `parseKeyEvents`**
+
+Replace the `parseKeyEvents` stub at the bottom of `app/lib/src/tui/input.dart`:
+
+```dart
+/// Parse a raw byte stream into a stream of [KeyEvent]s.
+///
+/// Recognized sequences:
+/// - ASCII 0x20–0x7e → printable [CharKey].
+/// - ASCII 0x01–0x1a (except 0x09, 0x0a, 0x0d) → ctrl-letter [CharKey].
+/// - 0x09 → tab; 0x0a / 0x0d → enter; 0x7f → backspace.
+/// - 0x1b alone (stream ends or no more bytes available) → escape.
+/// - 0x1b 0x5b … (CSI) → arrows, home/end, page up/down, with optional
+///   modifier params (`ESC [1;<mod>A`).
+/// - 0x1b 0x4f X (SS3) → arrows (some terminals send these in app mode).
+/// - 0xc0–0xfd start of a UTF-8 multi-byte sequence → one [CharKey] with the
+///   decoded code point.
+///
+/// Sequences split across chunk boundaries are reassembled internally.
+Stream<KeyEvent> parseKeyEvents(Stream<List<int>> bytes) async* {
+  final pending = Queue<int>();
+  await for (final chunk in bytes) {
+    pending.addAll(chunk);
+    while (pending.isNotEmpty) {
+      // Attempt to consume one event from the front of [pending]. If the
+      // available bytes are an incomplete prefix of a multi-byte sequence,
+      // _consume returns null and we break to await more input.
+      final result = _consume(pending, streamClosed: false);
+      if (result == null) break;
+      yield result;
+    }
+  }
+  // Stream closed. Drain any pending bytes; treat lone ESC as escape.
+  while (pending.isNotEmpty) {
+    final result = _consume(pending, streamClosed: true);
+    if (result == null) break;
+    yield result;
+  }
+}
+
+/// Try to consume one [KeyEvent] from the front of [bytes]. Returns null if
+/// the bytes form an incomplete sequence and [streamClosed] is false.
+/// When [streamClosed] is true, ambiguous prefixes are resolved as best-effort
+/// (e.g. lone ESC → escape).
+KeyEvent? _consume(Queue<int> bytes, {required bool streamClosed}) {
+  final first = bytes.first;
+
+  // --- Special single-byte cases ---
+  if (first == 0x1b) {
+    // ESC: could be standalone escape, or the start of CSI/SS3.
+    if (bytes.length == 1) {
+      if (!streamClosed) return null;
+      bytes.removeFirst();
+      return const SpecialKey(code: SpecialKeyCode.escape, modifiers: {});
+    }
+    final second = bytes.elementAt(1);
+    if (second == 0x5b /* [ */) {
+      return _consumeCsi(bytes, streamClosed: streamClosed);
+    }
+    if (second == 0x4f /* O */) {
+      return _consumeSs3(bytes, streamClosed: streamClosed);
+    }
+    // Anything else after ESC: treat ESC as standalone for stage 1.
+    bytes.removeFirst();
+    return const SpecialKey(code: SpecialKeyCode.escape, modifiers: {});
+  }
+
+  if (first == 0x09) {
+    bytes.removeFirst();
+    return const SpecialKey(code: SpecialKeyCode.tab, modifiers: {});
+  }
+  if (first == 0x0a || first == 0x0d) {
+    bytes.removeFirst();
+    return const SpecialKey(code: SpecialKeyCode.enter, modifiers: {});
+  }
+  if (first == 0x7f) {
+    bytes.removeFirst();
+    return const SpecialKey(code: SpecialKeyCode.backspace, modifiers: {});
+  }
+
+  // --- ctrl-letter (0x01–0x1a, excluding the specials above) ---
+  if (first >= 0x01 && first <= 0x1a) {
+    bytes.removeFirst();
+    // 0x01 = ctrl-A → rune 'a' (0x61). General: rune = 0x60 + first.
+    return CharKey(rune: 0x60 + first, modifiers: const {Modifier.ctrl});
+  }
+
+  // --- Plain ASCII printable ---
+  if (first >= 0x20 && first <= 0x7e) {
+    bytes.removeFirst();
+    return CharKey(rune: first, modifiers: const {});
+  }
+
+  // --- UTF-8 multi-byte ---
+  if (first >= 0xc0 && first < 0xf8) {
+    final byteLen = first < 0xe0 ? 2 : (first < 0xf0 ? 3 : 4);
+    if (bytes.length < byteLen) {
+      return streamClosed
+          ? (bytes.clear(), const CharKey(rune: 0xFFFD /* replacement */, modifiers: {})).$2
+          : null;
+    }
+    var rune = first & (0xff >> (byteLen + 1));
+    final consumed = <int>[bytes.removeFirst()];
+    for (var i = 1; i < byteLen; i++) {
+      final next = bytes.removeFirst();
+      consumed.add(next);
+      rune = (rune << 6) | (next & 0x3f);
+    }
+    return CharKey(rune: rune, modifiers: const {});
+  }
+
+  // --- Anything else (continuation bytes appearing alone, 0xfe/0xff, etc.) ---
+  // Drop the byte to avoid an infinite loop.
+  bytes.removeFirst();
+  return CharKey(rune: 0xFFFD, modifiers: const {});
+}
+
+/// Consume an `ESC [ ...` CSI sequence. Called with [bytes] starting at 0x1b 0x5b.
+/// Returns null if more bytes are needed and the stream is still open.
+KeyEvent? _consumeCsi(Queue<int> bytes, {required bool streamClosed}) {
+  // We need at least ESC, [, and one final byte.
+  if (bytes.length < 3 && !streamClosed) return null;
+
+  // Snapshot the bytes so we can roll back if incomplete.
+  final snapshot = bytes.toList();
+  // Consume ESC and [.
+  snapshot.removeAt(0);
+  snapshot.removeAt(0);
+
+  // Read parameter bytes (0x30–0x3f), intermediate bytes (0x20–0x2f),
+  // and finally one final byte (0x40–0x7e).
+  final paramBytes = <int>[];
+  var idx = 0;
+  while (idx < snapshot.length && snapshot[idx] >= 0x30 && snapshot[idx] <= 0x3f) {
+    paramBytes.add(snapshot[idx]);
+    idx++;
+  }
+  if (idx >= snapshot.length) {
+    return streamClosed ? _csiUnknown(bytes) : null;
+  }
+  final finalByte = snapshot[idx];
+  if (finalByte < 0x40 || finalByte > 0x7e) {
+    return streamClosed ? _csiUnknown(bytes) : null;
+  }
+
+  // Successful parse — actually consume from [bytes].
+  // Total consumed = 2 (ESC, [) + paramBytes.length + 1 (final).
+  final totalConsumed = 2 + paramBytes.length + 1;
+  for (var i = 0; i < totalConsumed; i++) {
+    bytes.removeFirst();
+  }
+
+  return _interpretCsi(paramBytes, finalByte);
+}
+
+KeyEvent _csiUnknown(Queue<int> bytes) {
+  // Stream closed mid-sequence. Drain ESC and [ at least, and emit escape.
+  bytes.removeFirst(); // ESC
+  if (bytes.isNotEmpty) bytes.removeFirst(); // [
+  return const SpecialKey(code: SpecialKeyCode.escape, modifiers: {});
+}
+
+KeyEvent _interpretCsi(List<int> paramBytes, int finalByte) {
+  // Parse parameters: bytes 0x30–0x39 are digits, 0x3b is separator.
+  final params = <int>[];
+  var cur = 0;
+  var any = false;
+  for (final b in paramBytes) {
+    if (b >= 0x30 && b <= 0x39) {
+      cur = cur * 10 + (b - 0x30);
+      any = true;
+    } else if (b == 0x3b /* ; */) {
+      params.add(any ? cur : 0);
+      cur = 0;
+      any = false;
+    }
+  }
+  if (any) params.add(cur);
+
+  // Modifier param (xterm convention: 1=none, 2=shift, 3=alt, 4=shift+alt,
+  // 5=ctrl, 6=ctrl+shift, 7=ctrl+alt, 8=ctrl+shift+alt). Apparent in
+  // sequences like `ESC [1;<mod><final>` or `ESC [<n>;<mod>~`.
+  Set<Modifier> mods = const {};
+  if (params.length >= 2) {
+    mods = _xtermModifiers(params[1]);
+  }
+
+  switch (finalByte) {
+    case 0x41: // A
+      return SpecialKey(code: SpecialKeyCode.up, modifiers: mods);
+    case 0x42: // B
+      return SpecialKey(code: SpecialKeyCode.down, modifiers: mods);
+    case 0x43: // C
+      return SpecialKey(code: SpecialKeyCode.right, modifiers: mods);
+    case 0x44: // D
+      return SpecialKey(code: SpecialKeyCode.left, modifiers: mods);
+    case 0x48: // H
+      return SpecialKey(code: SpecialKeyCode.home, modifiers: mods);
+    case 0x46: // F
+      return SpecialKey(code: SpecialKeyCode.end, modifiers: mods);
+    case 0x7e: // ~
+      // First param identifies the key. Common values:
+      // 2=insert, 3=delete, 5=pgUp, 6=pgDn, 15=F5, 17=F6, 18=F7, 19=F8,
+      // 20=F9, 21=F10, 23=F11, 24=F12.
+      final keyId = params.isNotEmpty ? params[0] : 0;
+      final code = switch (keyId) {
+        2 => SpecialKeyCode.insert,
+        3 => SpecialKeyCode.delete,
+        5 => SpecialKeyCode.pageUp,
+        6 => SpecialKeyCode.pageDown,
+        15 => SpecialKeyCode.f5,
+        17 => SpecialKeyCode.f6,
+        18 => SpecialKeyCode.f7,
+        19 => SpecialKeyCode.f8,
+        20 => SpecialKeyCode.f9,
+        21 => SpecialKeyCode.f10,
+        23 => SpecialKeyCode.f11,
+        24 => SpecialKeyCode.f12,
+        _ => null,
+      };
+      if (code != null) return SpecialKey(code: code, modifiers: mods);
+      return const SpecialKey(code: SpecialKeyCode.escape, modifiers: {});
+    default:
+      return const SpecialKey(code: SpecialKeyCode.escape, modifiers: {});
+  }
+}
+
+Set<Modifier> _xtermModifiers(int param) {
+  // xterm encodes modifiers as (param - 1) treated as a bitfield:
+  // bit 0 = shift, bit 1 = alt, bit 2 = ctrl.
+  final m = (param - 1).clamp(0, 7);
+  final out = <Modifier>{};
+  if (m & 1 != 0) out.add(Modifier.shift);
+  if (m & 2 != 0) out.add(Modifier.alt);
+  if (m & 4 != 0) out.add(Modifier.ctrl);
+  return out;
+}
+
+KeyEvent? _consumeSs3(Queue<int> bytes, {required bool streamClosed}) {
+  // ESC O X — we need 3 bytes.
+  if (bytes.length < 3) {
+    return streamClosed
+        ? (bytes.removeFirst(), const SpecialKey(code: SpecialKeyCode.escape, modifiers: {})).$2
+        : null;
+  }
+  bytes.removeFirst(); // ESC
+  bytes.removeFirst(); // O
+  final final_ = bytes.removeFirst();
+  switch (final_) {
+    case 0x41:
+      return const SpecialKey(code: SpecialKeyCode.up, modifiers: {});
+    case 0x42:
+      return const SpecialKey(code: SpecialKeyCode.down, modifiers: {});
+    case 0x43:
+      return const SpecialKey(code: SpecialKeyCode.right, modifiers: {});
+    case 0x44:
+      return const SpecialKey(code: SpecialKeyCode.left, modifiers: {});
+    case 0x50:
+      return const SpecialKey(code: SpecialKeyCode.f1, modifiers: {});
+    case 0x51:
+      return const SpecialKey(code: SpecialKeyCode.f2, modifiers: {});
+    case 0x52:
+      return const SpecialKey(code: SpecialKeyCode.f3, modifiers: {});
+    case 0x53:
+      return const SpecialKey(code: SpecialKeyCode.f4, modifiers: {});
+    default:
+      return const SpecialKey(code: SpecialKeyCode.escape, modifiers: {});
+  }
+}
+```
+
+- [ ] **Step 6.4: Run tests to verify they pass**
+
+```bash
+dart test test/tui/input_test.dart
+```
+
+Expected: all tests pass, including the `parseKeyEvents` group.
+
+- [ ] **Step 6.5: Commit**
+
+```bash
+git add app/lib/src/tui/input.dart app/test/tui/input_test.dart
+git commit -m "Implement parseKeyEvents with CSI/SS3/UTF-8 support"
+```
+
+---
+
+## Task 7: `Terminal` lifecycle
+
+This task wires everything together: alt-screen, raw mode, signal handling, the public `Terminal.run` API. There are no unit tests here — terminal interaction is integration-level. Verification is via the demo in Task 8 and explicit manual checks.
+
+**Files:**
+- Create: `app/lib/src/tui/terminal.dart`
+
+- [ ] **Step 7.1: Write the implementation**
+
+`app/lib/src/tui/terminal.dart`:
+
+```dart
+import 'dart:async';
+import 'dart:io';
+
+import 'ansi.dart';
+import 'buffer.dart';
+import 'input.dart';
+
+/// Owns the terminal lifecycle: alt-screen entry/exit, raw-mode stdin,
+/// signal handling, double-buffered painting, and crash-safe restore.
+///
+/// Usage:
+/// ```dart
+/// await Terminal.run((terminal) async {
+///   terminal.draw((buffer) { ... });
+///   await for (final event in terminal.keys) { ... }
+/// });
+/// ```
+class Terminal {
+  /// Run [body] inside an active terminal session. The terminal is restored
+  /// to its previous state on normal completion, on uncaught error, and on
+  /// SIGINT/SIGTERM/SIGHUP.
+  static Future<void> run(FutureOr<void> Function(Terminal terminal) body) async {
+    final terminal = Terminal._();
+    await terminal._run(body);
+  }
+
+  Terminal._();
+
+  int _rows = 0;
+  int _cols = 0;
+  late CellBuffer _front;
+  late CellBuffer _back;
+
+  bool _wasEcho = false;
+  bool _wasLine = false;
+  bool _restored = false;
+
+  final _resizeController = StreamController<void>.broadcast();
+  final _keysController = StreamController<KeyEvent>();
+  StreamSubscription<KeyEvent>? _keysSub;
+  final _subs = <StreamSubscription>[];
+
+  int get rows => _rows;
+  int get cols => _cols;
+  Stream<void> get resizes => _resizeController.stream;
+  Stream<KeyEvent> get keys => _keysController.stream;
+
+  Future<void> _run(FutureOr<void> Function(Terminal) body) async {
+    _installSignalHandlers();
+    _enter();
+    try {
+      await runZonedGuarded(() async {
+        await body(this);
+      }, (error, stack) {
+        _restore();
+        stderr.writeln('Unhandled error in Terminal.run: $error');
+        stderr.writeln(stack);
+        exitCode = 1;
+      });
+    } finally {
+      _restore();
+    }
+  }
+
+  void _enter() {
+    _wasEcho = stdin.echoMode;
+    _wasLine = stdin.lineMode;
+    stdin.echoMode = false;
+    stdin.lineMode = false;
+
+    stdout.write(Ansi.enterAltScreen);
+    stdout.write(Ansi.hideCursor);
+    stdout.write(Ansi.clearScreen);
+    stdout.write(Ansi.moveTo(0, 0));
+
+    _rows = stdout.terminalLines;
+    _cols = stdout.terminalColumns;
+    _front = CellBuffer(_rows, _cols);
+    _back = CellBuffer(_rows, _cols);
+
+    // Pipe parsed key events into the public stream.
+    _keysSub = parseKeyEvents(stdin).listen(
+      _keysController.add,
+      onError: _keysController.addError,
+      onDone: _keysController.close,
+    );
+
+    // SIGWINCH — Unix only. Errors silently ignored on platforms without it.
+    try {
+      _subs.add(ProcessSignal.sigwinch.watch().listen((_) => _onResize()));
+    } catch (_) {/* not supported on this platform */}
+  }
+
+  void _onResize() {
+    final newRows = stdout.terminalLines;
+    final newCols = stdout.terminalColumns;
+    if (newRows == _rows && newCols == _cols) return;
+    _rows = newRows;
+    _cols = newCols;
+    _front = CellBuffer(_rows, _cols);
+    _back = CellBuffer(_rows, _cols);
+    // Force a full repaint by clearing the screen; the caller will redraw
+    // on the next resizes event and the diff will show every cell as changed.
+    stdout.write(Ansi.clearScreen);
+    stdout.write(Ansi.moveTo(0, 0));
+    _resizeController.add(null);
+  }
+
+  void _installSignalHandlers() {
+    void onTermSignal(int code) {
+      _restore();
+      exit(code);
+    }
+
+    try {
+      _subs.add(ProcessSignal.sigint.watch().listen((_) => onTermSignal(130)));
+    } catch (_) {}
+    try {
+      _subs.add(ProcessSignal.sigterm.watch().listen((_) => onTermSignal(143)));
+    } catch (_) {}
+    try {
+      _subs.add(ProcessSignal.sighup.watch().listen((_) => onTermSignal(129)));
+    } catch (_) {}
+  }
+
+  /// Compute and emit the diff between the current back buffer and the
+  /// caller's freshly-painted back buffer. The user's [paint] function
+  /// receives a cleared back buffer.
+  void draw(void Function(CellBuffer buffer) paint) {
+    _back.clear();
+    paint(_back);
+    final diff = encodeDiff(_front, _back);
+    if (diff.isNotEmpty) {
+      stdout.write(diff);
+    }
+    _front.copyFrom(_back);
+  }
+
+  void _restore() {
+    if (_restored) return;
+    _restored = true;
+
+    for (final sub in _subs) {
+      sub.cancel();
+    }
+    _subs.clear();
+    _keysSub?.cancel();
+    if (!_keysController.isClosed) _keysController.close();
+    if (!_resizeController.isClosed) _resizeController.close();
+
+    // Write restore sequences synchronously so they reach the terminal even
+    // on the way out of the process.
+    try {
+      stdout.write(Ansi.resetStyle);
+      stdout.write(Ansi.showCursor);
+      stdout.write(Ansi.exitAltScreen);
+    } catch (_) {/* stdout may already be closed */}
+
+    try {
+      stdin.echoMode = _wasEcho;
+      stdin.lineMode = _wasLine;
+    } catch (_) {}
+  }
+}
+```
+
+- [ ] **Step 7.2: Verify the file compiles**
+
+```bash
+dart analyze lib/src/tui/terminal.dart
+```
+
+Expected: `No issues found!`
+
+- [ ] **Step 7.3: Commit**
+
+```bash
+git add app/lib/src/tui/terminal.dart
+git commit -m "Add Terminal lifecycle with signal-safe restore"
+```
+
+---
+
+## Task 8: Barrel file and demo
+
+**Files:**
+- Create: `app/lib/src/tui/tui.dart`
+- Create: `app/lib/src/tui/example/step1_demo.dart`
+
+- [ ] **Step 8.1: Write the barrel file**
+
+`app/lib/src/tui/tui.dart`:
+
+```dart
+/// Public surface of the stage 1 TUI engine.
+library;
+
+export 'ansi.dart' show Ansi, encodeDiff;
+export 'buffer.dart';
+export 'cell.dart';
+export 'input.dart';
+export 'terminal.dart';
+```
+
+- [ ] **Step 8.2: Write the demo**
+
+`app/lib/src/tui/example/step1_demo.dart`:
+
+```dart
+import 'dart:async';
+
+import '../buffer.dart';
+import '../cell.dart';
+import '../input.dart';
+import '../terminal.dart';
+
+Future<void> main() async {
+  await Terminal.run((terminal) async {
+    String lastKey = '(none)';
+    int keyCount = 0;
+
+    void repaint() {
+      terminal.draw((b) {
+        final w = terminal.cols;
+        final h = terminal.rows;
+        const boxW = 36;
+        const boxH = 5;
+        final row = ((h - boxH) ~/ 2).clamp(0, h);
+        final col = ((w - boxW) ~/ 2).clamp(0, w);
+        _drawBorder(b, row, col, boxH, boxW);
+        b.writeAt(row + 1, col + 2, 'Size: $w × $h');
+        b.writeAt(row + 2, col + 2, 'Last key: $lastKey (count: $keyCount)');
+        b.writeAt(row + 3, col + 2, '(q to quit)');
+      });
+    }
+
+    repaint();
+    final resizeSub = terminal.resizes.listen((_) => repaint());
+
+    try {
+      await for (final event in terminal.keys) {
+        keyCount++;
+        lastKey = _describe(event);
+        if (event is CharKey && event.rune == 0x71 /* 'q' */) break;
+        if (event is CharKey &&
+            event.rune == 0x63 /* 'c' */ &&
+            event.modifiers.contains(Modifier.ctrl)) {
+          break;
+        }
+        repaint();
+      }
+    } finally {
+      await resizeSub.cancel();
+    }
+  });
+}
+
+void _drawBorder(CellBuffer b, int row, int col, int rows, int cols) {
+  const tl = 0x250C, tr = 0x2510, bl = 0x2514, br = 0x2518;
+  const h = 0x2500, v = 0x2502;
+  b.set(row, col, const Cell(rune: tl));
+  b.set(row, col + cols - 1, const Cell(rune: tr));
+  b.set(row + rows - 1, col, const Cell(rune: bl));
+  b.set(row + rows - 1, col + cols - 1, const Cell(rune: br));
+  for (var c = col + 1; c < col + cols - 1; c++) {
+    b.set(row, c, const Cell(rune: h));
+    b.set(row + rows - 1, c, const Cell(rune: h));
+  }
+  for (var r = row + 1; r < row + rows - 1; r++) {
+    b.set(r, col, const Cell(rune: v));
+    b.set(r, col + cols - 1, const Cell(rune: v));
+  }
+}
+
+String _describe(KeyEvent event) {
+  final mods = event.modifiers.isEmpty
+      ? ''
+      : '${event.modifiers.map((m) => m.name).join('+')}+';
+  return switch (event) {
+    CharKey(:final rune) => '$mods${String.fromCharCode(rune)} (0x${rune.toRadixString(16)})',
+    SpecialKey(:final code) => '$mods${code.name}',
+  };
+}
+```
+
+- [ ] **Step 8.3: Verify it compiles**
+
+```bash
+dart analyze lib/src/tui/example/step1_demo.dart
+```
+
+Expected: `No issues found!`
+
+- [ ] **Step 8.4: Run the demo manually and verify behavior**
+
+```bash
+dart run lib/src/tui/example/step1_demo.dart
+```
+
+Verify each of the following manually:
+
+1. **Alt-screen entry:** The terminal clears and shows the centered box. Previous terminal contents are not overwritten in the scrollback.
+2. **Box content:** Shows current size, "Last key: (none) (count: 0)", and "(q to quit)".
+3. **Key echo:** Press several keys (letters, arrows, enter, ctrl-A). The box updates with each one. No flicker on update.
+4. **Resize:** Resize the terminal window. The box re-centers correctly. New dimensions show in the box.
+5. **Quit via q:** Press q. The terminal returns to its previous state with cursor visible. Previous shell history is intact.
+6. **Quit via ctrl-C:** Restart the demo, press ctrl-C. Terminal restores correctly; exit code is 130 (`echo $?`).
+7. **Quit via SIGTERM:** Restart the demo, in another terminal `kill <pid>`. Terminal restores; exit code 143.
+8. **Crash safety:** Temporarily edit the demo to throw at the top of `repaint()` (`throw 'oops';`). Run it. Terminal must restore even though the demo crashed. Revert the edit.
+
+Document any failure here. If all eight pass, proceed.
+
+- [ ] **Step 8.5: Run the full test suite to make sure nothing regressed**
+
+```bash
+dart test test/tui/
+```
+
+Expected: every test passes.
+
+- [ ] **Step 8.6: Commit**
+
+```bash
+git add app/lib/src/tui/tui.dart app/lib/src/tui/example/step1_demo.dart
+git commit -m "Add TUI stage 1 barrel and step1_demo program"
+```
+
+---
+
+## Done criteria
+
+- All test files pass: `dart test test/tui/` reports green.
+- `dart run lib/src/tui/example/step1_demo.dart` shows the centered status box, updates on key/resize, and restores the terminal cleanly on q, ctrl-C, SIGTERM, and uncaught error.
+- No new pub dependencies were added to `app/pubspec.yaml`.
+- The codebase under `app/lib/src/tui/` is organized as described in the File Structure section.
+
+## Self-review notes
+
+- **Spec coverage:** each spec component is covered — Cell (Task 1), CellBuffer (Task 2), ansi constants (Task 3), encodeDiff (Task 4), KeyEvent (Task 5), parser (Task 6), Terminal (Task 7), demo (Task 8). The crash-safety section is implemented in Task 7 (three layers: try/finally, runZonedGuarded, signal handlers) and verified manually in Task 8 step 4.
+- **Non-goals are honored:** no widgets/elements/render-objects, no mouse, no Windows special-casing (just doesn't crash on unsupported signals), no emoji width.
+- **Types stay consistent across tasks:** `Cell.style` is `int`, `KeyEvent.modifiers` is `Set<Modifier>`, `Terminal.run` returns `Future<void>`. Method names (`draw`, `writeAt`, `fillRect`, `inBounds`, `copyFrom`) are used identically in spec, plan, and code.

--- a/docs/superpowers/plans/2026-05-14-tui-step1-inline-mode.md
+++ b/docs/superpowers/plans/2026-05-14-tui-step1-inline-mode.md
@@ -1,0 +1,960 @@
+# TUI Step 1 — Inline Mode Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add inline rendering mode to the existing stage 1 TUI engine — a fixed-height region anchored at the cursor's startup position, complementing the existing full-screen alt-screen mode.
+
+**Architecture:** Five small, focused changes: extend `encodeDiff` with an optional coordinate-origin offset; introduce a `TerminalMode` sealed class; add a cursor-position query helper for capturing the inline anchor row; branch `Terminal`'s lifecycle on mode; ship an `inline_demo.dart`. Engine modules below `Terminal` (Cell, CellBuffer, parser, Ansi) are unchanged — they were already mode-agnostic.
+
+**Tech Stack:** Same as before — Dart 3.6+, `package:test`, zero pub dependencies.
+
+**Spec:** [`docs/superpowers/specs/2026-05-14-tui-step1-inline-mode-design.md`](../specs/2026-05-14-tui-step1-inline-mode-design.md)
+
+---
+
+## File Structure
+
+```
+app/lib/src/tui/
+  ansi.dart            # MODIFY — encodeDiff gains originRow/originCol
+  terminal.dart        # MODIFY — TerminalMode types, mode-aware lifecycle
+  cursor_query.dart    # NEW    — cursor-position query helper (testable)
+  tui.dart             # MODIFY — export TerminalMode, FullScreenMode, InlineMode
+  example/
+    inline_demo.dart   # NEW    — demonstrates inline mode
+
+app/test/tui/
+  ansi_test.dart       # MODIFY — add origin-offset tests
+  cursor_query_test.dart # NEW  — unit tests for the query parser
+```
+
+**Run commands** assume `cd app` from the worktree root before running `dart test` / `dart analyze`.
+
+---
+
+## Task 1: Extend `encodeDiff` with origin offset
+
+**Files:**
+- Modify: `app/lib/src/tui/ansi.dart` (encodeDiff signature + body)
+- Modify: `app/test/tui/ansi_test.dart` (add 2 new tests)
+
+- [ ] **Step 1.1: Add failing tests**
+
+Append these tests to the existing `group('encodeDiff', () { ... })` block in `app/test/tui/ansi_test.dart`, before its closing `});`:
+
+```dart
+test('originRow shifts all cursor moves down', () {
+  final front = CellBuffer(1, 2);
+  final back = CellBuffer(1, 2);
+  back.set(0, 0, Cell(rune: 0x41));
+  back.set(0, 1, Cell(rune: 0x42));
+  final out = encodeDiff(front, back, originRow: 5);
+  // The single cursor move for the first cell should target row 5+0=5
+  // (1-indexed: 6), col 0 (1-indexed: 1).
+  expect(out, contains('\x1b[6;1H'));
+  expect(out, contains('AB'));
+});
+
+test('originCol shifts all cursor moves right', () {
+  final front = CellBuffer(1, 1);
+  final back = CellBuffer(1, 1);
+  back.set(0, 0, Cell(rune: 0x41));
+  final out = encodeDiff(front, back, originCol: 10);
+  // Move target: row 0+0=0 (1-indexed: 1), col 0+10=10 (1-indexed: 11).
+  expect(out, contains('\x1b[1;11H'));
+});
+
+test('default origin (0, 0) preserves existing behavior', () {
+  // Regression guard: omitting the new params must produce identical output
+  // to the pre-extension version.
+  final front = CellBuffer(1, 1);
+  final back = CellBuffer(1, 1);
+  back.set(0, 0, Cell(rune: 0x41));
+  final withDefault = encodeDiff(front, back);
+  final withExplicit = encodeDiff(front, back, originRow: 0, originCol: 0);
+  expect(withDefault, withExplicit);
+  expect(withDefault, contains('\x1b[1;1H'));
+});
+```
+
+- [ ] **Step 1.2: Run to verify they fail**
+
+```bash
+cd app && dart test test/tui/ansi_test.dart
+```
+
+Expected: the 3 new tests fail (compilation error because `encodeDiff` doesn't accept those named params).
+
+- [ ] **Step 1.3: Update `encodeDiff` signature and body**
+
+In `app/lib/src/tui/ansi.dart`, find the existing `encodeDiff` function and change its signature and the one line that emits cursor moves:
+
+```dart
+String encodeDiff(
+  CellBuffer front,
+  CellBuffer back, {
+  int originRow = 0,
+  int originCol = 0,
+}) {
+  if (front.rows != back.rows || front.cols != back.cols) {
+    throw ArgumentError(
+        'size mismatch: ${front.rows}×${front.cols} vs ${back.rows}×${back.cols}');
+  }
+
+  final buf = StringBuffer();
+
+  var cursorRow = -1;
+  var cursorCol = -1;
+
+  Color? lastFg;
+  Color? lastBg;
+  int? lastStyle;
+
+  for (var r = 0; r < back.rows; r++) {
+    for (var c = 0; c < back.cols; c++) {
+      final f = front.get(r, c);
+      final b = back.get(r, c);
+      if (f == b) continue;
+
+      if (cursorRow != r || cursorCol != c) {
+        buf.write(Ansi.moveTo(r + originRow, c + originCol));
+      }
+
+      // ... rest of the function body unchanged
+```
+
+Everything below the `buf.write(Ansi.moveTo(...))` line stays exactly the same. The only edit beyond the signature is `r + originRow, c + originCol` (was `r, c`).
+
+Also update the docstring at the top of `encodeDiff` to add one paragraph:
+
+```
+/// The optional [originRow] and [originCol] are added to every absolute
+/// cursor move emitted. Pass them when rendering into a sub-region of the
+/// terminal (e.g. inline mode); the back buffer is still addressed from
+/// (0, 0) on the caller's side.
+```
+
+- [ ] **Step 1.4: Run to verify all tests pass**
+
+```bash
+cd app && dart test test/tui/ansi_test.dart
+```
+
+Expected: 28 tests pass (25 pre-existing + 3 new).
+
+- [ ] **Step 1.5: Commit**
+
+```bash
+git add app/lib/src/tui/ansi.dart app/test/tui/ansi_test.dart
+git commit -m "Extend encodeDiff with originRow/originCol offset for sub-region rendering"
+```
+
+---
+
+## Task 2: `TerminalMode` types
+
+**Files:**
+- Modify: `app/lib/src/tui/terminal.dart` (add `TerminalMode` types, add `mode` parameter; no behavior change yet)
+- Modify: `app/lib/src/tui/tui.dart` (export the new types)
+
+This task introduces the API surface for mode selection. It does NOT yet change the lifecycle — `Terminal` accepts the parameter, stores it, but `_enter`/`_restore` still behave as before. Behavior change is Task 4.
+
+- [ ] **Step 2.1: Add the `TerminalMode` sealed hierarchy**
+
+At the top of `app/lib/src/tui/terminal.dart`, after the existing imports and before `class Terminal`, add:
+
+```dart
+/// Rendering mode for a [Terminal] session.
+sealed class TerminalMode {
+  const TerminalMode();
+}
+
+/// Take over the whole terminal via the alt-screen buffer. The default.
+final class FullScreenMode extends TerminalMode {
+  const FullScreenMode();
+}
+
+/// Render into a fixed-height region anchored at the cursor's position
+/// when [Terminal.run] starts. Normal scrollback above the region is
+/// preserved. Suitable for status panels and dashboards that coexist with
+/// regular CLI output.
+final class InlineMode extends TerminalMode {
+  /// Height of the region in rows. Must be > 0.
+  final int rows;
+  const InlineMode({required this.rows}) : assert(rows > 0);
+}
+```
+
+- [ ] **Step 2.2: Thread the `mode` parameter through `Terminal`**
+
+Find `Terminal.run` and update its signature:
+
+```dart
+static Future<void> run(
+  FutureOr<void> Function(Terminal terminal) body, {
+  TerminalMode mode = const FullScreenMode(),
+}) async {
+  final terminal = Terminal._(mode);
+  await terminal._run(body);
+}
+```
+
+Update the constructor and add the field:
+
+```dart
+Terminal._(this._mode);
+
+final TerminalMode _mode;
+```
+
+(Place `final TerminalMode _mode;` near the other private fields, around the same area as `_rows`, `_cols`.)
+
+The rest of the class is unchanged for Task 2 — `_enter`, `_onResize`, `_restore`, `draw` continue to behave as full-screen regardless of `_mode`. That's intentional; Task 4 wires up the inline branches.
+
+- [ ] **Step 2.3: Export the new types from the barrel**
+
+In `app/lib/src/tui/tui.dart`, update the `terminal.dart` export line:
+
+```dart
+export 'terminal.dart' show Terminal, TerminalMode, FullScreenMode, InlineMode;
+```
+
+(The rest of the barrel stays the same.)
+
+- [ ] **Step 2.4: Verify everything still compiles and existing tests pass**
+
+```bash
+cd app && dart analyze lib/src/tui/
+cd app && dart test test/tui/
+```
+
+Expected: `No issues found!`, and 70 tests pass (67 pre-existing + 3 from Task 1). No new tests in this task — `TerminalMode` is just a data class, and the absent behavior change means no observable difference yet.
+
+- [ ] **Step 2.5: Commit**
+
+```bash
+git add app/lib/src/tui/terminal.dart app/lib/src/tui/tui.dart
+git commit -m "Add TerminalMode sealed class and thread it through Terminal.run"
+```
+
+---
+
+## Task 3: Cursor-position query helper
+
+**Files:**
+- Create: `app/lib/src/tui/cursor_query.dart` (new)
+- Create: `app/test/tui/cursor_query_test.dart` (new)
+
+This is the hardest piece. The helper queries the terminal for its cursor position by writing `\x1b[6n` and parsing the response `\x1b[<row>;<col>R` out of an incoming byte stream, while preserving any non-response bytes (which are real input from the user typing during the query) for later delivery to the parser. Designed for unit-testing without a real terminal: it takes the byte source and the byte sink as parameters.
+
+- [ ] **Step 3.1: Write the failing tests**
+
+`app/test/tui/cursor_query_test.dart`:
+
+```dart
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutterware_app/src/tui/cursor_query.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('queryCursorPosition', () {
+    test('parses a clean response and returns 0-indexed row', () async {
+      final input = StreamController<List<int>>();
+      final outputBuf = <int>[];
+
+      final future = queryCursorPosition(
+        bytes: input.stream,
+        write: outputBuf.addAll,
+        fallbackRow: -1,
+      );
+
+      // Simulate terminal response: CSI 5;12R (row 5, col 12, 1-indexed).
+      input.add('\x1b[5;12R'.codeUnits);
+
+      final result = await future;
+      expect(result.row, 4); // 0-indexed
+      expect(result.col, 11);
+      expect(result.leftoverBytes, isEmpty);
+      // The query helper should have written CSI 6n.
+      expect(utf8.decode(outputBuf), '\x1b[6n');
+
+      await input.close();
+    });
+
+    test('response split across chunks', () async {
+      final input = StreamController<List<int>>();
+      final future = queryCursorPosition(
+        bytes: input.stream,
+        write: (_) {},
+        fallbackRow: -1,
+      );
+
+      input.add([0x1b, 0x5b]);
+      input.add('5'.codeUnits);
+      input.add(';12R'.codeUnits);
+
+      final result = await future;
+      expect(result.row, 4);
+      expect(result.col, 11);
+      expect(result.leftoverBytes, isEmpty);
+      await input.close();
+    });
+
+    test('non-response bytes before the response are forwarded as leftover', () async {
+      // The user typed 'A' before the response arrived.
+      final input = StreamController<List<int>>();
+      final future = queryCursorPosition(
+        bytes: input.stream,
+        write: (_) {},
+        fallbackRow: -1,
+      );
+
+      input.add([0x41]); // 'A'
+      input.add('\x1b[3;7R'.codeUnits);
+
+      final result = await future;
+      expect(result.row, 2);
+      expect(result.col, 6);
+      expect(result.leftoverBytes, [0x41]);
+      await input.close();
+    });
+
+    test('non-response bytes after the response are forwarded as leftover', () async {
+      // The user typed 'B' right after the response.
+      final input = StreamController<List<int>>();
+      final future = queryCursorPosition(
+        bytes: input.stream,
+        write: (_) {},
+        fallbackRow: -1,
+      );
+
+      input.add('\x1b[3;7R'.codeUnits);
+      input.add([0x42]); // 'B' — arrives in the same async tick
+
+      final result = await future;
+      expect(result.row, 2);
+      // 'B' arrived in a separate chunk after the helper had completed; it is
+      // NOT captured in leftoverBytes (the helper has already resolved).
+      expect(result.leftoverBytes, isEmpty);
+      await input.close();
+    });
+
+    test('interleaved escape-prefixed non-response bytes survive', () async {
+      // An up-arrow key '\x1b[A' interleaves: ESC, [, A. The parser must
+      // recognize that this isn't a position response (A isn't a digit after
+      // ESC [), discard its partial-parse state, and forward those 3 bytes
+      // to leftoverBytes. Then the real response comes through.
+      final input = StreamController<List<int>>();
+      final future = queryCursorPosition(
+        bytes: input.stream,
+        write: (_) {},
+        fallbackRow: -1,
+      );
+
+      input.add('\x1b[A'.codeUnits);     // arrow up — must NOT be consumed as response
+      input.add('\x1b[10;20R'.codeUnits); // real response
+
+      final result = await future;
+      expect(result.row, 9);
+      expect(result.col, 19);
+      expect(result.leftoverBytes, '\x1b[A'.codeUnits);
+      await input.close();
+    });
+
+    test('timeout returns fallback row and empty leftover', () async {
+      final input = StreamController<List<int>>();
+      final result = await queryCursorPosition(
+        bytes: input.stream,
+        write: (_) {},
+        fallbackRow: 42,
+        timeout: const Duration(milliseconds: 50),
+      );
+      expect(result.row, 42);
+      expect(result.col, 0);
+      expect(result.leftoverBytes, isEmpty);
+      await input.close();
+    });
+
+    test('timeout forwards any bytes received before timeout as leftover', () async {
+      final input = StreamController<List<int>>();
+      final future = queryCursorPosition(
+        bytes: input.stream,
+        write: (_) {},
+        fallbackRow: 42,
+        timeout: const Duration(milliseconds: 50),
+      );
+
+      input.add([0x58, 0x59]); // 'X', 'Y' — random non-response bytes
+      // No response ever comes.
+
+      final result = await future;
+      expect(result.row, 42);
+      expect(result.leftoverBytes, [0x58, 0x59]);
+      await input.close();
+    });
+  });
+}
+```
+
+- [ ] **Step 3.2: Run to verify they fail**
+
+```bash
+cd app && dart test test/tui/cursor_query_test.dart
+```
+
+Expected: compilation error — `cursor_query.dart` doesn't exist.
+
+- [ ] **Step 3.3: Implement `cursor_query.dart`**
+
+`app/lib/src/tui/cursor_query.dart`:
+
+```dart
+import 'dart:async';
+
+/// Result of a [queryCursorPosition] call.
+///
+/// [row] and [col] are 0-indexed.
+/// [leftoverBytes] are any bytes received during the query that were NOT
+/// part of the position response (typically keystrokes the user typed
+/// while the query was in flight). Callers should forward these to their
+/// regular input pipeline.
+class CursorPositionResult {
+  final int row;
+  final int col;
+  final List<int> leftoverBytes;
+  const CursorPositionResult({
+    required this.row,
+    required this.col,
+    required this.leftoverBytes,
+  });
+}
+
+/// Query the terminal for the current cursor position.
+///
+/// Writes `CSI 6n` via [write], then consumes bytes from [bytes] until a
+/// `CSI <row>;<col> R` response arrives. Returns 0-indexed coordinates.
+///
+/// If the terminal does not respond within [timeout], returns a result with
+/// [CursorPositionResult.row] equal to [fallbackRow] and any bytes received
+/// during the wait forwarded as `leftoverBytes`.
+///
+/// The query writes its own bytes and reads from the provided stream — it
+/// does not touch `stdin` or `stdout` directly, which makes it unit-testable
+/// without a real terminal.
+Future<CursorPositionResult> queryCursorPosition({
+  required Stream<List<int>> bytes,
+  required void Function(List<int>) write,
+  required int fallbackRow,
+  Duration timeout = const Duration(milliseconds: 200),
+}) async {
+  final completer = Completer<CursorPositionResult>();
+  final leftover = <int>[];
+
+  // Parser state: looking for ESC [ <digits> ; <digits> R
+  // _State values:
+  //   0 = scanning for ESC
+  //   1 = saw ESC, expect [
+  //   2 = saw ESC[, expect first digit of row
+  //   3 = in row digits (>=1 already consumed), expect more digits or ;
+  //   4 = saw ;, expect first digit of col
+  //   5 = in col digits, expect more digits or R
+  var state = 0;
+  var row = 0;
+  var col = 0;
+  // Bytes that we tentatively consumed as part of a possible response.
+  // If parsing bails out, these are flushed back to [leftover].
+  final pending = <int>[];
+
+  void rollback(int trailingByte) {
+    leftover.addAll(pending);
+    leftover.add(trailingByte);
+    pending.clear();
+    state = 0;
+    row = 0;
+    col = 0;
+  }
+
+  late StreamSubscription<List<int>> sub;
+  sub = bytes.listen(
+    (chunk) {
+      if (completer.isCompleted) {
+        leftover.addAll(chunk);
+        return;
+      }
+      for (final byte in chunk) {
+        if (completer.isCompleted) {
+          leftover.add(byte);
+          continue;
+        }
+        switch (state) {
+          case 0:
+            if (byte == 0x1b /* ESC */) {
+              pending.add(byte);
+              state = 1;
+            } else {
+              leftover.add(byte);
+            }
+            break;
+          case 1:
+            if (byte == 0x5b /* [ */) {
+              pending.add(byte);
+              state = 2;
+            } else {
+              rollback(byte);
+            }
+            break;
+          case 2:
+            if (byte >= 0x30 && byte <= 0x39) {
+              pending.add(byte);
+              row = byte - 0x30;
+              state = 3;
+            } else {
+              rollback(byte);
+            }
+            break;
+          case 3:
+            if (byte >= 0x30 && byte <= 0x39) {
+              pending.add(byte);
+              row = row * 10 + (byte - 0x30);
+            } else if (byte == 0x3b /* ; */) {
+              pending.add(byte);
+              state = 4;
+            } else {
+              rollback(byte);
+            }
+            break;
+          case 4:
+            if (byte >= 0x30 && byte <= 0x39) {
+              pending.add(byte);
+              col = byte - 0x30;
+              state = 5;
+            } else {
+              rollback(byte);
+            }
+            break;
+          case 5:
+            if (byte >= 0x30 && byte <= 0x39) {
+              pending.add(byte);
+              col = col * 10 + (byte - 0x30);
+            } else if (byte == 0x52 /* R */) {
+              // Response complete.
+              completer.complete(CursorPositionResult(
+                row: row - 1,
+                col: col - 1,
+                leftoverBytes: List.unmodifiable(leftover),
+              ));
+            } else {
+              rollback(byte);
+            }
+            break;
+        }
+      }
+    },
+    onError: (error, stack) {
+      if (!completer.isCompleted) {
+        completer.completeError(error, stack);
+      }
+    },
+    onDone: () {
+      if (!completer.isCompleted) {
+        // Stream closed before a response arrived. Treat as timeout-like.
+        completer.complete(CursorPositionResult(
+          row: fallbackRow,
+          col: 0,
+          leftoverBytes: List.unmodifiable(leftover),
+        ));
+      }
+    },
+  );
+
+  write('\x1b[6n'.codeUnits);
+
+  try {
+    final result = await completer.future.timeout(
+      timeout,
+      onTimeout: () => CursorPositionResult(
+        row: fallbackRow,
+        col: 0,
+        leftoverBytes: List.unmodifiable(leftover),
+      ),
+    );
+    return result;
+  } finally {
+    await sub.cancel();
+  }
+}
+```
+
+- [ ] **Step 3.4: Run tests to verify they pass**
+
+```bash
+cd app && dart test test/tui/cursor_query_test.dart
+```
+
+Expected: all 7 tests pass.
+
+- [ ] **Step 3.5: Commit**
+
+```bash
+git add app/lib/src/tui/cursor_query.dart app/test/tui/cursor_query_test.dart
+git commit -m "Add cursor-position query helper for inline-mode anchor capture"
+```
+
+---
+
+## Task 4: Inline-mode lifecycle in `Terminal`
+
+**Files:**
+- Modify: `app/lib/src/tui/terminal.dart` (mode-aware `_enter`, `_onResize`, `_restore`, `draw`; stdin routing for cursor query)
+
+This task makes `Terminal` actually behave differently based on `_mode`. It introduces a small stdin-routing layer so the cursor-position query can intercept bytes from stdin without losing them, and threads the captured `_originRow` into every `encodeDiff` call.
+
+Read the entire current `terminal.dart` before starting — this is a refactor of an existing file, not a greenfield write.
+
+- [ ] **Step 4.1: Add stdin routing**
+
+The current `Terminal._enter()` does `parseKeyEvents(stdin)` directly. The cursor-position query needs to consume bytes from stdin before the parser does. We introduce a single subscription to stdin and route bytes either to the parser's controller (normal mode) or to the cursor-query helper (briefly, only during inline-mode entry).
+
+Add these fields to `Terminal`, near the other private state:
+
+```dart
+final _stdinController = StreamController<List<int>>();
+StreamSubscription<List<int>>? _stdinSub;
+int _originRow = 0;
+int _originCol = 0;
+bool _anchored = false;
+```
+
+Strategy for the stdin routing:
+
+- `_stdinController` is a regular (single-subscription) `StreamController<List<int>>`. Single-sub controllers buffer events added before a listener attaches, which is what we need to bridge the gap between the cursor-query helper cancelling its subscription and the key parser subscribing.
+- `_stdinSub` is a single subscription to actual `stdin`, forwarding all bytes into `_stdinController` for the whole session.
+- During inline-mode entry, `queryCursorPosition` is the sole subscriber to `_stdinController.stream`. After it resolves, it cancels its subscription in its own `finally` block. The key parser then subscribes; bytes received in the gap are queued by the controller and delivered when the parser attaches.
+
+Replace `_enter()` entirely with:
+
+```dart
+Future<void> _enter() async {
+  _wasEcho = stdin.echoMode;
+  _wasLine = stdin.lineMode;
+  stdin.echoMode = false;
+  stdin.lineMode = false;
+
+  // Pipe stdin into our internal controller. Both the cursor-position query
+  // (briefly, during inline-mode entry) and the key parser (for the rest of
+  // the session) consume from _stdinController.stream.
+  _stdinSub = stdin.listen(
+    _stdinController.add,
+    onError: _stdinController.addError,
+    onDone: _stdinController.close,
+  );
+
+  final mode = _mode;
+  if (mode is InlineMode) {
+    stdout.write(Ansi.hideCursor);
+    stdout.write('\n' * mode.rows);
+    stdout.write('\x1b[${mode.rows}F'); // CPL: cursor previous line × rows
+
+    final result = await queryCursorPosition(
+      bytes: _stdinController.stream,
+      write: stdout.add,
+      fallbackRow: stdout.terminalLines - mode.rows,
+    );
+    _originRow = result.row;
+    _originCol = 0;
+    _anchored = true;
+    // Replay leftover bytes so the key parser sees them next.
+    if (result.leftoverBytes.isNotEmpty) {
+      _stdinController.add(result.leftoverBytes);
+    }
+
+    _rows = mode.rows;
+    _cols = stdout.terminalColumns;
+  } else {
+    stdout.write(Ansi.enterAltScreen);
+    stdout.write(Ansi.hideCursor);
+    stdout.write(Ansi.clearScreen);
+    stdout.write(Ansi.moveTo(0, 0));
+    _originRow = 0;
+    _originCol = 0;
+    _anchored = true;
+    _rows = stdout.terminalLines;
+    _cols = stdout.terminalColumns;
+  }
+
+  _front = CellBuffer(_rows, _cols);
+  _back = CellBuffer(_rows, _cols);
+
+  // Hook up the key parser to the (now free) _stdinController.stream.
+  _keysSub = parseKeyEvents(_stdinController.stream).listen(
+    _keysController.add,
+    onError: _keysController.addError,
+    onDone: _keysController.close,
+  );
+
+  // SIGWINCH — Unix only.
+  try {
+    _subs.add(ProcessSignal.sigwinch.watch().listen((_) => _onResize()));
+  } catch (_) {/* not supported on this platform */}
+}
+```
+
+`_enter()` now returns `Future<void>` (was `void`). Update `_run()` to await it:
+
+```dart
+Future<void> _run(FutureOr<void> Function(Terminal) body) async {
+  _installSignalHandlers();
+  await _enter();
+  // ... rest of _run body unchanged
+}
+```
+
+- [ ] **Step 4.2: Update `draw()` to use the origin**
+
+Find `Terminal.draw` and change the `encodeDiff` call to pass the origin:
+
+```dart
+void draw(void Function(CellBuffer buffer) paint) {
+  _back.clear();
+  paint(_back);
+  final diff = encodeDiff(_front, _back, originRow: _originRow, originCol: _originCol);
+  if (diff.isNotEmpty) {
+    stdout.write(diff);
+  }
+  _front.copyFrom(_back);
+}
+```
+
+- [ ] **Step 4.3: Update `_onResize()` for inline mode**
+
+Replace the existing `_onResize` with a mode-aware version:
+
+```dart
+void _onResize() {
+  final newCols = stdout.terminalColumns;
+  final mode = _mode;
+  if (mode is InlineMode) {
+    if (newCols == _cols) return; // height is fixed; only columns can change
+    _cols = newCols;
+    _front = CellBuffer(_rows, _cols);
+    _back = CellBuffer(_rows, _cols);
+    // Do NOT clearScreen — that would wipe scrollback content above the
+    // inline region. Callers should repaint in response to the resizes
+    // event; the new (empty) _front means every cell will appear changed
+    // and be repainted.
+  } else {
+    final newRows = stdout.terminalLines;
+    if (newRows == _rows && newCols == _cols) return;
+    _rows = newRows;
+    _cols = newCols;
+    _front = CellBuffer(_rows, _cols);
+    _back = CellBuffer(_rows, _cols);
+    stdout.write(Ansi.clearScreen);
+    stdout.write(Ansi.moveTo(0, 0));
+  }
+  _resizeController.add(null);
+}
+```
+
+- [ ] **Step 4.4: Update `_restore()` for inline mode**
+
+Modify `_restore` to branch on mode (just the ANSI sequence section; the subscription cancellation is unchanged):
+
+```dart
+void _restore() {
+  if (_restored) return;
+  _restored = true;
+
+  for (final sub in _subs) {
+    sub.cancel();
+  }
+  _subs.clear();
+  _keysSub?.cancel();
+  _stdinSub?.cancel();
+  if (!_keysController.isClosed) _keysController.close();
+  if (!_resizeController.isClosed) _resizeController.close();
+  if (!_stdinController.isClosed) _stdinController.close();
+
+  try {
+    stdout.write(Ansi.resetStyle);
+    if (_mode is InlineMode) {
+      if (_anchored) {
+        stdout.write(Ansi.moveTo(_originRow, 0));
+        stdout.write('\x1b[J'); // clear to end of screen
+      }
+      stdout.write(Ansi.showCursor);
+      stdout.write('\n'); // next prompt on a fresh line
+    } else {
+      stdout.write(Ansi.showCursor);
+      stdout.write(Ansi.exitAltScreen);
+    }
+  } catch (_) {/* stdout may already be closed */}
+
+  try {
+    stdin.echoMode = _wasEcho;
+    stdin.lineMode = _wasLine;
+  } catch (_) {}
+}
+```
+
+- [ ] **Step 4.5: Add the import for cursor_query.dart**
+
+At the top of `terminal.dart`, add:
+
+```dart
+import 'cursor_query.dart';
+```
+
+- [ ] **Step 4.6: Run analyze and tests**
+
+```bash
+cd app && dart analyze lib/src/tui/
+cd app && dart test test/tui/
+```
+
+Expected: clean analyze, all 77 tests pass (no new tests in this task — Task 1 added 3 encodeDiff tests, Task 3 added 7 cursor_query tests, both contributing to the running total).
+
+- [ ] **Step 4.7: Commit**
+
+```bash
+git add app/lib/src/tui/terminal.dart
+git commit -m "Wire inline-mode lifecycle into Terminal with cursor-position anchoring"
+```
+
+---
+
+## Task 5: Inline demo and final verification
+
+**Files:**
+- Create: `app/lib/src/tui/example/inline_demo.dart` (new)
+
+The inline demo serves the same purpose as `step1_demo.dart` does for full-screen mode: a small program that exercises every part of the new code path. Manual interactive verification by the human follows.
+
+- [ ] **Step 5.1: Write the demo**
+
+`app/lib/src/tui/example/inline_demo.dart`:
+
+```dart
+import 'dart:async';
+
+import '../tui.dart';
+
+Future<void> main() async {
+  // Print some normal CLI output above the inline region first, so we can
+  // visually confirm the scrollback is preserved.
+  print('--- preceding shell output (this should remain visible above) ---');
+  print('flutterware status:');
+
+  await Terminal.run((terminal) async {
+    var lastKey = '(none)';
+    var keyCount = 0;
+
+    void repaint() {
+      terminal.draw((b) {
+        final w = terminal.cols;
+        _drawBorder(b, 0, 0, terminal.rows, w);
+        b.writeAt(1, 2, 'Inline region: $w cols × ${terminal.rows} rows');
+        b.writeAt(2, 2, 'Last key: $lastKey (count: $keyCount)');
+        b.writeAt(3, 2, '(q to quit)');
+      });
+    }
+
+    repaint();
+    final resizeSub = terminal.resizes.listen((_) => repaint());
+
+    try {
+      await for (final event in terminal.keys) {
+        keyCount++;
+        lastKey = _describe(event);
+        if (event is CharKey && event.rune == 0x71 /* 'q' */) break;
+        if (event is CharKey &&
+            event.rune == 0x63 /* 'c' */ &&
+            event.modifiers.contains(Modifier.ctrl)) {
+          break;
+        }
+        repaint();
+      }
+    } finally {
+      await resizeSub.cancel();
+    }
+  }, mode: const InlineMode(rows: 5));
+
+  print('--- inline region exited; back to normal shell output ---');
+}
+
+void _drawBorder(CellBuffer b, int row, int col, int rows, int cols) {
+  const tl = 0x250C, tr = 0x2510, bl = 0x2514, br = 0x2518;
+  const h = 0x2500, v = 0x2502;
+  b.set(row, col, const Cell(rune: tl));
+  b.set(row, col + cols - 1, const Cell(rune: tr));
+  b.set(row + rows - 1, col, const Cell(rune: bl));
+  b.set(row + rows - 1, col + cols - 1, const Cell(rune: br));
+  for (var c = col + 1; c < col + cols - 1; c++) {
+    b.set(row, c, const Cell(rune: h));
+    b.set(row + rows - 1, c, const Cell(rune: h));
+  }
+  for (var r = row + 1; r < row + rows - 1; r++) {
+    b.set(r, col, const Cell(rune: v));
+    b.set(r, col + cols - 1, const Cell(rune: v));
+  }
+}
+
+String _describe(KeyEvent event) {
+  final mods = event.modifiers.isEmpty
+      ? ''
+      : '${event.modifiers.map((m) => m.name).join('+')}+';
+  return switch (event) {
+    CharKey(:final rune) => '$mods${String.fromCharCode(rune)} (0x${rune.toRadixString(16)})',
+    SpecialKey(:final code) => '$mods${code.name}',
+  };
+}
+```
+
+- [ ] **Step 5.2: Verify analyze and tests**
+
+```bash
+cd app && dart analyze lib/src/tui/
+cd app && dart test test/tui/
+```
+
+Expected: clean analyze and 77 tests pass.
+
+- [ ] **Step 5.3: Manual verification (SKIP for subagent run)**
+
+This step requires interactive testing in a real terminal and is for the human reviewer to run AFTER the implementation lands. The subagent should NOT attempt it.
+
+Items the human will verify:
+
+1. **Scrollback preserved.** The "preceding shell output" lines remain visible above the inline region after entry.
+2. **Inline rendering.** The bordered status panel appears below the preceding output, 5 rows tall.
+3. **Key updates.** Pressing keys updates the panel (`Last key:` field changes, count increments).
+4. **Resize width.** Resizing the terminal width reflows the panel border to the new width.
+5. **Resize height shrink (acceptable degradation).** Shrinking the terminal height to below the region's start row results in the region painting offscreen until the terminal is grown back. No crash.
+6. **Clean exit.** Pressing 'q' (or ctrl-C) clears the inline region; the cursor lands on a fresh line below; the next shell prompt appears there. The "preceding shell output" remains visible in scrollback. The final "back to normal shell output" line prints.
+7. **No regression in full-screen.** Run `dart run lib/src/tui/example/step1_demo.dart` to confirm the existing demo still works identically.
+
+- [ ] **Step 5.4: Commit**
+
+```bash
+git add app/lib/src/tui/example/inline_demo.dart
+git commit -m "Add inline-mode demo program"
+```
+
+---
+
+## Done criteria
+
+- All test files pass: `dart test test/tui/` reports green with 77 tests (67 original + 3 from Task 1 encodeDiff offset + 7 from Task 3 cursor_query).
+- `dart analyze lib/src/tui/` reports `No issues found!`.
+- `dart run lib/src/tui/example/step1_demo.dart` continues to work as before (full-screen).
+- `dart run lib/src/tui/example/inline_demo.dart` runs in a real terminal with the behavior described in Task 5.3.
+- No new pub dependencies in `app/pubspec.yaml`.
+- `Terminal.run(...)` still works with no `mode` argument (default is `FullScreenMode`).
+
+## Self-review notes
+
+- **Spec coverage:** Cursor-query mechanism (Task 3), `TerminalMode` types (Task 2), `encodeDiff` offset (Task 1), mode-aware lifecycle (Task 4), inline demo (Task 5), barrel exports (Task 2). The `_anchored` flag in the crash-safe restore is part of Task 4 step 4.4.
+- **Backwards compatibility:** Every existing test, demo, and call site continues to work unchanged. `encodeDiff`'s new params default to 0; `Terminal.run`'s `mode` parameter defaults to `const FullScreenMode()`.
+- **Type consistency:** `_originRow` / `_originCol` are `int`; the cursor-query helper returns 0-indexed values; `encodeDiff` adds them to the 0-indexed buffer coords before passing to `Ansi.moveTo` (which 1-indexes for CSI output). The cursor-query helper subtracts 1 from the parsed CSI response (which was 1-indexed) so the stored origin is 0-indexed. No off-by-one across the chain.

--- a/docs/superpowers/specs/2026-05-14-tui-step1-engine-design.md
+++ b/docs/superpowers/specs/2026-05-14-tui-step1-engine-design.md
@@ -1,0 +1,264 @@
+# TUI Step 1 — Engine foundation
+
+**Status:** Draft
+**Date:** 2026-05-14
+**Scope:** Step 1 of a multi-step initiative to build a Flutter-style TUI framework in Dart for the flutterware CLI.
+
+---
+
+## Context
+
+The flutterware CLI (`app/bin/flutterware.dart`) currently uses a line-oriented logger (vendored AnsiTerminal + StdoutLogger) for its output. The long-term goal is to give it a real full-screen TUI: dashboards, navigation, live state. We're getting there in stages — each stage delivering something demonstrable on its own — and this spec covers stage 1 only.
+
+The end-state architecture mirrors Flutter's three-tree pipeline (Widget → Element → RenderObject), but the render and engine layers are terminal-shaped instead of Skia-shaped. Stages 2–4 build the paint kit, render tree, and widget layer on top of stage 1.
+
+**Stage 1 builds the engine layer in isolation, with a direct procedural paint API.** No layout, no render objects, no widgets. The deliverable is something a stage-2 paint kit, and eventually a stage-4 widget tree, can sit on top of without modification.
+
+## Goals
+
+1. A clean, restartable, crash-safe terminal session: alt-screen entry/exit, raw-mode stdin, restore-on-panic.
+2. A `CellBuffer` abstraction (rows × cols of `Cell`) that can be painted into procedurally.
+3. Efficient output: diff the back-buffer against the front-buffer, emit ANSI escape sequences only for changed cells.
+4. A `KeyEvent` stream from stdin with the common keys (printable chars, arrows, enter, tab, backspace, escape, ctrl-modifiers).
+5. Resize-aware: a SIGWINCH handler triggers a redraw with the new dimensions.
+6. A demo program that exercises all of the above.
+
+## Non-goals (for stage 1)
+
+- **No layout.** No constraints, no flex, no padding. Painting is by absolute `(row, col)`.
+- **No widgets, elements, or render objects.** Those are stages 3 and 4.
+- **No mouse input.** Defer to a later stage (Unix mouse escape parsing has its own rabbit holes).
+- **No Windows polish.** Mac/Linux first. Code should compile on Windows but quirks (no SIGWINCH, alternative raw-mode dance) are out of scope. Windows handling is a follow-up.
+- **No emoji or CJK width handling.** Basic Latin only. The `Cell` struct will carry a `width` field so we can extend later, but the parser/painter treats every rune as 1 cell for now.
+- **No animations or ticker.** The engine repaints on demand (input event, resize, explicit caller-driven `markDirty`), not on a frame clock.
+- **No theming, colors-by-name, or color profiles.** A `Color` is an explicit 24-bit RGB or one of the 16 ANSI named colors. Terminal capability detection is a follow-up.
+
+## Location
+
+`app/lib/src/tui/` inside the `flutterware_app` package. Reasoning: the consuming CLI lives there, and `flutterware_app` (`publish_to: 'none'`) is the more permissive package for adding dependencies if we ever need them. Promotable later if we want to share.
+
+Source layout:
+
+```
+app/lib/src/tui/
+  cell.dart          # Cell, Color, TextStyle, CellWidth
+  buffer.dart        # CellBuffer + paint helpers
+  ansi.dart          # ANSI escape constants + buffer-diff encoder
+  input.dart         # raw-stdin → KeyEvent parser
+  terminal.dart      # Terminal lifecycle (enter/exit alt-screen, frame loop, signals)
+  tui.dart           # barrel file (public exports for stage 1)
+app/lib/src/tui/example/
+  step1_demo.dart    # the demo described below
+```
+
+## Dependencies
+
+**Zero pub dependencies.** Stage 1 uses only `dart:io`, `dart:async`, `dart:convert` (for `utf8`), and `dart:typed_data` (for `Uint8List` in the buffer).
+
+## Components
+
+### `Cell`
+
+```dart
+class Cell {
+  final int rune;         // Unicode code point; 0x20 = space (the "empty" cell)
+  final Color fg;
+  final Color bg;
+  final int style;        // bitfield: bold, italic, underline, reverse, dim
+  final int width;        // 1 for stage 1; reserved for future wide-char support
+  const Cell({...});
+  static const empty = Cell(rune: 0x20, fg: Color.defaultFg, bg: Color.defaultBg, style: 0, width: 1);
+}
+```
+
+`Cell` is immutable and value-comparable (override `==` / `hashCode`). Value equality drives the diff in `ansi.dart`.
+
+**Why a fixed `rune: int` and not a `String`:** keeps `Cell` cheap to compare and store. Multi-codepoint sequences (combining marks, emoji families) are out of scope for stage 1.
+
+`Color` is a small sealed-style class: named ANSI (16 colors), 256-color indexed, or 24-bit RGB. `Color.defaultFg`/`Color.defaultBg` map to "reset to terminal default" (ANSI `39` / `49`), distinct from explicit colors.
+
+`TextStyle` is a bitfield constant container: `TextStyle.bold | TextStyle.underline`. Lives in `cell.dart`.
+
+### `CellBuffer`
+
+```dart
+class CellBuffer {
+  final int rows;
+  final int cols;
+  CellBuffer(this.rows, this.cols);
+
+  Cell get(int row, int col);
+  void set(int row, int col, Cell cell);
+  void writeAt(int row, int col, String text, {Color fg, Color bg, int style});
+  void fill(Cell cell);
+  void fillRect(int row, int col, int rows, int cols, Cell cell);
+  void clear();  // fill(Cell.empty)
+  void copyFrom(CellBuffer other);  // for back→front after flush
+
+  bool inBounds(int row, int col);  // returns false instead of throwing — callers can clip freely
+}
+```
+
+**Storage:** a flat `List<Cell>` of length `rows * cols`. Index = `row * cols + col`. Cells are immutable, so storing them directly is fine.
+
+**Out-of-bounds policy:** `set` / `writeAt` silently clip. Painting past the right edge truncates; painting at a negative row/col is a no-op for those cells. This is important: stage 2's paint helpers will routinely paint shapes that extend past the buffer (e.g. a centered box bigger than the terminal) and we want that to degrade gracefully, not throw.
+
+**Resize:** buffers are immutable in size. On SIGWINCH, `Terminal` allocates new back and front buffers at the new dimensions and re-invokes the caller's paint function. No in-place resize.
+
+### `ansi.dart`
+
+Two things live here:
+
+**(1) Escape sequence constants:** `enterAltScreen`, `exitAltScreen`, `hideCursor`, `showCursor`, `clearScreen`, `moveTo(row, col)`, `setForeground(Color)`, `setBackground(Color)`, `setStyle(int)`, `resetStyle`.
+
+**(2) `String encodeDiff(CellBuffer front, CellBuffer back)`:** the heart of the engine's output. Walks both buffers, emits ANSI for each changed cell. Optimizations:
+
+- Skip unchanged cells.
+- When the next changed cell is the immediate neighbor of the previous one, omit the cursor-move (the cursor advances naturally after a character write).
+- Track current fg/bg/style and only emit `setForeground` / `setBackground` / `setStyle` when they change.
+- Group consecutive changed cells in the same row to minimize cursor moves.
+
+**Output is a single `String` built with a `StringBuffer`**, returned to `Terminal` which writes it to `stdout` in one call. Atomic-ish writes minimize tearing.
+
+### `KeyEvent` and `input.dart`
+
+```dart
+sealed class KeyEvent { final Set<Modifier> modifiers; ... }
+class CharKey extends KeyEvent { final int rune; }
+class SpecialKey extends KeyEvent { final SpecialKeyCode code; }
+enum SpecialKeyCode { up, down, left, right, enter, tab, backspace, escape, home, end, pageUp, pageDown, delete, ... }
+enum Modifier { ctrl, alt, shift }
+```
+
+`Stream<KeyEvent> readKeys(Stdin stdin)` consumes raw bytes and emits events.
+
+**Parsing approach:** a small state machine that handles:
+
+- Single byte 0x20–0x7e → `CharKey` (ASCII printable).
+- Single byte < 0x20 → ctrl-modifier `CharKey` (0x01 = ctrl-A, 0x03 = ctrl-C, etc.). Special handling for `\r` / `\n` → `SpecialKey(enter)`, `\t` → `tab`, `\x7f` → `backspace`, `\x1b` standalone → `escape`.
+- ESC `[` … → CSI sequences (arrow keys `\x1b[A` etc., modifier-prefixed forms like `\x1b[1;5A` for ctrl-up).
+- ESC `O` … → SS3 sequences (some terminals send `\x1bOA` for arrows in app mode).
+- UTF-8 multi-byte → decode to a single `CharKey` with the full code point.
+
+**Ambiguity handled:** a bare `\x1b` could be the escape key or the start of an unfinished sequence. Resolution: short timer (e.g. 50ms with no further bytes → emit `SpecialKey(escape)`). For stage 1, simpler approach: if no bytes follow within one event-loop tick, treat as escape. Refine later if needed.
+
+**ctrl-C handling:** the input parser emits a `CharKey(rune: 0x03, modifiers: {ctrl})`. SIGINT handling is the `Terminal`'s job, not the input layer's — when raw mode is on, ctrl-C arrives as a byte, not a signal. `Terminal` may translate that byte into a clean shutdown if no listener handles it.
+
+### `Terminal`
+
+The lifecycle owner. Public surface:
+
+```dart
+class Terminal {
+  static Future<void> run(FutureOr<void> Function(Terminal terminal) body);
+
+  int get rows;
+  int get cols;
+  Stream<KeyEvent> get keys;
+  Stream<void> get resizes;  // emits whenever rows/cols change
+
+  void draw(void Function(CellBuffer buffer) paint);
+  Future<void> exit([int code = 0]);
+}
+```
+
+**`Terminal.run` is the only entry point.** It:
+
+1. Saves the current terminal state (`stdin.echoMode`, `lineMode`).
+2. Enters alt-screen (`\x1b[?1049h`), hides cursor (`\x1b[?25l`), enables raw mode.
+3. Allocates `front` and `back` buffers at current size.
+4. Sets up signal handlers: SIGWINCH (resize), SIGINT/SIGTERM (clean exit), and a top-level `runZonedGuarded` for uncaught errors.
+5. Starts the stdin parser, exposed via the `keys` stream.
+6. Calls `body(terminal)`, which is expected to subscribe to events and call `draw` as needed. Most stage-1 programs will be a loop reading keys.
+7. On any exit path (normal completion, error, signal): restore cursor, exit alt-screen, restore stdin modes, write any pending error to stderr, and exit with the appropriate code.
+
+**`draw(paint)`:**
+
+- Calls `back.clear()` (cheap — single fill).
+- Calls user's `paint(back)`.
+- Computes `encodeDiff(front, back)` and writes the result to stdout.
+- `front.copyFrom(back)`.
+
+This is a pull model: nothing redraws unless the caller asks for it. Stage 1 doesn't impose a frame clock; that comes later when the widget layer needs `setState` → schedule frame.
+
+### Crash safety (the load-bearing piece)
+
+A failed restore leaves the user in alt-screen with no echo and no cursor — they have to `reset(1)` blind. Three layers of defense:
+
+1. **Normal path:** `Terminal.run` uses `try { … } finally { _restore() }`.
+2. **Async errors:** the whole body runs inside `runZonedGuarded`; uncaught zone errors trigger `_restore()` before rethrowing.
+3. **Signals:** SIGINT, SIGTERM, SIGHUP handlers each call `_restore()` and then `exit(130)` / `exit(143)` / `exit(129)`. These handlers are installed before alt-screen entry.
+
+`_restore()` is idempotent and writes the exit sequences directly to `stdout` (no async, no Dart-side state assumptions — the process may be on its way out).
+
+**Known residual risk:** a `SIGKILL` or a hard crash of the Dart VM still leaves a broken terminal. There's no defense for that on Unix; it's accepted. (Some TUI libs install a shell-level trap via parent process; out of scope.)
+
+## The demo (`step1_demo.dart`)
+
+```dart
+import 'dart:async';
+import '../tui.dart';
+
+Future<void> main() async {
+  await Terminal.run((terminal) async {
+    String lastKey = '(none)';
+    int keyCount = 0;
+
+    void repaint() {
+      terminal.draw((b) {
+        b.fill(Cell.empty);
+        final w = terminal.cols, h = terminal.rows;
+        final boxW = 30, boxH = 5;
+        final row = (h - boxH) ~/ 2;
+        final col = (w - boxW) ~/ 2;
+        _drawBorder(b, row, col, boxH, boxW);
+        b.writeAt(row + 1, col + 2, 'Size: $w × $h');
+        b.writeAt(row + 2, col + 2, 'Last key: $lastKey ($keyCount)');
+        b.writeAt(row + 3, col + 2, '(q to quit)');
+      });
+    }
+
+    repaint();
+    terminal.resizes.listen((_) => repaint());
+
+    await for (final event in terminal.keys) {
+      keyCount++;
+      lastKey = _describe(event);
+      if (event is CharKey && event.rune == 0x71 /* q */) break;
+      repaint();
+    }
+  });
+}
+```
+
+(Helper `_drawBorder` and `_describe` are inline in the demo file.)
+
+**What this proves:**
+
+- Alt-screen entry/exit and terminal restore (kill the process or press q, terminal should look untouched).
+- CellBuffer painting and diff output (no flicker, no full-screen repaints on every key).
+- Key event parsing (arrows show up as ↑ ↓ ← →, q quits, ctrl-C exits cleanly).
+- Resize handling (resize terminal during run, box re-centers).
+- Crash safety (replace `b.writeAt(...)` with `throw 'oops'` — terminal still restores).
+
+## Testing strategy
+
+Unit tests for the parts that don't touch a real terminal:
+
+- **`CellBuffer`** — write/read round-trip, bounds clipping, fill/fillRect.
+- **`encodeDiff`** — given two synthetic buffers, assert exact escape sequence output. Several cases: no changes, single cell change, run of changes in one row, changes across rows, fg/bg/style transitions, default-color reset.
+- **`input.dart` parser** — feed canned byte sequences (as `Stream<List<int>>`), assert emitted `KeyEvent`s. Cover: ASCII, ctrl-letters, all arrow forms (CSI and SS3), CSI with modifier params, multi-byte UTF-8, the escape-vs-prefix ambiguity.
+
+Integration test for `Terminal` is harder (needs a pty). For stage 1, the demo program serves as manual integration test. Automated pty-driven testing is a follow-up stage if it earns its keep.
+
+## Open questions deferred to later stages
+
+- Mouse input parsing (stage 2 or 3).
+- Wide-character / emoji width (stage 4, when `Text` widget arrives).
+- Windows terminal quirks (lack of SIGWINCH, ConPTY raw-mode setup).
+- Capability detection (does this terminal support 24-bit color? Does it understand a particular CSI sequence?).
+- A frame scheduler for animations (stage 4 alongside `Ticker`).
+
+## Success criteria for stage 1
+
+The demo runs, behaves as described, and the codebase is structured such that stage 2 can build a paint kit on top of `CellBuffer` without touching anything in `terminal.dart`, `input.dart`, or `ansi.dart`. If we have to refactor those for stage 2, the boundary was wrong.

--- a/docs/superpowers/specs/2026-05-14-tui-step1-inline-mode-design.md
+++ b/docs/superpowers/specs/2026-05-14-tui-step1-inline-mode-design.md
@@ -1,0 +1,211 @@
+# TUI Step 1 — Inline Mode (extension)
+
+**Status:** Draft
+**Date:** 2026-05-14
+**Scope:** Add an inline rendering mode to the existing stage 1 engine, so the framework supports both full-screen (alt-screen) and inline (fixed-height region at the cursor) use cases. This is a stage-1 extension, not a separate stage — it ships in the same branch.
+
+**Extends:** [`2026-05-14-tui-step1-engine-design.md`](./2026-05-14-tui-step1-engine-design.md)
+
+---
+
+## Context
+
+The original stage 1 design assumed full-screen, alt-screen rendering. Reviewing it against ratatui's inline mode (`ratatui::Terminal::with_options(Viewport::Inline(N))`), inline mode is a strictly more useful default for many CLI scenarios — including the immediate flutterware use case where the long-running CLI in `app/bin/flutterware.dart` wants a "dashboard at the bottom of the terminal while normal output continues to scroll above" UX rather than full-screen takeover.
+
+The engine layer is already mode-agnostic. `CellBuffer`, `encodeDiff`, and `parseKeyEvents` don't care whether their output covers the whole screen or a small region. The full-screen assumption lives entirely inside `Terminal`. This extension makes the mode an explicit parameter.
+
+## Goals
+
+1. A `TerminalMode` API on `Terminal.run` that supports both `fullScreen()` (current behavior, default) and `inline({required int rows})`.
+2. Inline mode renders an N-row region anchored at the cursor's position when `Terminal.run` started. Normal terminal scrollback above is preserved on exit.
+3. `encodeDiff` becomes coordinate-origin-aware so the same diff pipeline drives both modes.
+4. A working inline demo (`inline_demo.dart`) demonstrating the mode.
+
+## Non-goals (for this round)
+
+- **No `print_above` / `insert_before`** — i.e. no API for "scroll log lines into the scrollback above the inline region while the region stays put". This is the natural next feature after inline-mode lands, but it's out of scope here. The architecture must not preclude it.
+- **No relative-move rendering.** Inline mode still uses absolute `\x1b[r;cH` positioning, just offset by the region's anchor row. This is simpler and works for stage 1.5; if `print_above` lands later and needs relative anchoring, we'll revisit at that time.
+- **No height-on-resize.** If the terminal shrinks below the inline region's reserved height, the buffer keeps its declared height and painting clips naturally (CellBuffer already handles OOB writes). Width does adjust on SIGWINCH.
+- **No "anchor moves with output above".** Once the inline region is anchored at startup, its absolute row stays put. If the user prints to stdout from outside the TUI in a way that scrolls the terminal, the region will drift. This is acceptable for stage 1.5 because the inline TUI body owns the output channel. `print_above` (deferred) is what would fix this.
+- **No automatic "follow the cursor" mode.** Inline starts at the cursor's current position at `Terminal.run` entry, and that position is captured once. There's no support for repositioning.
+
+## Architecture
+
+### `TerminalMode` sealed class
+
+```dart
+sealed class TerminalMode {
+  const TerminalMode();
+  factory TerminalMode.fullScreen() = FullScreenMode;
+  factory TerminalMode.inline({required int rows}) = InlineMode;
+}
+final class FullScreenMode extends TerminalMode {
+  const FullScreenMode();
+}
+final class InlineMode extends TerminalMode {
+  final int rows;
+  const InlineMode({required this.rows}) : assert(rows > 0);
+}
+```
+
+Public surface stays minimal: callers pass `TerminalMode.fullScreen()` (or omit for the default) or `TerminalMode.inline(rows: 8)`. The sealed hierarchy keeps the door open if we ever need polymorphism, but stage 1.5 just switches on `mode` directly in `Terminal`.
+
+### `Terminal.run` signature change
+
+```dart
+static Future<void> run(
+  FutureOr<void> Function(Terminal terminal) body, {
+  TerminalMode mode = const FullScreenMode(),
+});
+```
+
+Default value is `const FullScreenMode()` so all existing call sites keep working unchanged. The `step1_demo.dart` doesn't change.
+
+### `encodeDiff` signature change
+
+```dart
+String encodeDiff(
+  CellBuffer front,
+  CellBuffer back, {
+  int originRow = 0,
+  int originCol = 0,
+});
+```
+
+Adds two named parameters defaulting to 0. Inside the function, each `Ansi.moveTo(r, c)` call becomes `Ansi.moveTo(r + originRow, c + originCol)`. That's the only line that changes; everything else (cursor-advance tracking, SGR coalescing) is unchanged.
+
+### `Terminal` internal state additions
+
+```dart
+class Terminal {
+  final TerminalMode _mode;
+  int _originRow = 0;     // absolute row of buffer (0, 0)
+  int _originCol = 0;     // absolute col of buffer (0, 0)
+  // existing _front, _back, _rows, _cols, ...
+}
+```
+
+For full-screen mode, `_originRow`/`_originCol` stay 0 and the buffer covers the whole viewport (existing behavior). For inline mode, `_originRow` is captured at entry from where the cursor was, and `_cols` mirrors `stdout.terminalColumns` while `_rows` is fixed to `InlineMode.rows`.
+
+### Computing the inline region's anchor row
+
+`encodeDiff` emits absolute `\x1b[<r>;<c>H` moves with the `originRow`/`originCol` offset added. So `Terminal` needs to know the absolute row of the inline region's top-left corner. We capture that row once at entry, via a cursor-position query:
+
+1. Reserve vertical space: print `'\n' * rows` (the terminal scrolls the viewport up if there's no room below the cursor — exactly what we want).
+2. Move cursor back: `\x1b[<rows>F` (CPL — cursor previous line) brings the cursor to column 0 of what will become the region's top row.
+3. Briefly pause the key parser's stdin listener (or attach an intercepting filter).
+4. Write `\x1b[6n` (DSR — device status report). The terminal responds on stdin with `\x1b[<r>;<c>R`.
+5. Read bytes from stdin until we get the response. Parse `<r>` as the 1-indexed absolute row; store `_originRow = r - 1` (0-indexed) and `_originCol = 0`.
+6. Resume / un-filter the key parser. Any non-DSR bytes received during step 5 (e.g. keystrokes the user happened to type during entry) are forwarded to the parser as if they'd arrived normally.
+
+If the terminal doesn't respond within ~200ms (rare — basically only headless test terminals), we fall back to `_originRow = stdout.terminalLines - rows` (best-guess). The fallback is documented as imperfect; an inline TUI in a non-responsive terminal will paint at the bottom of the viewport and may behave oddly if the viewport doesn't auto-scroll.
+
+**Why not use DECSC/DECRC (cursor save/restore)?** They'd avoid needing the absolute row — the terminal remembers the anchor for us. But `encodeDiff` emits absolute `CSI r;cH` positioning, so the cursor's "current" position doesn't help. We'd have to either rewrite the encoder to use relative moves (out of scope; see Non-goals) or query the absolute row anyway. Querying once at entry and offsetting all moves is the simpler path.
+
+Implementation: the query/parse logic lives in a new private helper inside `terminal.dart` (estimate ~40 lines including the parser-pause/intercept dance). It runs exactly once, during `_enter()` in inline mode, and isn't needed for full-screen mode.
+
+### Lifecycle differences
+
+```
+                       FullScreenMode              InlineMode
+─────────────────────────────────────────────────────────────
+_enter() writes        enterAltScreen              hideCursor
+                       hideCursor                  '\n' * rows  (reserve space)
+                       clearScreen                 CSI <rows> F (back to top)
+                       moveTo(0, 0)                (then query cursor pos for
+                                                    _originRow — see above)
+
+buffer size            cols × terminalLines        cols × InlineMode.rows
+_originRow             0                           captured at entry
+_originCol             0                           0
+draw() origin          (0, 0) passed to            (_originRow, 0) passed to
+                       encodeDiff                  encodeDiff
+
+_onResize()            reallocate cols × lines     reallocate cols × InlineMode.rows
+                       full clearScreen            do NOT re-anchor; just resize
+                                                   buffers and signal the user
+
+_restore() writes      resetStyle                  resetStyle
+                       showCursor                  Ansi.moveTo(_originRow, 0)
+                       exitAltScreen               CSI J  (clear to end of screen)
+                                                   showCursor
+                                                   '\n'  (move cursor below region
+                                                   so next shell prompt starts on
+                                                   a fresh line)
+```
+
+### SIGWINCH in inline mode
+
+When the terminal is resized:
+
+- `terminalColumns` may change → reallocate `_front` and `_back` at `(InlineMode.rows, newCols)`.
+- `terminalLines` may change → could push the inline region off-screen if the terminal shrinks below `_originRow + rows`. In stage 1.5, we accept this: the region stays at the captured `_originRow`, and if it's now off-screen, paint output writes to invisible cells. The next time the terminal grows back, the region reappears.
+
+A more robust approach (re-anchoring on resize) is deferred. It's doable but adds complexity around "the cursor isn't at the anchor anymore after a resize-induced scroll".
+
+### Crash-safe restore in inline mode
+
+The three-layer safety from full-screen mode (try/finally, runZonedGuarded, signal handlers) carries over unchanged. The `_restore()` sequence for inline mode:
+
+1. `\x1b[0m` — reset style.
+2. `Ansi.moveTo(_originRow, 0)` — position cursor at the anchor (absolute).
+3. `\x1b[J` — clear from cursor to end of screen (wipes the region and any output below it within the viewport).
+4. `\x1b[?25h` — show cursor.
+5. `\n` — move cursor one line below so the next shell prompt starts fresh.
+6. Restore stdin echo/line modes.
+
+If the process crashes hard before `_originRow` was captured (e.g. uncaught error inside the cursor-position query helper), `_originRow` defaults to 0 and step 2 would move the cursor to absolute row 0. To avoid trashing the user's shell scrollback in that early-crash case, `_restore()` guards on a separate `_anchored` flag set only after the cursor query succeeds (or its fallback runs). If `!_anchored`, the inline-mode restore skips steps 2 and 3 entirely and just writes the style reset, cursor show, and a newline.
+
+## Coordinate translation summary
+
+The mental model:
+
+- The user's `draw((buf) => ...)` paints into `buf`, whose coordinate origin `(0, 0)` is the top-left of the inline region.
+- The `Terminal` adds `(_originRow, _originCol)` to every absolute move emitted by `encodeDiff`.
+- For full-screen mode, `(_originRow, _originCol)` is `(0, 0)` and the behavior is identical to today.
+
+## Public API summary
+
+```dart
+// Existing, unchanged behavior:
+await Terminal.run((t) async { ... });
+await Terminal.run((t) async { ... }, mode: TerminalMode.fullScreen());
+
+// New:
+await Terminal.run((t) async {
+  t.draw((b) {
+    b.writeAt(0, 0, 'Status: running');
+    b.writeAt(1, 0, 'Tests: 42 passing');
+  });
+  await for (final key in t.keys) { /* ... */ }
+}, mode: TerminalMode.inline(rows: 5));
+```
+
+## Files touched
+
+- **Modify** `app/lib/src/tui/ansi.dart` — add `originRow`/`originCol` to `encodeDiff`. Existing tests still pass (default 0/0 = unchanged behavior). Add 1-2 new tests for the offset case.
+- **Modify** `app/lib/src/tui/terminal.dart` — `TerminalMode` sealed class, optional `mode` parameter on `Terminal.run`, mode-aware `_enter` / `_onResize` / `_restore` / `draw`. Add cursor-position query helper. The `_keysController` and `parseKeyEvents` wiring needs a "pause/resume + intercept" capability for the position query.
+- **Modify** `app/lib/src/tui/tui.dart` — export the new `TerminalMode` types.
+- **Create** `app/lib/src/tui/example/inline_demo.dart` — demonstrates inline mode.
+- **Modify** `app/test/tui/ansi_test.dart` — 1-2 tests for the `originRow`/`originCol` offset behavior.
+
+Estimated total: ~250-350 lines of additions (largely in terminal.dart) plus ~50 lines of tests.
+
+## Success criteria
+
+1. All existing tests still pass without modification (default `mode` keeps behavior identical).
+2. New offset tests for `encodeDiff` pass.
+3. `inline_demo.dart` runs in a real terminal:
+   - Shows a small status panel at the cursor.
+   - Normal shell output is preserved above on entry.
+   - Pressing keys updates the panel.
+   - Pressing `q` exits, the region is cleared, and the next shell prompt appears below where the region was.
+   - Resizing the terminal width reflows the panel; resizing the height doesn't shift the anchor (acceptable for stage 1.5).
+4. The full-screen demo (`step1_demo.dart`) still works identically.
+
+## Open questions deferred
+
+- `print_above`/`insert_before` capability.
+- Re-anchoring on terminal-height shrink.
+- Headless test mode (a `Terminal` variant that paints into an in-memory sink for golden-file testing).
+- Multiplexer (tmux/screen) quirks around `\x1b[6n` cursor-position queries.

--- a/docs/superpowers/tui-roadmap.md
+++ b/docs/superpowers/tui-roadmap.md
@@ -1,0 +1,102 @@
+# TUI framework — roadmap
+
+This document tracks the staged plan for building a Flutter-style terminal UI
+framework in `app/lib/src/tui/`, and records the design decisions made along
+the way. It is the index over the per-stage specs and plans in
+`docs/superpowers/specs/` and `docs/superpowers/plans/`.
+
+## The idea
+
+Flutter's genius is its reactive pipeline — the Widget tree (immutable config),
+the Element tree (mounted instances + state), and the RenderObject tree (layout
++ paint). That machinery is **rendering-backend agnostic**: it doesn't care
+whether the final output is pixels via Skia or characters via ANSI escape
+codes. The plan is to keep that upper architecture and replace the
+pixel-shaped render/engine layers with terminal-shaped ones.
+
+The end goal is a full-screen TUI; the immediate, concrete consumer is the
+flutterware CLI in `app/`, which today uses line-oriented logger output and
+could use a richer status/dashboard UI.
+
+## Stages
+
+| Stage | What it delivers | Status |
+|-------|------------------|--------|
+| **1. Engine** | Terminal lifecycle, `CellBuffer`, diff-to-ANSI, key parsing, crash-safe restore | ✅ Done |
+| **1.5 Inline mode** | A fixed-height region anchored at the cursor, alongside full-screen | ✅ Done |
+| **`print_above`** | Print log lines into scrollback above an inline region | ⏳ Next |
+| **2. Paint kit** | `Rect`/`CellSize` geometry + procedural paint helpers (text, border, fill) | ⬜ Not started |
+| **3. Render tree** | `RenderObject`/`RenderBox`, `BoxConstraints`, `Row`/`Column`/`Padding` | ⬜ Not started |
+| **4. Widget layer** | `Widget`/`Element`, `StatelessWidget`/`StatefulWidget`, `setState` | ⬜ Not started |
+| **5. Integration** | Replace the flutterware CLI startup UX with a real TUI screen | ⬜ Not started |
+
+Each stage is independently useful: after stage 1 you have a working terminal
+library; after stage 3 you have a layout engine; after stage 4 you have the
+framework.
+
+### Detailed docs per stage
+
+- Stage 1 — [spec](specs/2026-05-14-tui-step1-engine-design.md) ·
+  [plan](plans/2026-05-14-tui-step1-engine.md)
+- Stage 1.5 inline mode — [spec](specs/2026-05-14-tui-step1-inline-mode-design.md) ·
+  [plan](plans/2026-05-14-tui-step1-inline-mode.md)
+
+## Key design decisions
+
+Recorded so future work doesn't re-litigate them:
+
+- **Cells, not pixels.** Layout reuses Flutter's box protocol (`BoxConstraints`,
+  parent passes constraints down, child returns a size) — the only change is
+  the unit: terminal cells instead of logical pixels. Text layout becomes
+  trivial because a monospace cell is one grapheme.
+- **Shared-buffer painting.** Render objects paint into one shared `CellBuffer`
+  with an offset, like Skia's `Canvas` — not by each returning its own buffer.
+  Avoids per-frame allocation.
+- **Always double-buffer + diff.** `encodeDiff` compares the just-painted back
+  buffer to the on-screen front buffer and emits ANSI only for changed cells.
+  Skipping this would mean visible flicker and ~2 KB of escapes per frame.
+- **Reimplement the engine; transcribe the framework.** Stages 1–3 are written
+  from scratch — Flutter's render layer is pixel/Skia-shaped, there's nothing
+  to copy. Stage 4 is where transcribing `package:flutter`'s
+  `framework.dart` pays off: the Widget/Element machinery (rebuild scheduling,
+  `GlobalKey`, `InheritedWidget`) is backend-agnostic and full of hard-won edge
+  cases.
+- **Location: `app/lib/src/tui/`.** Inside the `flutterware_app` package
+  (`publish_to: none`), because the consuming CLI lives there and that package
+  tolerates new dependencies if ever needed. Promotable to a standalone package
+  later if it earns it.
+- **Zero pub dependencies.** The whole engine is `dart:io` + `dart:async`. A
+  goal worth preserving through later stages where practical.
+- **Two terminal modes.** Full-screen (alt-screen takeover) and inline (a
+  fixed-height region at the cursor). `TerminalMode` is a sealed class so the
+  set is closed and exhaustively switchable.
+
+## `print_above` — the next step
+
+Inline mode renders a fixed region anchored at the cursor. `print_above` (the
+ratatui `insert_before` capability) lets inline-mode code emit log/output lines
+that scroll into the terminal scrollback **above** the region, without
+disturbing the region itself.
+
+It was deliberately scoped out of the inline-mode work — see the "Non-goals"
+and "Open questions deferred" sections of the
+[inline-mode spec](specs/2026-05-14-tui-step1-inline-mode-design.md). The core
+design tension: printing above the region shifts it down, so the region's
+absolute anchor row (`_originRow` in `terminal.dart`) drifts and must be kept
+in sync. The likely approach is a `Terminal.printAbove` that moves the cursor
+to the region's top, opens space with insert-line (`ESC[L`) or a scroll-region
+command, writes the lines, and bumps `_originRow`.
+
+## Known limitations carried forward
+
+These are accepted in stage 1 and should be revisited as later stages land:
+
+- Non-tty stdin throws `StdinException` on startup (before alt-screen entry —
+  no terminal damage). A try/catch with a fallback would fix it.
+- A microsecond-wide window during inline-mode entry where a keystroke could be
+  dropped, between the cursor-query subscription cancelling and the key parser
+  subscribing.
+- No re-anchoring when the terminal height shrinks below the inline region.
+- No wide-character / emoji width handling — deferred to stage 4, when the
+  `Text` widget arrives. The `Cell.width` field is reserved for it.
+- Windows: signal-driven features (resize via SIGWINCH) are Unix-only.


### PR DESCRIPTION
## Summary

Adds a Flutter-style terminal UI engine under `app/lib/src/tui/` — the foundation for a future TUI alternative to the GUI app, and richer output for the long-running CLI. This is **stage 1**: the engine layer only (no widgets/layout/render-tree yet — those are later stages).

Two rendering modes:
- **Full-screen** — takes over the terminal via the alt-screen buffer.
- **Inline** — a fixed-height region anchored at the cursor, with normal scrollback preserved above (think `cargo`/`npm` status panels).

## What's included

- `cell.dart` — `Cell`, `Color` (default / 16 ANSI / 24-bit RGB), `TextStyle` bitfield.
- `buffer.dart` — `CellBuffer`, a clipping row-major grid.
- `ansi.dart` — ANSI escape constants, SGR encoders, and `encodeDiff` (back/front buffer diff → minimal escape sequences, with cursor + SGR coalescing and an `originRow`/`originCol` offset for sub-region rendering).
- `input.dart` — `parseKeyEvents`: raw stdin → `KeyEvent` stream (ASCII, ctrl-modifiers, CSI/SS3 arrows & function keys, UTF-8, chunk-boundary reassembly).
- `cursor_query.dart` — cursor-position query helper (`\x1b[6n`) used to anchor the inline region.
- `terminal.dart` — `Terminal` lifecycle: alt-screen / inline entry, raw mode, SIGWINCH/SIGINT/SIGTERM/SIGHUP, double-buffered painting, three-layer crash-safe restore.
- Two runnable showcases under `app/examples/tui/`.

Design specs and implementation plans are in `docs/superpowers/`.

**78 unit tests, `dart analyze` clean, zero new pub dependencies.**

## Known limitations (deferred, not blockers)

- Non-tty stdin throws `StdinException` on startup (before alt-screen entry — no terminal damage). Trivial try/catch fix later; the flutterware CLI always runs attached to a tty.
- A microsecond-wide window during inline-mode entry where a keystroke could be dropped (between the cursor-query subscription cancelling and the key parser subscribing).
- No re-anchoring when the terminal height shrinks below the inline region — it paints offscreen until grown back.

## Test plan

- [x] `cd app && dart test test/tui/` — 78 tests pass
- [x] `cd app && dart analyze lib/src/tui/ examples/tui/` — no issues
- [x] Manual: `dart run app/examples/tui/step1_demo.dart` — full-screen showcase (color swatches, RGB gradient, text styles, live stats, key log)
- [x] Manual: `dart run app/examples/tui/inline_demo.dart` — inline build-status panel (animated progress bar, spinner, scrollback preserved)
- [ ] Reviewer: confirm both demos behave as described on their terminal

🤖 Generated with [Claude Code](https://claude.com/claude-code)