### PR TITLE
Add pre-commit hook that formats staged Dart files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,26 @@
+# Contributing
+
+## Development setup
+
+```sh
+flutter pub get
+dart tool/install_hooks.dart
+```
+
+`install_hooks.dart` points git at the version-controlled `hooks/` directory
+(`core.hooksPath=hooks`). Run it once per clone — and once per added worktree,
+since `core.hooksPath` is shared but each worktree needs it set.
+
+## Pre-commit hook
+
+`hooks/pre-commit` formats staged Dart files (and re-stages them) before each
+commit, so unformatted code never reaches CI. It compiles
+`tool/format_pre_commit.dart` to a cached AOT binary on first use — subsequent
+commits are near-instant.
+
+The hook uses the same formatter configuration as `tool/prepare_submit.dart`
+(which CI runs); keep the two in sync. Code style beyond formatting (analyzer
+lints) is still enforced by CI, not the hook.
+
+If dependencies aren't resolved yet, the hook skips itself gracefully and lets
+the commit through — run `flutter pub get` to enable it.

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,0 +1,55 @@
+#!/bin/bash
+# Pre-commit hook — formats staged Dart files so unformatted code never
+# reaches CI. Enabled per-clone via `core.hooksPath=hooks`; run once:
+#
+#   dart tool/install_hooks.dart
+#
+# Compiles tool/format_pre_commit.dart to an AOT binary the first time it
+# runs, and whenever its source or the relevant pubspec.lock entries change.
+# Every subsequent commit just execs the cached binary — no `pub get`, no
+# `dart run`, near-instant.
+
+set -e
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+BIN=build/pre_commit
+LOCKHASH=build/pre_commit.lockhash
+SOURCE=tool/format_pre_commit.dart
+
+# Hash only the pubspec.lock entries we compile against, so unrelated
+# dependency bumps don't force a rebuild.
+relevant_lockhash() {
+  awk '
+    /^  (analyzer|dart_style|path|project_tools|pub_semver):/ {p=1; print; next}
+    /^  [a-z][a-z0-9_]*:[[:space:]]*$/ {p=0}
+    p
+  ' pubspec.lock | cksum | awk '{print $1"-"$2}'
+}
+
+CURRENT_LOCKHASH=$(relevant_lockhash)
+
+needs_build=0
+if [ ! -x "$BIN" ]; then
+  needs_build=1
+elif [ ! -f "$LOCKHASH" ] || [ "$(cat "$LOCKHASH")" != "$CURRENT_LOCKHASH" ]; then
+  needs_build=1
+elif [ "$SOURCE" -nt "$BIN" ]; then
+  needs_build=1
+fi
+
+if [ "$needs_build" = 1 ]; then
+  # Compiling needs resolved deps. If they're missing, skip the hook
+  # gracefully rather than block the commit — CI still catches formatting.
+  if [ ! -f .dart_tool/package_config.json ]; then
+    echo "pre-commit: deps not resolved — run 'flutter pub get' to enable the format hook"
+    exit 0
+  fi
+  echo "pre-commit: building $BIN..."
+  mkdir -p build
+  dart compile exe "$SOURCE" -o "$BIN"
+  echo "$CURRENT_LOCKHASH" > "$LOCKHASH"
+fi
+
+exec "$BIN"

--- a/tool/format_pre_commit.dart
+++ b/tool/format_pre_commit.dart
@@ -51,12 +51,15 @@ Directory _gitRoot() {
 }
 
 List<String> _stagedDartFiles(Directory gitRoot) {
-  final result = Process.runSync('git', [
-    'diff',
-    '--cached',
-    '--name-only',
-    '--diff-filter=ACMR',
-  ], workingDirectory: gitRoot.path);
+  final result = Process.runSync(
+      'git',
+      [
+        'diff',
+        '--cached',
+        '--name-only',
+        '--diff-filter=ACMR',
+      ],
+      workingDirectory: gitRoot.path);
   if (result.exitCode != 0) {
     throw StateError('git diff --cached failed: ${result.stderr}');
   }

--- a/tool/format_pre_commit.dart
+++ b/tool/format_pre_commit.dart
@@ -1,0 +1,68 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:project_tools/project_tools.dart';
+
+/// Formats staged Dart files and re-stages them, so unformatted code never
+/// reaches CI. Invoked by `hooks/pre-commit`.
+///
+/// The formatter config must stay in sync with `tool/prepare_submit.dart` —
+/// CI runs that one and fails if it produces any change.
+///
+/// Git-root and staged-file detection are done with `git` directly rather
+/// than `project_tools`' `findGitRootOrThrow`, because the latter only
+/// recognizes a `.git` directory and fails inside a git worktree (where
+/// `.git` is a file). Flutterware is developed across worktrees.
+Future<void> main() async {
+  final gitRoot = _gitRoot();
+  final projects = DartProject.find(gitRoot)
+    ..sort((a, b) => b.path.length.compareTo(a.path.length));
+
+  final formatter = DartFormatter(languageVersion: Version(3, 5, 0));
+
+  final modified = <ProjectFile>[];
+  for (final absPath in _stagedDartFiles(gitRoot)) {
+    final file = projects.findFile(absPath);
+    if (file == null) continue;
+    if (formatFile(file, formatter)) modified.add(file);
+  }
+
+  if (modified.isEmpty) return;
+
+  // Give the filesystem a moment to settle before re-staging.
+  await Future<void>.delayed(const Duration(seconds: 1));
+  for (final file in modified) {
+    Process.runSync('git', [
+      'add',
+      p.join(file.project.path, file.relativePath),
+    ]);
+    print('pre-commit: formatted ${file.project.packageName}:'
+        '${file.relativePath}');
+  }
+}
+
+Directory _gitRoot() {
+  final result = Process.runSync('git', ['rev-parse', '--show-toplevel']);
+  if (result.exitCode != 0) {
+    throw StateError('git rev-parse --show-toplevel failed: ${result.stderr}');
+  }
+  return Directory((result.stdout as String).trim());
+}
+
+List<String> _stagedDartFiles(Directory gitRoot) {
+  final result = Process.runSync('git', [
+    'diff',
+    '--cached',
+    '--name-only',
+    '--diff-filter=ACMR',
+  ], workingDirectory: gitRoot.path);
+  if (result.exitCode != 0) {
+    throw StateError('git diff --cached failed: ${result.stderr}');
+  }
+  return LineSplitter.split(result.stdout as String)
+      .where((line) => line.isNotEmpty && line.endsWith('.dart'))
+      .map((rel) => p.join(gitRoot.path, rel))
+      .where((abs) => File(abs).existsSync())
+      .toList();
+}

--- a/tool/install_hooks.dart
+++ b/tool/install_hooks.dart
@@ -1,0 +1,15 @@
+import 'dart:io';
+
+/// One-time setup: point git at the version-controlled `hooks/` directory.
+/// Run once per clone (or worktree checkout):
+///
+///   dart tool/install_hooks.dart
+void main() {
+  final result = Process.runSync('git', ['config', 'core.hooksPath', 'hooks']);
+  if (result.exitCode != 0) {
+    stderr.writeln('Failed to set core.hooksPath: ${result.stderr}');
+    exit(1);
+  }
+  print('Git hooks enabled — commits now run ./hooks/pre-commit '
+      '(core.hooksPath=hooks).');
+}


### PR DESCRIPTION
## Summary

Adds a git pre-commit hook that formats staged Dart files (and re-stages them) before each commit, so unformatted code never reaches CI's `prepare_submit.dart` check. Adapted from the equivalent setup in another project, simplified to Dart-only.

- **`hooks/pre-commit`** — bash hook. AOT-compiles `tool/format_pre_commit.dart` to a cached binary on first use (and when its source or relevant `pubspec.lock` entries change); every later commit just execs the cache — no `pub get`, no `dart run`, near-instant. Skips itself gracefully if deps aren't resolved.
- **`tool/format_pre_commit.dart`** — formats staged `.dart` files using the same formatter config as `tool/prepare_submit.dart` (which CI runs), so the hook and CI agree. Git-root and staged-file detection use `git` directly rather than `project_tools`' `findGitRootOrThrow`, which only recognizes a `.git` directory and fails inside git worktrees.
- **`tool/install_hooks.dart`** — one-time `core.hooksPath=hooks` setup.
- **`CONTRIBUTING.md`** — development setup instructions.

## Why

The hook is version-controlled under `hooks/` and enabled per-clone with `dart tool/install_hooks.dart`. It catches formatting drift locally; analyzer lints remain CI's responsibility (kept out of the hook to keep commits fast).

## Test plan

- [x] Hook compiles and runs; formats a deliberately-misformatted staged file and re-stages it
- [x] Build cache: no rebuild when unchanged, rebuilds when source changes
- [x] Works inside a git worktree (where `.git` is a file, not a directory)
- [ ] `dart tool/install_hooks.dart` on a fresh clone, then a real commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)