### PR TITLE
Add print_above to the TUI engine (stage 1 extension)

### DIFF
--- a/app/examples/tui/print_above_demo.dart
+++ b/app/examples/tui/print_above_demo.dart
@@ -1,20 +1,46 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:flutterware_app/src/tui/tui.dart';
 
-/// print_above showcase: a simulated `flutter build` whose log lines stream
-/// into the terminal scrollback while a status panel stays pinned below.
+/// print_above mechanism demo — an instrumented, step-through walkthrough of
+/// how [Terminal.printAbove] scrolls log lines into the terminal scrollback
+/// above an anchored inline region.
 ///
-/// Exercises [Terminal.printAbove] (colored log lines into scrollback),
-/// the region staying intact and re-anchored after each insert, and a
-/// timer-driven animated panel rendered with [Terminal.draw].
+/// The bordered inline panel shows the live state of the mechanism: the
+/// region's anchor row (`_originRow`), the terminal height, the "pin point",
+/// the drift-vs-pinned phase, and how many lines have scrolled off into
+/// scrollback. A horizontal gauge stands in for the vertical screen so the
+/// region's position is visible at a glance. Each emitted line narrates what
+/// that single `printAbove` call did, so the scrollback itself becomes a
+/// readable transcript of the mechanism.
+///
+/// Controls: [space] emit one line · [a] toggle auto-play · [q] quit.
 Future<void> main() async {
-  print('--- flutterware build (print_above demo) ---');
-  await Terminal.run(_dashboard, mode: const InlineMode(rows: 5));
-  print('--- build finished; back to normal shell output ---');
+  print('print_above — scrolling mechanism demo');
+  print('');
+  print('The bordered panel below is an inline region. Every log line above');
+  print('it is emitted by ONE Terminal.printAbove(1, ...) call. The mechanism');
+  print('has two phases:');
+  print('');
+  print('  DRIFTING  the region has empty rows below it, so a new line just');
+  print('            pushes the region DOWN — nothing leaves the screen and');
+  print('            the anchor row (_originRow) increases by one.');
+  print('  PINNED    the region sits on the last screen row, so a new line');
+  print('            SCROLLS the screen — the top line drops into real');
+  print('            scrollback and the anchor row stays put.');
+  print('');
+  print('Tip: launch this in a tall terminal with lots of empty space below');
+  print('the prompt to watch the DRIFTING phase first. With the prompt near');
+  print('the bottom the region anchors there and starts already PINNED.');
+  print('');
+
+  await Terminal.run(_demo, mode: const InlineMode(rows: 9));
+
+  print('--- demo exited; the narrated log lines remain in scrollback ---');
 }
 
-// Braille spinner frames.
+// Braille spinner frames, for liveness.
 const _spinner = [
   0x280B,
   0x2819,
@@ -28,153 +54,217 @@ const _spinner = [
   0x280F,
 ];
 
-// A scripted build log: (level, message). level: 0 info, 1 warn, 2 error.
-const _script = <(int, String)>[
-  (0, 'Resolving dependencies...'),
-  (0, 'Got dependencies.'),
-  (0, 'Running Gradle task assembleDebug...'),
-  (0, 'Compiling lib/main.dart'),
-  (0, 'Compiling lib/src/app.dart'),
-  (1, 'lib/src/app.dart:42: unused import'),
-  (0, 'Compiling lib/src/widgets/home.dart'),
-  (0, 'Compiling lib/src/widgets/details.dart'),
-  (1, 'lib/src/widgets/details.dart:88: deprecated API'),
-  (0, 'Linking native libraries'),
-  (2, 'ld: duplicate symbol _kFoo (recovered)'),
-  (0, 'Bundling assets'),
-  (0, 'Optimizing icon tree-shaking'),
-  (0, 'Signing build/app/outputs/apk/debug/app-debug.apk'),
-  (0, 'Built build/app/outputs/apk/debug/app-debug.apk (24.1MB)'),
-];
-
-Future<void> _dashboard(Terminal terminal) async {
-  final start = DateTime.now();
-  var frames = 0;
+Future<void> _demo(Terminal terminal) async {
   var emitted = 0;
-  var warns = 0;
-  var errors = 0;
-  var done = false;
+  var scrolledOff = 0;
+  var auto = false;
+  var frames = 0;
+  var lastNote = 'press [space] to emit the first line';
+
+  int screenHeight() => stdout.terminalLines;
+  int pinPoint() => screenHeight() - terminal.rows;
 
   void repaint() {
     frames++;
     terminal.draw((b) {
       final w = terminal.cols;
-      _drawBorder(b, 0, 0, terminal.rows, w, title: ' flutterware build ');
+      final origin = terminal.originRow;
+      final pin = pinPoint();
+      final drifting = origin < pin;
+      final spin = String.fromCharCode(_spinner[frames % _spinner.length]);
 
-      final progress = (emitted / _script.length * 100).round();
-      final color = done ? Color.brightGreen : Color.brightCyan;
+      _drawBorder(b, terminal.rows, w,
+          title: ' print_above · scrolling mechanism $spin ');
 
-      // Row 1: spinner + phase label.
-      b.set(
-          1,
-          2,
-          Cell(
-              rune: done
-                  ? 0x2714 /* heavy check */
-                  : _spinner[frames % _spinner.length],
-              fg: color));
-      b.writeAt(1, 4, done ? 'Build complete' : 'Building...',
-          style: TextStyle.bold, fg: color);
-
-      // Row 2: progress bar + percentage.
-      final barStart = 2;
-      final barEnd = w - 8;
-      final barWidth = (barEnd - barStart).clamp(0, w);
-      final filled = (barWidth * progress / 100).round();
-      for (var i = 0; i < barWidth; i++) {
-        b.set(
-          2,
-          barStart + i,
-          i < filled
-              ? Cell(rune: 0x2588, fg: color)
-              : const Cell(rune: 0x2591, fg: Color.brightBlack),
-        );
+      // Row 1 — current phase.
+      b.writeAt(1, 2, 'PHASE', style: TextStyle.bold);
+      if (drifting) {
+        b.writeAt(1, 8, 'DRIFTING',
+            fg: Color.brightYellow, style: TextStyle.bold);
+        b.writeAt(1, 17,
+            '— ${pin - origin} row(s) of headroom; next line moves the region down',
+            style: TextStyle.dim);
+      } else {
+        b.writeAt(1, 8, 'PINNED', fg: Color.brightGreen, style: TextStyle.bold);
+        b.writeAt(1, 15,
+            '— region on the last row; next line scrolls into scrollback',
+            style: TextStyle.dim);
       }
-      b.writeAt(2, barEnd + 1, '${progress.toString().padLeft(3)}%', fg: color);
 
-      // Row 3: counts + elapsed + quit hint.
-      final elapsed = DateTime.now().difference(start);
-      b.writeAt(3, 2,
-          'warnings $warns   errors $errors   elapsed ${elapsed.inSeconds}s',
-          style: TextStyle.dim);
-      b.writeAt(3, w - 19, 'press q to quit', style: TextStyle.dim);
+      // Row 2 — viewport gauge: a horizontal stand-in for the vertical
+      // screen. Left edge = screen row 0, right edge = the last screen row.
+      _drawGauge(b, 2, w,
+          origin: origin,
+          regionRows: terminal.rows,
+          screenHeight: screenHeight(),
+          scrolledOff: scrolledOff);
+
+      // Row 3 — the last action.
+      b.writeAt(3, 2, 'last: $lastNote', style: TextStyle.dim);
+
+      // Row 4/5 — the mechanism's numbers.
+      b.writeAt(
+          4,
+          2,
+          'anchor _originRow = ${origin.toString().padLeft(3)}     '
+          'screen height = ${screenHeight()}     '
+          'region rows = ${terminal.rows}',
+          fg: Color.brightCyan);
+      b.writeAt(
+          5,
+          2,
+          'pin point (height - region rows) = $pin     '
+          'next printAbove ${drifting ? "drifts the region" : "scrolls the screen"}',
+          fg: Color.brightCyan);
+
+      // Row 6 — running counts. Every emitted line is either still visible
+      // above the region or has scrolled off into scrollback.
+      b.writeAt(
+          6,
+          2,
+          'emitted = $emitted      on-screen above = ${emitted - scrolledOff}'
+          '      in scrollback = $scrolledOff',
+          style: TextStyle.bold);
+
+      // Row 7 — controls.
+      final controls =
+          '[space] emit   [a] auto:${auto ? "ON " : "off"}   [q] quit';
+      final controlsCol = (w - 2 - controls.length).clamp(2, w);
+      b.writeAt(7, controlsCol, controls, fg: Color.brightBlack);
     });
   }
 
-  // Quit when the user presses q, or 1.5s after the build finishes.
-  final quit = Completer<void>();
-  void maybeFinish() {
-    if (emitted >= _script.length && !done) {
-      done = true;
-      Timer(const Duration(milliseconds: 1500), () {
-        if (!quit.isCompleted) quit.complete();
-      });
-    }
-  }
-
-  // Emit one scripted log line into the scrollback above the panel.
-  void emitLogLine() {
-    if (emitted >= _script.length) return;
-    final (level, message) = _script[emitted];
+  // Emit one log line via a single Terminal.printAbove(1, ...) call and
+  // narrate, in the line itself, exactly what that call did.
+  void emitNext() {
+    final before = terminal.originRow;
+    final pin = pinPoint();
+    // A one-row printAbove drifts the region down by one row while it has
+    // headroom; once pinned, the anchor holds and one line scrolls off.
+    final after = before < pin ? before + 1 : before;
+    final scrolled = 1 - (after - before); // 0 while drifting, 1 once pinned
     emitted++;
-    final (tag, color) = switch (level) {
-      2 => ('ERROR', Color.brightRed),
-      1 => (' WARN', Color.brightYellow),
-      _ => (' INFO', Color.brightGreen),
-    };
-    if (level == 1) warns++;
-    if (level == 2) errors++;
-    // The tag is colored; the message is default-colored. Two printTextAbove
-    // calls would be two scrollback rows, so build one styled line via the
-    // printAbove primitive instead.
+    scrolledOff += scrolled;
+
+    final pinned = scrolled == 1;
+    final tag = pinned ? ' SCROLL ' : ' DRIFT  ';
+    final tagColor = pinned ? Color.brightGreen : Color.brightYellow;
+    final detail = pinned
+        ? 'screen scrolled — top line pushed into scrollback; anchor held at $after'
+        : 'region pushed down — anchor _originRow $before → $after';
+
+    lastNote = '#$emitted ${pinned ? "SCROLL" : "DRIFT"} — $detail';
+
     terminal.printAbove(1, (b) {
-      b.writeAt(0, 0, tag, fg: color, style: TextStyle.bold);
-      b.writeAt(0, 6, message);
+      b.writeAt(0, 0, '#${emitted.toString().padLeft(3)}',
+          fg: Color.brightBlack);
+      b.writeAt(0, 5, tag,
+          fg: Color.black, bg: tagColor, style: TextStyle.bold);
+      b.writeAt(0, 14, 'printAbove(1)  →  $detail');
     });
     repaint();
-    maybeFinish();
   }
 
   repaint();
   final resizeSub = terminal.resizes.listen((_) => repaint());
-  final ticker =
-      Timer.periodic(const Duration(milliseconds: 100), (_) => repaint());
-  final logTicker =
-      Timer.periodic(const Duration(milliseconds: 350), (_) => emitLogLine());
+  // A gentle ticker keeps the spinner alive while idle.
+  final spinTicker =
+      Timer.periodic(const Duration(milliseconds: 120), (_) => repaint());
+  Timer? autoTicker;
 
+  void setAuto(bool on) {
+    if (auto == on) return;
+    auto = on;
+    autoTicker?.cancel();
+    autoTicker = on
+        ? Timer.periodic(const Duration(milliseconds: 700), (_) => emitNext())
+        : null;
+    repaint();
+  }
+
+  final quit = Completer<void>();
   final keySub = terminal.keys.listen((event) {
-    if (event is CharKey && event.rune == 0x71 /* q */) {
-      if (!quit.isCompleted) quit.complete();
+    if (event is! CharKey) return;
+    switch (event.rune) {
+      case 0x71: // q
+        if (!quit.isCompleted) quit.complete();
+      case 0x20: // space
+        emitNext();
+      case 0x61: // a
+        setAuto(!auto);
     }
   });
 
   try {
     await quit.future;
   } finally {
-    ticker.cancel();
-    logTicker.cancel();
+    spinTicker.cancel();
+    autoTicker?.cancel();
     await resizeSub.cancel();
     await keySub.cancel();
   }
 }
 
-void _drawBorder(CellBuffer b, int row, int col, int rows, int cols,
-    {String? title}) {
+/// Draws the viewport gauge on [row]: a horizontal bar standing in for the
+/// vertical screen. The region's span is highlighted; as it drifts the block
+/// slides right, then sticks at the right edge once pinned. A `N↑` marker on
+/// the left counts lines that have scrolled off into scrollback.
+void _drawGauge(
+  CellBuffer b,
+  int row,
+  int width, {
+  required int origin,
+  required int regionRows,
+  required int screenHeight,
+  required int scrolledOff,
+}) {
+  final marker = scrolledOff > 0 ? '$scrolledOff↑' : '';
+  if (marker.isNotEmpty) {
+    b.writeAt(row, 2, marker, fg: Color.brightGreen, style: TextStyle.bold);
+  }
+  final trackStart = 2 + (marker.isEmpty ? 0 : marker.length + 1) + 1;
+  final trackEnd = width - 3;
+  final trackLen = trackEnd - trackStart;
+  if (trackLen < 4 || screenHeight <= 0) return;
+
+  b.set(row, trackStart - 1, const Cell(rune: 0x5B /* [ */));
+  b.set(row, trackEnd, const Cell(rune: 0x5D /* ] */));
+
+  final regStart =
+      (origin * trackLen / screenHeight).floor().clamp(0, trackLen - 1);
+  var regEnd = ((origin + regionRows) * trackLen / screenHeight)
+      .ceil()
+      .clamp(1, trackLen);
+  if (regEnd <= regStart) regEnd = regStart + 1;
+
+  for (var i = 0; i < trackLen; i++) {
+    final inRegion = i >= regStart && i < regEnd;
+    b.set(
+      row,
+      trackStart + i,
+      inRegion
+          ? const Cell(rune: 0x2588 /* full block */, fg: Color.brightCyan)
+          : const Cell(rune: 0x00B7 /* middle dot */, fg: Color.brightBlack),
+    );
+  }
+}
+
+void _drawBorder(CellBuffer b, int rows, int cols, {String? title}) {
   const tl = 0x250C, tr = 0x2510, bl = 0x2514, br = 0x2518;
   const h = 0x2500, v = 0x2502;
-  b.set(row, col, const Cell(rune: tl));
-  b.set(row, col + cols - 1, const Cell(rune: tr));
-  b.set(row + rows - 1, col, const Cell(rune: bl));
-  b.set(row + rows - 1, col + cols - 1, const Cell(rune: br));
-  for (var c = col + 1; c < col + cols - 1; c++) {
-    b.set(row, c, const Cell(rune: h));
-    b.set(row + rows - 1, c, const Cell(rune: h));
+  b.set(0, 0, const Cell(rune: tl));
+  b.set(0, cols - 1, const Cell(rune: tr));
+  b.set(rows - 1, 0, const Cell(rune: bl));
+  b.set(rows - 1, cols - 1, const Cell(rune: br));
+  for (var c = 1; c < cols - 1; c++) {
+    b.set(0, c, const Cell(rune: h));
+    b.set(rows - 1, c, const Cell(rune: h));
   }
-  for (var r = row + 1; r < row + rows - 1; r++) {
-    b.set(r, col, const Cell(rune: v));
-    b.set(r, col + cols - 1, const Cell(rune: v));
+  for (var r = 1; r < rows - 1; r++) {
+    b.set(r, 0, const Cell(rune: v));
+    b.set(r, cols - 1, const Cell(rune: v));
   }
   if (title != null) {
-    b.writeAt(row, col + 2, title, style: TextStyle.bold);
+    b.writeAt(0, 2, title, style: TextStyle.bold);
   }
 }

--- a/app/examples/tui/print_above_demo.dart
+++ b/app/examples/tui/print_above_demo.dart
@@ -16,7 +16,15 @@ Future<void> main() async {
 
 // Braille spinner frames.
 const _spinner = [
-  0x280B, 0x2819, 0x2839, 0x2838, 0x283C, 0x2834, 0x2826, 0x2827, 0x2807,
+  0x280B,
+  0x2819,
+  0x2839,
+  0x2838,
+  0x283C,
+  0x2834,
+  0x2826,
+  0x2827,
+  0x2807,
   0x280F,
 ];
 
@@ -51,8 +59,7 @@ Future<void> _dashboard(Terminal terminal) async {
     frames++;
     terminal.draw((b) {
       final w = terminal.cols;
-      _drawBorder(b, 0, 0, terminal.rows, w,
-          title: ' flutterware build ');
+      _drawBorder(b, 0, 0, terminal.rows, w, title: ' flutterware build ');
 
       final progress = (emitted / _script.length * 100).round();
       final color = done ? Color.brightGreen : Color.brightCyan;
@@ -62,7 +69,8 @@ Future<void> _dashboard(Terminal terminal) async {
           1,
           2,
           Cell(
-              rune: done ? 0x2714 /* heavy check */
+              rune: done
+                  ? 0x2714 /* heavy check */
                   : _spinner[frames % _spinner.length],
               fg: color));
       b.writeAt(1, 4, done ? 'Build complete' : 'Building...',

--- a/app/examples/tui/print_above_demo.dart
+++ b/app/examples/tui/print_above_demo.dart
@@ -1,0 +1,175 @@
+import 'dart:async';
+
+import 'package:flutterware_app/src/tui/tui.dart';
+
+/// print_above showcase: a simulated `flutter build` whose log lines stream
+/// into the terminal scrollback while a status panel stays pinned below.
+///
+/// Exercises [Terminal.printAbove] (colored log lines into scrollback),
+/// the region staying intact and re-anchored after each insert, and a
+/// timer-driven animated panel rendered with [Terminal.draw].
+Future<void> main() async {
+  print('--- flutterware build (print_above demo) ---');
+  await Terminal.run(_dashboard, mode: const InlineMode(rows: 5));
+  print('--- build finished; back to normal shell output ---');
+}
+
+// Braille spinner frames.
+const _spinner = [
+  0x280B, 0x2819, 0x2839, 0x2838, 0x283C, 0x2834, 0x2826, 0x2827, 0x2807,
+  0x280F,
+];
+
+// A scripted build log: (level, message). level: 0 info, 1 warn, 2 error.
+const _script = <(int, String)>[
+  (0, 'Resolving dependencies...'),
+  (0, 'Got dependencies.'),
+  (0, 'Running Gradle task assembleDebug...'),
+  (0, 'Compiling lib/main.dart'),
+  (0, 'Compiling lib/src/app.dart'),
+  (1, 'lib/src/app.dart:42: unused import'),
+  (0, 'Compiling lib/src/widgets/home.dart'),
+  (0, 'Compiling lib/src/widgets/details.dart'),
+  (1, 'lib/src/widgets/details.dart:88: deprecated API'),
+  (0, 'Linking native libraries'),
+  (2, 'ld: duplicate symbol _kFoo (recovered)'),
+  (0, 'Bundling assets'),
+  (0, 'Optimizing icon tree-shaking'),
+  (0, 'Signing build/app/outputs/apk/debug/app-debug.apk'),
+  (0, 'Built build/app/outputs/apk/debug/app-debug.apk (24.1MB)'),
+];
+
+Future<void> _dashboard(Terminal terminal) async {
+  final start = DateTime.now();
+  var frames = 0;
+  var emitted = 0;
+  var warns = 0;
+  var errors = 0;
+  var done = false;
+
+  void repaint() {
+    frames++;
+    terminal.draw((b) {
+      final w = terminal.cols;
+      _drawBorder(b, 0, 0, terminal.rows, w,
+          title: ' flutterware build ');
+
+      final progress = (emitted / _script.length * 100).round();
+      final color = done ? Color.brightGreen : Color.brightCyan;
+
+      // Row 1: spinner + phase label.
+      b.set(
+          1,
+          2,
+          Cell(
+              rune: done ? 0x2714 /* heavy check */
+                  : _spinner[frames % _spinner.length],
+              fg: color));
+      b.writeAt(1, 4, done ? 'Build complete' : 'Building...',
+          style: TextStyle.bold, fg: color);
+
+      // Row 2: progress bar + percentage.
+      final barStart = 2;
+      final barEnd = w - 8;
+      final barWidth = (barEnd - barStart).clamp(0, w);
+      final filled = (barWidth * progress / 100).round();
+      for (var i = 0; i < barWidth; i++) {
+        b.set(
+          2,
+          barStart + i,
+          i < filled
+              ? Cell(rune: 0x2588, fg: color)
+              : const Cell(rune: 0x2591, fg: Color.brightBlack),
+        );
+      }
+      b.writeAt(2, barEnd + 1, '${progress.toString().padLeft(3)}%', fg: color);
+
+      // Row 3: counts + elapsed + quit hint.
+      final elapsed = DateTime.now().difference(start);
+      b.writeAt(3, 2,
+          'warnings $warns   errors $errors   elapsed ${elapsed.inSeconds}s',
+          style: TextStyle.dim);
+      b.writeAt(3, w - 19, 'press q to quit', style: TextStyle.dim);
+    });
+  }
+
+  // Emit one scripted log line into the scrollback above the panel.
+  void emitLogLine() {
+    if (emitted >= _script.length) return;
+    final (level, message) = _script[emitted];
+    emitted++;
+    final (tag, color) = switch (level) {
+      2 => ('ERROR', Color.brightRed),
+      1 => (' WARN', Color.brightYellow),
+      _ => (' INFO', Color.brightGreen),
+    };
+    if (level == 1) warns++;
+    if (level == 2) errors++;
+    // The tag is colored; the message is default-colored. Two printTextAbove
+    // calls would be two scrollback rows, so build one styled line via the
+    // printAbove primitive instead.
+    terminal.printAbove(1, (b) {
+      b.writeAt(0, 0, tag, fg: color, style: TextStyle.bold);
+      b.writeAt(0, 6, message);
+    });
+    repaint();
+  }
+
+  repaint();
+  final resizeSub = terminal.resizes.listen((_) => repaint());
+  final ticker =
+      Timer.periodic(const Duration(milliseconds: 100), (_) => repaint());
+  final logTicker =
+      Timer.periodic(const Duration(milliseconds: 350), (_) => emitLogLine());
+
+  // Quit when the user presses q, or 1.5s after the build finishes.
+  final quit = Completer<void>();
+  void maybeFinish() {
+    if (emitted >= _script.length && !done) {
+      done = true;
+      logTicker.cancel();
+      Timer(const Duration(milliseconds: 1500), () {
+        if (!quit.isCompleted) quit.complete();
+      });
+    }
+  }
+
+  final keySub = terminal.keys.listen((event) {
+    if (event is CharKey && event.rune == 0x71 /* q */) {
+      if (!quit.isCompleted) quit.complete();
+    }
+  });
+  final finishTicker = Timer.periodic(
+      const Duration(milliseconds: 100), (_) => maybeFinish());
+
+  try {
+    await quit.future;
+  } finally {
+    ticker.cancel();
+    logTicker.cancel();
+    finishTicker.cancel();
+    await resizeSub.cancel();
+    await keySub.cancel();
+  }
+}
+
+void _drawBorder(CellBuffer b, int row, int col, int rows, int cols,
+    {String? title}) {
+  const tl = 0x250C, tr = 0x2510, bl = 0x2514, br = 0x2518;
+  const h = 0x2500, v = 0x2502;
+  b.set(row, col, const Cell(rune: tl));
+  b.set(row, col + cols - 1, const Cell(rune: tr));
+  b.set(row + rows - 1, col, const Cell(rune: bl));
+  b.set(row + rows - 1, col + cols - 1, const Cell(rune: br));
+  for (var c = col + 1; c < col + cols - 1; c++) {
+    b.set(row, c, const Cell(rune: h));
+    b.set(row + rows - 1, c, const Cell(rune: h));
+  }
+  for (var r = row + 1; r < row + rows - 1; r++) {
+    b.set(r, col, const Cell(rune: v));
+    b.set(r, col + cols - 1, const Cell(rune: v));
+  }
+  if (title != null) {
+    b.writeAt(row, col + 2, title, style: TextStyle.bold);
+  }
+}

--- a/app/examples/tui/print_above_demo.dart
+++ b/app/examples/tui/print_above_demo.dart
@@ -93,6 +93,17 @@ Future<void> _dashboard(Terminal terminal) async {
     });
   }
 
+  // Quit when the user presses q, or 1.5s after the build finishes.
+  final quit = Completer<void>();
+  void maybeFinish() {
+    if (emitted >= _script.length && !done) {
+      done = true;
+      Timer(const Duration(milliseconds: 1500), () {
+        if (!quit.isCompleted) quit.complete();
+      });
+    }
+  }
+
   // Emit one scripted log line into the scrollback above the panel.
   void emitLogLine() {
     if (emitted >= _script.length) return;
@@ -113,6 +124,7 @@ Future<void> _dashboard(Terminal terminal) async {
       b.writeAt(0, 6, message);
     });
     repaint();
+    maybeFinish();
   }
 
   repaint();
@@ -122,32 +134,17 @@ Future<void> _dashboard(Terminal terminal) async {
   final logTicker =
       Timer.periodic(const Duration(milliseconds: 350), (_) => emitLogLine());
 
-  // Quit when the user presses q, or 1.5s after the build finishes.
-  final quit = Completer<void>();
-  void maybeFinish() {
-    if (emitted >= _script.length && !done) {
-      done = true;
-      logTicker.cancel();
-      Timer(const Duration(milliseconds: 1500), () {
-        if (!quit.isCompleted) quit.complete();
-      });
-    }
-  }
-
   final keySub = terminal.keys.listen((event) {
     if (event is CharKey && event.rune == 0x71 /* q */) {
       if (!quit.isCompleted) quit.complete();
     }
   });
-  final finishTicker = Timer.periodic(
-      const Duration(milliseconds: 100), (_) => maybeFinish());
 
   try {
     await quit.future;
   } finally {
     ticker.cancel();
     logTicker.cancel();
-    finishTicker.cancel();
     await resizeSub.cancel();
     await keySub.cancel();
   }

--- a/app/lib/src/tui/ansi.dart
+++ b/app/lib/src/tui/ansi.dart
@@ -143,3 +143,61 @@ String encodeDiff(
 
   return buf.toString();
 }
+
+/// Encode a single row of [buffer] (the row at [rowIndex]) as ANSI SGR +
+/// characters, starting at the current cursor position. No leading cursor
+/// move is emitted.
+///
+/// Trailing cells equal to [Cell.empty] are dropped — the caller is expected
+/// to follow the output with an erase-to-end-of-line (`\x1b[K`) so a short
+/// line leaves no stale cells behind.
+///
+/// SGR foreground/background/style transitions are coalesced the same way
+/// [encodeDiff] coalesces them between successive cells.
+String encodeRow(CellBuffer buffer, {int rowIndex = 0}) {
+  // Find the last non-blank cell so trailing blanks are not emitted.
+  var lastCol = -1;
+  for (var c = 0; c < buffer.cols; c++) {
+    if (buffer.get(rowIndex, c) != Cell.empty) lastCol = c;
+  }
+  if (lastCol < 0) return '';
+
+  final buf = StringBuffer();
+  Color? lastFg;
+  Color? lastBg;
+  int? lastStyle;
+
+  for (var c = 0; c <= lastCol; c++) {
+    final cell = buffer.get(rowIndex, c);
+    final params = <String>[];
+    if (lastFg == null || lastFg != cell.fg) {
+      params.add(Ansi.sgrForeground(cell.fg));
+    }
+    if (lastBg == null || lastBg != cell.bg) {
+      params.add(Ansi.sgrBackground(cell.bg));
+    }
+    if (lastStyle == null || lastStyle != cell.style) {
+      if (lastStyle != null && lastStyle != 0) {
+        params.insert(0, '0');
+        // After reset, fg/bg also reset — re-emit them.
+        if (!params.contains(Ansi.sgrForeground(cell.fg))) {
+          params.add(Ansi.sgrForeground(cell.fg));
+        }
+        if (!params.contains(Ansi.sgrBackground(cell.bg))) {
+          params.add(Ansi.sgrBackground(cell.bg));
+        }
+      }
+      params.addAll(Ansi.sgrStyle(cell.style));
+    }
+    if (params.isNotEmpty) {
+      buf.write('${Ansi.csi}${params.join(';')}m');
+    }
+    buf.writeCharCode(cell.rune);
+
+    lastFg = cell.fg;
+    lastBg = cell.bg;
+    lastStyle = cell.style;
+  }
+
+  return buf.toString();
+}

--- a/app/lib/src/tui/terminal.dart
+++ b/app/lib/src/tui/terminal.dart
@@ -26,6 +26,27 @@ final class InlineMode extends TerminalMode {
   const InlineMode({required this.rows}) : assert(rows > 0);
 }
 
+/// Compute the inline region's new origin row after [linesPrinted] lines are
+/// printed into the scrollback above it.
+///
+/// The region drifts downward as lines are inserted above it, until it is
+/// pinned against the bottom of the terminal (`terminalLines - regionRows`),
+/// after which further lines scroll the screen and the anchor stays put.
+/// Clamped to a minimum of 0 so a terminal shorter than the region still
+/// yields a valid row.
+int anchorRowAfterPrintAbove({
+  required int originRow,
+  required int regionRows,
+  required int linesPrinted,
+  required int terminalLines,
+}) {
+  final maxOrigin = terminalLines - regionRows;
+  var next = originRow + linesPrinted;
+  if (next > maxOrigin) next = maxOrigin;
+  if (next < 0) next = 0;
+  return next;
+}
+
 /// Owns the terminal lifecycle: alt-screen entry/exit, raw-mode stdin,
 /// signal handling, double-buffered painting, and crash-safe restore.
 ///

--- a/app/lib/src/tui/terminal.dart
+++ b/app/lib/src/tui/terminal.dart
@@ -101,6 +101,11 @@ class Terminal {
   int get rows => _rows;
   int get cols => _cols;
 
+  /// Absolute terminal row of the region's top-left corner — its anchor.
+  /// Always 0 in full-screen mode. In inline mode it is captured at entry
+  /// and advanced by [printAbove] as lines scroll above the region.
+  int get originRow => _originRow;
+
   /// Emits when the terminal is resized. The caller is responsible for
   /// calling [draw] in response — the engine clears the screen on resize
   /// but does not repaint until asked.

--- a/app/lib/src/tui/terminal.dart
+++ b/app/lib/src/tui/terminal.dart
@@ -294,7 +294,7 @@ class Terminal {
 
     _front = CellBuffer(_rows, _cols);
     _back.clear();
-    (_lastPaint ?? (_) {})(_back);
+    _lastPaint?.call(_back);
     out.write(encodeDiff(_front, _back,
         originRow: _originRow, originCol: _originCol));
     _front.copyFrom(_back);

--- a/app/lib/src/tui/terminal.dart
+++ b/app/lib/src/tui/terminal.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 
 import 'ansi.dart';
 import 'buffer.dart';
+import 'cell.dart';
 import 'cursor_query.dart';
 import 'input.dart';
 
@@ -77,6 +78,10 @@ class Terminal {
   int _cols = 0;
   late CellBuffer _front;
   late CellBuffer _back;
+
+  /// The most recent paint callback passed to [draw]. Replayed by
+  /// [printAbove] to redraw the region after it has been re-anchored.
+  void Function(CellBuffer buffer)? _lastPaint;
 
   bool _wasEcho = false;
   bool _wasLine = false;
@@ -234,6 +239,7 @@ class Terminal {
   /// caller's freshly-painted back buffer. The user's [paint] function
   /// receives a cleared back buffer.
   void draw(void Function(CellBuffer buffer) paint) {
+    _lastPaint = paint;
     _back.clear();
     paint(_back);
     final diff =
@@ -242,6 +248,76 @@ class Terminal {
       stdout.write(diff);
     }
     _front.copyFrom(_back);
+  }
+
+  /// Insert [height] rows of content into the terminal scrollback immediately
+  /// above the inline region, then redraw the region at its new anchor.
+  ///
+  /// [paint] receives a fresh [height]×cols [CellBuffer] addressed from
+  /// (0, 0). Content wider than the terminal is clipped; lines are not
+  /// wrapped. A non-positive [height] is a no-op.
+  ///
+  /// Only valid in inline mode. Throws [StateError] in full-screen mode,
+  /// where the alt-screen buffer has no scrollback.
+  void printAbove(int height, void Function(CellBuffer buffer) paint) {
+    if (_mode is! InlineMode) {
+      throw StateError('printAbove is only available in inline mode');
+    }
+    if (height <= 0) return;
+
+    final lines = CellBuffer(height, _cols);
+    paint(lines);
+
+    final out = StringBuffer();
+    // Write the new lines starting at the region's current top row. Each
+    // trailing newline either drifts the region down or, once the region is
+    // pinned at the bottom, scrolls a line into the terminal's scrollback.
+    out.write(Ansi.moveTo(_originRow, 0));
+    for (var r = 0; r < height; r++) {
+      out.write(encodeRow(lines, rowIndex: r));
+      out.write(Ansi.resetStyle); // so the erase below uses the default bg
+      out.write('\x1b[K'); // erase to end of line
+      out.write('\n');
+    }
+
+    _originRow = anchorRowAfterPrintAbove(
+      originRow: _originRow,
+      regionRows: _rows,
+      linesPrinted: height,
+      terminalLines: stdout.terminalLines,
+    );
+
+    // Wipe the now-stale region area, then redraw the region at the new
+    // anchor by replaying the last paint callback against a blank front.
+    out.write(Ansi.moveTo(_originRow, 0));
+    out.write('\x1b[J'); // erase from cursor to end of screen
+
+    _front = CellBuffer(_rows, _cols);
+    _back.clear();
+    (_lastPaint ?? (_) {})(_back);
+    out.write(encodeDiff(_front, _back,
+        originRow: _originRow, originCol: _originCol));
+    _front.copyFrom(_back);
+
+    stdout.write(out.toString());
+  }
+
+  /// Convenience over [printAbove] for plain text. [text] is split on '\n';
+  /// each line becomes one scrollback row painted with the given style.
+  ///
+  /// Only valid in inline mode. Throws [StateError] in full-screen mode.
+  void printTextAbove(
+    String text, {
+    Color fg = Color.defaultFg,
+    Color bg = Color.defaultBg,
+    int style = 0,
+  }) {
+    final textLines = text.split('\n');
+    printAbove(textLines.length, (buffer) {
+      for (var i = 0; i < textLines.length; i++) {
+        buffer.writeAt(i, 0, textLines[i], fg: fg, bg: bg, style: style);
+      }
+    });
   }
 
   void _restore() {

--- a/app/test/tui/ansi_test.dart
+++ b/app/test/tui/ansi_test.dart
@@ -238,4 +238,53 @@ void main() {
       expect(out, contains('B'));
     });
   });
+
+  group('encodeRow', () {
+    test('empty row produces empty string', () {
+      final buffer = CellBuffer(1, 5);
+      expect(encodeRow(buffer), '');
+    });
+
+    test('plain row emits runes with no leading cursor move', () {
+      final buffer = CellBuffer(1, 5);
+      buffer.writeAt(0, 0, 'Hi');
+      final out = encodeRow(buffer);
+      expect(out, contains('Hi'));
+      expect(out, isNot(matches(RegExp(r'\x1b\[\d+;\d+H'))));
+    });
+
+    test('trailing blank cells are dropped', () {
+      final buffer = CellBuffer(1, 10);
+      buffer.writeAt(0, 0, 'ab');
+      // Row is "ab" followed by 8 blank cells; output must not pad them.
+      final out = encodeRow(buffer);
+      expect(out.endsWith('b'), isTrue);
+    });
+
+    test('rowIndex selects the row', () {
+      final buffer = CellBuffer(3, 5);
+      buffer.writeAt(2, 0, 'Xy');
+      expect(encodeRow(buffer, rowIndex: 2), contains('Xy'));
+      expect(encodeRow(buffer, rowIndex: 0), '');
+    });
+
+    test('foreground color emits SGR once per run', () {
+      final buffer = CellBuffer(1, 3);
+      buffer.writeAt(0, 0, 'RR', fg: Color.red);
+      final out = encodeRow(buffer);
+      expect('31'.allMatches(out).length, 1);
+      expect(out, contains('RR'));
+    });
+
+    test('style transition resets and re-applies color', () {
+      final buffer = CellBuffer(1, 2);
+      buffer.set(0, 0, Cell(rune: 0x41, fg: Color.red, style: TextStyle.bold));
+      buffer.set(0, 1, Cell(rune: 0x42, fg: Color.red));
+      final out = encodeRow(buffer);
+      expect(out, matches(RegExp(r'(\x1b\[|;)0(;|m)')));
+      expect(out, contains('31'));
+      expect(out, contains('A'));
+      expect(out, contains('B'));
+    });
+  });
 }

--- a/app/test/tui/terminal_test.dart
+++ b/app/test/tui/terminal_test.dart
@@ -1,0 +1,49 @@
+import 'package:flutterware_app/src/tui/terminal.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('anchorRowAfterPrintAbove', () {
+    test('region with room below just drifts down by the line count', () {
+      // Region top at row 5, height 4, terminal 40 rows: plenty of room.
+      expect(
+        anchorRowAfterPrintAbove(
+            originRow: 5, regionRows: 4, linesPrinted: 3, terminalLines: 40),
+        8,
+      );
+    });
+
+    test('region pins at the bottom once it reaches it', () {
+      // maxOrigin = 40 - 4 = 36. originRow 35 + 10 lines would be 45.
+      expect(
+        anchorRowAfterPrintAbove(
+            originRow: 35, regionRows: 4, linesPrinted: 10, terminalLines: 40),
+        36,
+      );
+    });
+
+    test('already pinned region stays pinned', () {
+      expect(
+        anchorRowAfterPrintAbove(
+            originRow: 36, regionRows: 4, linesPrinted: 5, terminalLines: 40),
+        36,
+      );
+    });
+
+    test('zero lines printed leaves the anchor unchanged', () {
+      expect(
+        anchorRowAfterPrintAbove(
+            originRow: 12, regionRows: 4, linesPrinted: 0, terminalLines: 40),
+        12,
+      );
+    });
+
+    test('terminal shorter than the region clamps the anchor to 0', () {
+      // maxOrigin = 3 - 5 = -2; result must clamp up to 0.
+      expect(
+        anchorRowAfterPrintAbove(
+            originRow: 0, regionRows: 5, linesPrinted: 2, terminalLines: 3),
+        0,
+      );
+    });
+  });
+}

--- a/docs/superpowers/plans/2026-05-15-tui-print-above.md
+++ b/docs/superpowers/plans/2026-05-15-tui-print-above.md
@@ -1,0 +1,701 @@
+# `print_above` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `print_above` capability to the TUI engine's inline mode, letting code emit log lines that scroll into the terminal scrollback above the anchored region while the region stays intact.
+
+**Architecture:** Natural-scroll technique — move the cursor to the inline region's top row, write the new lines each followed by `\n` (letting the terminal scroll lines into real scrollback), recompute the region's anchor row, then redraw the region by replaying the last `draw()` paint callback. A new `encodeRow` helper encodes a single buffer row; a pure `anchorRowAfterPrintAbove` helper computes the new anchor.
+
+**Tech Stack:** Pure Dart (`dart:io`, `dart:async`), `package:test` / `flutter test`. No new dependencies.
+
+**Spec:** [docs/superpowers/specs/2026-05-15-tui-print-above-design.md](../specs/2026-05-15-tui-print-above-design.md)
+
+---
+
+## File Structure
+
+- `app/lib/src/tui/ansi.dart` — **modify**: add `encodeRow`, encodes a single `CellBuffer` row to SGR + characters.
+- `app/lib/src/tui/terminal.dart` — **modify**: add top-level `anchorRowAfterPrintAbove`, the `_lastPaint` field, `printAbove`, and `printTextAbove`.
+- `app/test/tui/ansi_test.dart` — **modify**: add an `encodeRow` test group.
+- `app/test/tui/terminal_test.dart` — **create**: tests for the pure `anchorRowAfterPrintAbove` helper.
+- `app/examples/tui/print_above_demo.dart` — **create**: streaming build-log dashboard demo.
+- `docs/superpowers/tui-roadmap.md` — **modify**: mark `print_above` done.
+
+### Testability note
+
+`Terminal` cannot be unit-tested: `Terminal.run` sets `stdin.echoMode = false`, which throws `StdinException` outside a tty — that is why no `terminal_test.dart` exists today. So the plan unit-tests only the **pure** pieces (`encodeRow`, `anchorRowAfterPrintAbove`). The `printAbove` / `printTextAbove` methods and the full-screen `StateError` guard are verified by running the demo in a real terminal (Task 4).
+
+---
+
+## Task 1: `encodeRow` helper
+
+Encodes one row of a `CellBuffer` as ANSI SGR + characters, starting at the current cursor position, with no leading cursor move and trailing blank cells dropped. `printAbove` uses it to emit each scrollback line; `encodeDiff` cannot be reused because it emits absolute cursor moves and never emits the `\n` that drives scrolling.
+
+**Files:**
+- Modify: `app/lib/src/tui/ansi.dart`
+- Test: `app/test/tui/ansi_test.dart`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add this group at the end of `main()` in `app/test/tui/ansi_test.dart`, before the final closing `}`:
+
+```dart
+  group('encodeRow', () {
+    test('empty row produces empty string', () {
+      final buffer = CellBuffer(1, 5);
+      expect(encodeRow(buffer), '');
+    });
+
+    test('plain row emits runes with no leading cursor move', () {
+      final buffer = CellBuffer(1, 5);
+      buffer.writeAt(0, 0, 'Hi');
+      final out = encodeRow(buffer);
+      expect(out, contains('Hi'));
+      expect(out, isNot(matches(RegExp(r'\x1b\[\d+;\d+H'))));
+    });
+
+    test('trailing blank cells are dropped', () {
+      final buffer = CellBuffer(1, 10);
+      buffer.writeAt(0, 0, 'ab');
+      // Row is "ab" followed by 8 blank cells; output must not pad them.
+      final out = encodeRow(buffer);
+      expect(out.endsWith('b'), isTrue);
+    });
+
+    test('rowIndex selects the row', () {
+      final buffer = CellBuffer(3, 5);
+      buffer.writeAt(2, 0, 'Xy');
+      expect(encodeRow(buffer, rowIndex: 2), contains('Xy'));
+      expect(encodeRow(buffer, rowIndex: 0), '');
+    });
+
+    test('foreground color emits SGR once per run', () {
+      final buffer = CellBuffer(1, 3);
+      buffer.writeAt(0, 0, 'RR', fg: Color.red);
+      final out = encodeRow(buffer);
+      expect('31'.allMatches(out).length, 1);
+      expect(out, contains('RR'));
+    });
+
+    test('style transition resets and re-applies color', () {
+      final buffer = CellBuffer(1, 2);
+      buffer.set(0, 0, Cell(rune: 0x41, fg: Color.red, style: TextStyle.bold));
+      buffer.set(0, 1, Cell(rune: 0x42, fg: Color.red));
+      final out = encodeRow(buffer);
+      expect(out, matches(RegExp(r'(\x1b\[|;)0(;|m)')));
+      expect(out, contains('31'));
+      expect(out, contains('A'));
+      expect(out, contains('B'));
+    });
+  });
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd app && flutter test test/tui/ansi_test.dart`
+Expected: FAIL — `encodeRow` is undefined.
+
+- [ ] **Step 3: Implement `encodeRow`**
+
+Append to `app/lib/src/tui/ansi.dart` after `encodeDiff`:
+
+```dart
+/// Encode a single row of [buffer] (the row at [rowIndex]) as ANSI SGR +
+/// characters, starting at the current cursor position. No leading cursor
+/// move is emitted.
+///
+/// Trailing cells equal to [Cell.empty] are dropped — the caller is expected
+/// to follow the output with an erase-to-end-of-line (`\x1b[K`) so a short
+/// line leaves no stale cells behind.
+///
+/// SGR foreground/background/style transitions are coalesced the same way
+/// [encodeDiff] coalesces them between successive cells.
+String encodeRow(CellBuffer buffer, {int rowIndex = 0}) {
+  // Find the last non-blank cell so trailing blanks are not emitted.
+  var lastCol = -1;
+  for (var c = 0; c < buffer.cols; c++) {
+    if (buffer.get(rowIndex, c) != Cell.empty) lastCol = c;
+  }
+  if (lastCol < 0) return '';
+
+  final buf = StringBuffer();
+  Color? lastFg;
+  Color? lastBg;
+  int? lastStyle;
+
+  for (var c = 0; c <= lastCol; c++) {
+    final cell = buffer.get(rowIndex, c);
+    final params = <String>[];
+    if (lastFg == null || lastFg != cell.fg) {
+      params.add(Ansi.sgrForeground(cell.fg));
+    }
+    if (lastBg == null || lastBg != cell.bg) {
+      params.add(Ansi.sgrBackground(cell.bg));
+    }
+    if (lastStyle == null || lastStyle != cell.style) {
+      if (lastStyle != null && lastStyle != 0) {
+        params.insert(0, '0');
+        if (!params.contains(Ansi.sgrForeground(cell.fg))) {
+          params.add(Ansi.sgrForeground(cell.fg));
+        }
+        if (!params.contains(Ansi.sgrBackground(cell.bg))) {
+          params.add(Ansi.sgrBackground(cell.bg));
+        }
+      }
+      params.addAll(Ansi.sgrStyle(cell.style));
+    }
+    if (params.isNotEmpty) {
+      buf.write('${Ansi.csi}${params.join(';')}m');
+    }
+    buf.writeCharCode(cell.rune);
+
+    lastFg = cell.fg;
+    lastBg = cell.bg;
+    lastStyle = cell.style;
+  }
+
+  return buf.toString();
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd app && flutter test test/tui/ansi_test.dart`
+Expected: PASS — all tests, including the existing `encodeDiff` group.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/lib/src/tui/ansi.dart app/test/tui/ansi_test.dart
+git commit -m "Add encodeRow helper for TUI print_above"
+```
+
+---
+
+## Task 2: `anchorRowAfterPrintAbove` helper
+
+A pure function computing the inline region's new origin row after N lines are printed above it. The region drifts down until pinned against the bottom of the terminal, then stays. Extracted as a top-level function so it is unit-testable without a tty.
+
+**Files:**
+- Modify: `app/lib/src/tui/terminal.dart`
+- Test: `app/test/tui/terminal_test.dart` (create)
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `app/test/tui/terminal_test.dart`:
+
+```dart
+import 'package:flutterware_app/src/tui/terminal.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('anchorRowAfterPrintAbove', () {
+    test('region with room below just drifts down by the line count', () {
+      // Region top at row 5, height 4, terminal 40 rows: plenty of room.
+      expect(
+        anchorRowAfterPrintAbove(
+            originRow: 5, regionRows: 4, linesPrinted: 3, terminalLines: 40),
+        8,
+      );
+    });
+
+    test('region pins at the bottom once it reaches it', () {
+      // maxOrigin = 40 - 4 = 36. originRow 35 + 10 lines would be 45.
+      expect(
+        anchorRowAfterPrintAbove(
+            originRow: 35, regionRows: 4, linesPrinted: 10, terminalLines: 40),
+        36,
+      );
+    });
+
+    test('already pinned region stays pinned', () {
+      expect(
+        anchorRowAfterPrintAbove(
+            originRow: 36, regionRows: 4, linesPrinted: 5, terminalLines: 40),
+        36,
+      );
+    });
+
+    test('zero lines printed leaves the anchor unchanged', () {
+      expect(
+        anchorRowAfterPrintAbove(
+            originRow: 12, regionRows: 4, linesPrinted: 0, terminalLines: 40),
+        12,
+      );
+    });
+
+    test('terminal shorter than the region clamps the anchor to 0', () {
+      // maxOrigin = 3 - 5 = -2; result must clamp up to 0.
+      expect(
+        anchorRowAfterPrintAbove(
+            originRow: 0, regionRows: 5, linesPrinted: 2, terminalLines: 3),
+        0,
+      );
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd app && flutter test test/tui/terminal_test.dart`
+Expected: FAIL — `anchorRowAfterPrintAbove` is undefined.
+
+- [ ] **Step 3: Implement the helper**
+
+Add this top-level function to `app/lib/src/tui/terminal.dart`, after the `TerminalMode` classes and before `class Terminal`:
+
+```dart
+/// Compute the inline region's new origin row after [linesPrinted] lines are
+/// printed into the scrollback above it.
+///
+/// The region drifts downward as lines are inserted above it, until it is
+/// pinned against the bottom of the terminal (`terminalLines - regionRows`),
+/// after which further lines scroll the screen and the anchor stays put.
+/// Clamped to a minimum of 0 so a terminal shorter than the region still
+/// yields a valid row.
+int anchorRowAfterPrintAbove({
+  required int originRow,
+  required int regionRows,
+  required int linesPrinted,
+  required int terminalLines,
+}) {
+  final maxOrigin = terminalLines - regionRows;
+  var next = originRow + linesPrinted;
+  if (next > maxOrigin) next = maxOrigin;
+  if (next < 0) next = 0;
+  return next;
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd app && flutter test test/tui/terminal_test.dart`
+Expected: PASS — all 5 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/lib/src/tui/terminal.dart app/test/tui/terminal_test.dart
+git commit -m "Add anchorRowAfterPrintAbove helper for TUI print_above"
+```
+
+---
+
+## Task 3: `printAbove` and `printTextAbove` on `Terminal`
+
+Add the two public methods plus the `_lastPaint` field. `printAbove` is the primitive (a `CellBuffer`-paint callback, forward-compatible with a future widget layer); `printTextAbove` is the plain-text convenience. These touch `stdout` directly and cannot be unit-tested without a tty (see the Testability note) — they are exercised by the demo in Task 4.
+
+**Files:**
+- Modify: `app/lib/src/tui/terminal.dart`
+
+- [ ] **Step 1: Add the `_lastPaint` field**
+
+In `class Terminal`, add this field next to the other buffer state (after the `late CellBuffer _back;` line):
+
+```dart
+  /// The most recent paint callback passed to [draw]. Replayed by
+  /// [printAbove] to redraw the region after it has been re-anchored.
+  void Function(CellBuffer buffer)? _lastPaint;
+```
+
+- [ ] **Step 2: Store the paint callback in `draw`**
+
+Modify `draw` in `app/lib/src/tui/terminal.dart` so its body begins by storing the callback. The method becomes:
+
+```dart
+  void draw(void Function(CellBuffer buffer) paint) {
+    _lastPaint = paint;
+    _back.clear();
+    paint(_back);
+    final diff =
+        encodeDiff(_front, _back, originRow: _originRow, originCol: _originCol);
+    if (diff.isNotEmpty) {
+      stdout.write(diff);
+    }
+    _front.copyFrom(_back);
+  }
+```
+
+- [ ] **Step 3: Add `printAbove` and `printTextAbove`**
+
+Add both methods to `class Terminal`, immediately after `draw`:
+
+```dart
+  /// Insert [height] rows of content into the terminal scrollback immediately
+  /// above the inline region, then redraw the region at its new anchor.
+  ///
+  /// [paint] receives a fresh [height]×cols [CellBuffer] addressed from
+  /// (0, 0). Content wider than the terminal is clipped; lines are not
+  /// wrapped. A non-positive [height] is a no-op.
+  ///
+  /// Only valid in inline mode. Throws [StateError] in full-screen mode,
+  /// where the alt-screen buffer has no scrollback.
+  void printAbove(int height, void Function(CellBuffer buffer) paint) {
+    if (_mode is! InlineMode) {
+      throw StateError('printAbove is only available in inline mode');
+    }
+    if (height <= 0) return;
+
+    final lines = CellBuffer(height, _cols);
+    paint(lines);
+
+    final out = StringBuffer();
+    // Write the new lines starting at the region's current top row. Each
+    // trailing newline either drifts the region down or, once the region is
+    // pinned at the bottom, scrolls a line into the terminal's scrollback.
+    out.write(Ansi.moveTo(_originRow, 0));
+    for (var r = 0; r < height; r++) {
+      out.write(encodeRow(lines, rowIndex: r));
+      out.write(Ansi.resetStyle); // so the erase below uses the default bg
+      out.write('\x1b[K'); // erase to end of line
+      out.write('\n');
+    }
+
+    _originRow = anchorRowAfterPrintAbove(
+      originRow: _originRow,
+      regionRows: _rows,
+      linesPrinted: height,
+      terminalLines: stdout.terminalLines,
+    );
+
+    // Wipe the now-stale region area, then redraw the region at the new
+    // anchor by replaying the last paint callback against a blank front.
+    out.write(Ansi.moveTo(_originRow, 0));
+    out.write('\x1b[J'); // erase from cursor to end of screen
+
+    _front = CellBuffer(_rows, _cols);
+    _back.clear();
+    (_lastPaint ?? (_) {})(_back);
+    out.write(encodeDiff(_front, _back,
+        originRow: _originRow, originCol: _originCol));
+    _front.copyFrom(_back);
+
+    stdout.write(out.toString());
+  }
+
+  /// Convenience over [printAbove] for plain text. [text] is split on '\n';
+  /// each line becomes one scrollback row painted with the given style.
+  ///
+  /// Only valid in inline mode. Throws [StateError] in full-screen mode.
+  void printTextAbove(
+    String text, {
+    Color fg = Color.defaultFg,
+    Color bg = Color.defaultBg,
+    int style = 0,
+  }) {
+    final textLines = text.split('\n');
+    printAbove(textLines.length, (buffer) {
+      for (var i = 0; i < textLines.length; i++) {
+        buffer.writeAt(i, 0, textLines[i], fg: fg, bg: bg, style: style);
+      }
+    });
+  }
+```
+
+- [ ] **Step 4: Add the `cell.dart` import**
+
+`printTextAbove`'s signature references `Color` and the default style. Check the imports at the top of `app/lib/src/tui/terminal.dart`. It currently imports `ansi.dart`, `buffer.dart`, `cursor_query.dart`, `input.dart`. Add:
+
+```dart
+import 'cell.dart';
+```
+
+(Place it in alphabetical order among the existing relative imports.)
+
+- [ ] **Step 5: Verify it analyzes cleanly**
+
+Run: `cd app && dart analyze lib/src/tui/terminal.dart`
+Expected: "No issues found!"
+
+- [ ] **Step 6: Run the full tui test suite to confirm no regressions**
+
+Run: `cd app && flutter test test/tui/`
+Expected: PASS — all files.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/lib/src/tui/terminal.dart
+git commit -m "Add Terminal.printAbove and printTextAbove"
+```
+
+---
+
+## Task 4: Streaming build-log dashboard demo
+
+A demo that shows the feature end to end: an inline status panel pinned at the bottom while colored log lines stream into the scrollback above it via `printAbove`. This is the concrete flutterware-CLI use case (a live progress panel + scrolling build log).
+
+**Files:**
+- Create: `app/examples/tui/print_above_demo.dart`
+
+- [ ] **Step 1: Write the demo**
+
+Create `app/examples/tui/print_above_demo.dart`:
+
+```dart
+import 'dart:async';
+
+import 'package:flutterware_app/src/tui/tui.dart';
+
+/// print_above showcase: a simulated `flutter build` whose log lines stream
+/// into the terminal scrollback while a status panel stays pinned below.
+///
+/// Exercises [Terminal.printAbove] (colored log lines into scrollback),
+/// the region staying intact and re-anchored after each insert, and a
+/// timer-driven animated panel rendered with [Terminal.draw].
+Future<void> main() async {
+  print('--- flutterware build (print_above demo) ---');
+  await Terminal.run(_dashboard, mode: const InlineMode(rows: 5));
+  print('--- build finished; back to normal shell output ---');
+}
+
+// Braille spinner frames.
+const _spinner = [
+  0x280B, 0x2819, 0x2839, 0x2838, 0x283C, 0x2834, 0x2826, 0x2827, 0x2807,
+  0x280F,
+];
+
+// A scripted build log: (level, message). level: 0 info, 1 warn, 2 error.
+const _script = <(int, String)>[
+  (0, 'Resolving dependencies...'),
+  (0, 'Got dependencies.'),
+  (0, 'Running Gradle task assembleDebug...'),
+  (0, 'Compiling lib/main.dart'),
+  (0, 'Compiling lib/src/app.dart'),
+  (1, 'lib/src/app.dart:42: unused import'),
+  (0, 'Compiling lib/src/widgets/home.dart'),
+  (0, 'Compiling lib/src/widgets/details.dart'),
+  (1, 'lib/src/widgets/details.dart:88: deprecated API'),
+  (0, 'Linking native libraries'),
+  (2, 'ld: duplicate symbol _kFoo (recovered)'),
+  (0, 'Bundling assets'),
+  (0, 'Optimizing icon tree-shaking'),
+  (0, 'Signing build/app/outputs/apk/debug/app-debug.apk'),
+  (0, 'Built build/app/outputs/apk/debug/app-debug.apk (24.1MB)'),
+];
+
+Future<void> _dashboard(Terminal terminal) async {
+  final start = DateTime.now();
+  var frames = 0;
+  var emitted = 0;
+  var warns = 0;
+  var errors = 0;
+  var done = false;
+
+  void repaint() {
+    frames++;
+    terminal.draw((b) {
+      final w = terminal.cols;
+      _drawBorder(b, 0, 0, terminal.rows, w,
+          title: ' flutterware build ');
+
+      final progress = (emitted / _script.length * 100).round();
+      final color = done ? Color.brightGreen : Color.brightCyan;
+
+      // Row 1: spinner + phase label.
+      b.set(
+          1,
+          2,
+          Cell(
+              rune: done ? 0x2714 /* heavy check */
+                  : _spinner[frames % _spinner.length],
+              fg: color));
+      b.writeAt(1, 4, done ? 'Build complete' : 'Building...',
+          style: TextStyle.bold, fg: color);
+
+      // Row 2: progress bar + percentage.
+      final barStart = 2;
+      final barEnd = w - 8;
+      final barWidth = (barEnd - barStart).clamp(0, w);
+      final filled = (barWidth * progress / 100).round();
+      for (var i = 0; i < barWidth; i++) {
+        b.set(
+          2,
+          barStart + i,
+          i < filled
+              ? Cell(rune: 0x2588, fg: color)
+              : const Cell(rune: 0x2591, fg: Color.brightBlack),
+        );
+      }
+      b.writeAt(2, barEnd + 1, '${progress.toString().padLeft(3)}%', fg: color);
+
+      // Row 3: counts + elapsed + quit hint.
+      final elapsed = DateTime.now().difference(start);
+      b.writeAt(3, 2,
+          'warnings $warns   errors $errors   elapsed ${elapsed.inSeconds}s',
+          style: TextStyle.dim);
+      b.writeAt(3, w - 19, 'press q to quit', style: TextStyle.dim);
+    });
+  }
+
+  // Emit one scripted log line into the scrollback above the panel.
+  void emitLogLine() {
+    if (emitted >= _script.length) return;
+    final (level, message) = _script[emitted];
+    emitted++;
+    final (tag, color) = switch (level) {
+      2 => ('ERROR', Color.brightRed),
+      1 => (' WARN', Color.brightYellow),
+      _ => (' INFO', Color.brightGreen),
+    };
+    if (level == 1) warns++;
+    if (level == 2) errors++;
+    // The tag is colored; the message is default-colored. Two printTextAbove
+    // calls would be two scrollback rows, so build one styled line via the
+    // printAbove primitive instead.
+    terminal.printAbove(1, (b) {
+      b.writeAt(0, 0, tag, fg: color, style: TextStyle.bold);
+      b.writeAt(0, 6, message);
+    });
+    repaint();
+  }
+
+  repaint();
+  final resizeSub = terminal.resizes.listen((_) => repaint());
+  final ticker =
+      Timer.periodic(const Duration(milliseconds: 100), (_) => repaint());
+  final logTicker =
+      Timer.periodic(const Duration(milliseconds: 350), (_) => emitLogLine());
+
+  // Quit when the user presses q, or 1.5s after the build finishes.
+  final quit = Completer<void>();
+  void maybeFinish() {
+    if (emitted >= _script.length && !done) {
+      done = true;
+      logTicker.cancel();
+      Timer(const Duration(milliseconds: 1500), () {
+        if (!quit.isCompleted) quit.complete();
+      });
+    }
+  }
+
+  final keySub = terminal.keys.listen((event) {
+    if (event is CharKey && event.rune == 0x71 /* q */) {
+      if (!quit.isCompleted) quit.complete();
+    }
+  });
+  final finishTicker = Timer.periodic(
+      const Duration(milliseconds: 100), (_) => maybeFinish());
+
+  try {
+    await quit.future;
+  } finally {
+    ticker.cancel();
+    logTicker.cancel();
+    finishTicker.cancel();
+    await resizeSub.cancel();
+    await keySub.cancel();
+  }
+}
+
+void _drawBorder(CellBuffer b, int row, int col, int rows, int cols,
+    {String? title}) {
+  const tl = 0x250C, tr = 0x2510, bl = 0x2514, br = 0x2518;
+  const h = 0x2500, v = 0x2502;
+  b.set(row, col, const Cell(rune: tl));
+  b.set(row, col + cols - 1, const Cell(rune: tr));
+  b.set(row + rows - 1, col, const Cell(rune: bl));
+  b.set(row + rows - 1, col + cols - 1, const Cell(rune: br));
+  for (var c = col + 1; c < col + cols - 1; c++) {
+    b.set(row, c, const Cell(rune: h));
+    b.set(row + rows - 1, c, const Cell(rune: h));
+  }
+  for (var r = row + 1; r < row + rows - 1; r++) {
+    b.set(r, col, const Cell(rune: v));
+    b.set(r, col + cols - 1, const Cell(rune: v));
+  }
+  if (title != null) {
+    b.writeAt(row, col + 2, title, style: TextStyle.bold);
+  }
+}
+```
+
+- [ ] **Step 2: Verify the demo analyzes cleanly**
+
+Run: `cd app && dart analyze examples/tui/print_above_demo.dart`
+Expected: "No issues found!"
+
+- [ ] **Step 3: Run the demo in a real terminal**
+
+Run: `cd app && dart run examples/tui/print_above_demo.dart`
+
+Expected, verify by eye:
+- A 5-row bordered status panel appears, with an animated spinner and progress bar.
+- Colored log lines (`INFO`/`WARN`/`ERROR` tags) stream into the scrollback **above** the panel, roughly 3 per second.
+- The panel is never corrupted or duplicated as lines stream in; it stays pinned.
+- After the last log line, the panel shows "Build complete" with a check mark, then the program exits ~1.5s later.
+- Pressing `q` quits early and cleanly; the next shell prompt starts on a fresh line below where the panel was.
+- Scrolling the terminal back shows all the emitted log lines preserved in scrollback.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/examples/tui/print_above_demo.dart
+git commit -m "Add print_above streaming build-log demo"
+```
+
+---
+
+## Task 5: Mark `print_above` done in the roadmap
+
+**Files:**
+- Modify: `docs/superpowers/tui-roadmap.md`
+
+- [ ] **Step 1: Update the stages table**
+
+In `docs/superpowers/tui-roadmap.md`, change the `print_above` row of the Stages table from:
+
+```markdown
+| **`print_above`** | Print log lines into scrollback above an inline region | ⏳ Next |
+```
+
+to:
+
+```markdown
+| **`print_above`** | Print log lines into scrollback above an inline region | ✅ Done |
+```
+
+- [ ] **Step 2: Update the detailed-docs list**
+
+In the "Detailed docs per stage" list, add a line after the Stage 1.5 inline-mode entry:
+
+```markdown
+- `print_above` — [spec](specs/2026-05-15-tui-print-above-design.md) ·
+  [plan](plans/2026-05-15-tui-print-above.md)
+```
+
+- [ ] **Step 3: Replace the "`print_above` — the next step" section**
+
+The section titled `## `print_above` — the next step` describes the feature as upcoming. Replace its body (keep the heading text as `## `print_above`` without "the next step") with a past-tense summary:
+
+```markdown
+## `print_above`
+
+Inline mode renders a fixed region anchored at the cursor. `print_above` (the
+ratatui `insert_before` capability) lets inline-mode code emit log/output
+lines that scroll into the terminal scrollback **above** the region, without
+disturbing the region itself.
+
+`Terminal.printAbove` writes the new lines at the region's top row and lets
+the terminal scroll them into real scrollback, recomputes the region's anchor
+row (`_originRow`), then redraws the region by replaying the last `draw()`
+paint callback. `printTextAbove` is the plain-text convenience over it. See
+the [design spec](specs/2026-05-15-tui-print-above-design.md).
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/superpowers/tui-roadmap.md
+git commit -m "Mark print_above done in TUI roadmap"
+```
+
+---
+
+## Final Verification
+
+- [ ] Run the full tui test suite: `cd app && flutter test test/tui/` — all PASS.
+- [ ] Run workspace analysis: `flutter analyze` from the repo root — no new issues.
+- [ ] Run the formatter: `dart tool/prepare_submit.dart` from the repo root, then `git status` — commit any formatting diff it produces.
+- [ ] Confirm the demo behaves as described in Task 4, Step 3.

--- a/docs/superpowers/specs/2026-05-15-tui-print-above-design.md
+++ b/docs/superpowers/specs/2026-05-15-tui-print-above-design.md
@@ -1,0 +1,215 @@
+# TUI Step 1 — `print_above` (extension)
+
+**Status:** Draft
+**Date:** 2026-05-15
+**Scope:** Add a `print_above` capability to the inline rendering mode: emit
+log/output lines that scroll into the terminal scrollback **above** the inline
+region while the region itself stays anchored and intact. This is the feature
+deliberately deferred from the inline-mode work.
+
+**Extends:** [`2026-05-14-tui-step1-inline-mode-design.md`](./2026-05-14-tui-step1-inline-mode-design.md)
+
+---
+
+## Context
+
+Inline mode renders a fixed-height region anchored at the cursor's position
+when `Terminal.run` starts. The inline-mode spec explicitly scoped out
+`print_above` (the ratatui `insert_before` capability) and listed it as the
+natural next feature.
+
+Without it, an inline TUI owns the terminal output channel exclusively: any
+`print` to stdout from outside the TUI scrolls the terminal and the region's
+absolute anchor (`_originRow`) drifts out of sync. `print_above` gives the TUI
+a sanctioned way to emit scrollback content — log lines, build output, command
+results — so that a status panel and a streaming log can coexist. This is the
+concrete flutterware-CLI use case: a live status/progress panel pinned at the
+bottom, with normal build log flowing into scrollback above it.
+
+## Goals
+
+1. A `Terminal.printAbove` primitive that inserts N painted rows into the
+   scrollback above the inline region.
+2. A `Terminal.printTextAbove` convenience for the common plain-text log-line
+   case.
+3. The inline region stays visually intact and correctly anchored after a
+   `printAbove` call — `_originRow` is recomputed and the region is redrawn.
+4. A demo (`print_above_demo.dart`) showing a streaming build-log dashboard.
+
+## Non-goals (for this round)
+
+- **No line wrapping.** Lines wider than the terminal are clipped, consistent
+  with `CellBuffer`'s existing out-of-bounds clipping. Wrapping is deferred.
+- **No full-screen support.** `print_above` is meaningless in full-screen mode
+  (the alt-screen buffer has no scrollback). Calling it in full-screen mode
+  throws `StateError`.
+- **No widget rendering.** The primitive takes a `CellBuffer`-paint callback —
+  the same model as `draw()` — which is forward-compatible with a future
+  widget layer (a widget renders into a buffer), but no widget machinery is
+  built here.
+- **No scroll-region (`DECSTBM`) approach.** See "Mechanism" below for why.
+- **No batching/coalescing.** Each `printAbove` call is one self-contained
+  scroll-and-redraw. Callers that want to emit many lines at once pass them in
+  a single call.
+
+## Mechanism
+
+### Why natural-scroll, not scroll-region
+
+Two ways to get lines into the scrollback above a fixed region:
+
+- **Scroll-region (`DECSTBM`, `\x1b[t;br`)** — define a scrolling region above
+  the inline region and scroll within it. **Rejected:** on most terminals,
+  lines that scroll *out* of a `DECSTBM` region are discarded rather than
+  pushed to scrollback — even when the region's top is screen row 1. That
+  defeats the purpose of `print_above`.
+- **Natural-scroll** — move the cursor to the region's top row, write the new
+  lines each followed by `\n`, and let the terminal scroll on its own. A `\n`
+  emitted on the last row of the screen performs a real scroll: the top line
+  enters the terminal's scrollback. This is the ratatui `insert_before`
+  technique and the approach used here.
+
+### Anchor drift
+
+The inline region occupies absolute rows `_originRow .. _originRow + _rows - 1`.
+When `printAbove` writes N new lines starting at `_originRow`, the region is
+pushed downward. Two sub-cases, unified by one formula:
+
+- If there is room below the region, the region simply moves down within the
+  viewport; nothing enters scrollback.
+- Once the region reaches the bottom of the screen, further `\n`s scroll the
+  screen — old top lines enter scrollback and the region stays pinned at the
+  bottom.
+
+Unified recomputation, evaluated against a freshly-read terminal height:
+
+```
+_originRow = min(_originRow + N, terminalLines - _rows)
+```
+
+`terminalLines` is read fresh inside `printAbove` so a resize that happened
+since the last frame is accounted for. If `terminalLines < _rows` (terminal
+shorter than the region) the result clamps via `max(0, ...)`; the region
+paints clipped, consistent with the inline-mode height non-goal.
+
+### Algorithm
+
+`printAbove(int height, void Function(CellBuffer) paint)`:
+
+1. If the mode is not `InlineMode`, throw `StateError`.
+2. Allocate a temporary `CellBuffer(height, _cols)`; run `paint` on it.
+3. Emit the cursor move to absolute `(_originRow, 0)`.
+4. For each of the `height` rows of the temp buffer: emit that row's encoded
+   SGR + characters via `encodeRow`, then `\x1b[K` (erase to end of line, so a
+   short line leaves no stale cells), then `\n`. The `\n`s drive the scroll.
+5. Recompute `_originRow` with the formula above.
+6. Emit a move to the new `(_originRow, 0)` followed by `\x1b[J` (erase from
+   cursor to end of screen), wiping the now-stale region area.
+7. Reset `_front` to a blank buffer of the current size, replay the stored
+   last-paint callback into `_back`, compute `encodeDiff` at the new origin,
+   write it, and copy `_back` into `_front`. The region reappears intact at its
+   new anchor.
+
+If no `draw()` has happened yet (`_lastPaint == null`), step 7 still runs with
+a no-op paint: the region area is left blank, which is correct.
+
+### Why `encodeDiff` cannot be reused for step 4
+
+`encodeDiff` emits absolute `\x1b[r;cH` cursor moves and never emits `\n`.
+Absolute positioning does not scroll the terminal, so it cannot push anything
+into scrollback. Step 4 needs explicit `\n`s. A small dedicated `encodeRow`
+helper encodes a single buffer row (left-to-right SGR-coalesced run of cells,
+trailing blank cells dropped since `\x1b[K` clears them).
+
+## API
+
+Both methods are added to the existing `Terminal` class; no new exported
+types.
+
+```dart
+/// Insert [height] rows of content into the terminal scrollback immediately
+/// above the inline region, then redraw the region at its new anchor.
+///
+/// [paint] receives a fresh [height]×cols [CellBuffer] addressed from (0, 0).
+/// Content wider than the terminal is clipped; lines are not wrapped.
+///
+/// Only valid in inline mode. Throws [StateError] in full-screen mode.
+void printAbove(int height, void Function(CellBuffer buffer) paint);
+
+/// Convenience over [printAbove] for plain text. [text] is split on '\n';
+/// each line becomes one scrollback row painted with the given style.
+///
+/// Only valid in inline mode. Throws [StateError] in full-screen mode.
+void printTextAbove(
+  String text, {
+  Color fg = Color.defaultFg,
+  Color bg = Color.defaultBg,
+  int style = 0,
+});
+```
+
+`printTextAbove` computes `height` from the split line count and delegates to
+`printAbove`.
+
+## `Terminal` internal state additions
+
+```dart
+class Terminal {
+  // existing fields ...
+  void Function(CellBuffer)? _lastPaint; // most recent draw() callback
+}
+```
+
+`draw()` stores its callback into `_lastPaint` before painting, so `printAbove`
+can replay it to redraw the region. This is the only new state.
+
+## `encodeRow` helper
+
+Lives in `ansi.dart` next to `encodeDiff`.
+
+```dart
+/// Encode a single [CellBuffer] row as SGR + characters, starting at the
+/// current cursor position (no leading cursor move). Trailing default/blank
+/// cells are omitted — the caller is expected to follow with `\x1b[K`.
+String encodeRow(CellBuffer row, {int rowIndex = 0});
+```
+
+It walks one row, coalescing foreground/background/style SGR transitions the
+same way `encodeDiff` does, and trims trailing blank cells.
+
+## Files touched
+
+- **Modify** `app/lib/src/tui/terminal.dart` — `printAbove`, `printTextAbove`,
+  `_lastPaint` field, `_lastPaint` assignment in `draw()`.
+- **Modify** `app/lib/src/tui/ansi.dart` — add `encodeRow`.
+- **Create** `app/examples/tui/print_above_demo.dart` — streaming build-log
+  dashboard demo.
+- **Modify** `app/test/tui/ansi_test.dart` — tests for `encodeRow` (SGR
+  coalescing, trailing-blank trimming, styled cells).
+- **Modify** `app/test/tui/terminal_test.dart` (or create) — anchor-drift
+  arithmetic and the full-screen `StateError`. If `Terminal` is not unit-
+  testable without a tty, cover the drift formula via an extracted pure
+  helper.
+- **Modify** `docs/superpowers/tui-roadmap.md` — mark `print_above` done.
+
+## Success criteria
+
+1. All existing tests still pass.
+2. `encodeRow` tests pass (plain row, styled row, trailing-blank trimming).
+3. The anchor-drift formula is covered by a test.
+4. `printAbove` / `printTextAbove` throw `StateError` in full-screen mode.
+5. `print_above_demo.dart` runs in a real terminal:
+   - A status panel stays pinned as an inline region.
+   - Log lines stream into the scrollback above it and remain visible in
+     scrollback when scrolled back.
+   - The status panel is never corrupted by the streaming output.
+   - Pressing `q` exits cleanly; the next shell prompt starts below the
+     region.
+
+## Open questions deferred
+
+- Line wrapping for content wider than the terminal.
+- Re-anchoring `print_above` interaction with terminal-height shrink mid-run.
+- A headless/in-memory `Terminal` for golden-file testing of `printAbove`.
+- Widget-layer integration (a `printAbove(Widget)` overload) — arrives with
+  the widget layer in stage 4.

--- a/docs/superpowers/tui-roadmap.md
+++ b/docs/superpowers/tui-roadmap.md
@@ -24,7 +24,7 @@ could use a richer status/dashboard UI.
 |-------|------------------|--------|
 | **1. Engine** | Terminal lifecycle, `CellBuffer`, diff-to-ANSI, key parsing, crash-safe restore | ✅ Done |
 | **1.5 Inline mode** | A fixed-height region anchored at the cursor, alongside full-screen | ✅ Done |
-| **`print_above`** | Print log lines into scrollback above an inline region | ⏳ Next |
+| **`print_above`** | Print log lines into scrollback above an inline region | ✅ Done |
 | **2. Paint kit** | `Rect`/`CellSize` geometry + procedural paint helpers (text, border, fill) | ⬜ Not started |
 | **3. Render tree** | `RenderObject`/`RenderBox`, `BoxConstraints`, `Row`/`Column`/`Padding` | ⬜ Not started |
 | **4. Widget layer** | `Widget`/`Element`, `StatelessWidget`/`StatefulWidget`, `setState` | ⬜ Not started |
@@ -40,6 +40,8 @@ framework.
   [plan](plans/2026-05-14-tui-step1-engine.md)
 - Stage 1.5 inline mode — [spec](specs/2026-05-14-tui-step1-inline-mode-design.md) ·
   [plan](plans/2026-05-14-tui-step1-inline-mode.md)
+- `print_above` — [spec](specs/2026-05-15-tui-print-above-design.md) ·
+  [plan](plans/2026-05-15-tui-print-above.md)
 
 ## Key design decisions
 
@@ -71,21 +73,18 @@ Recorded so future work doesn't re-litigate them:
   fixed-height region at the cursor). `TerminalMode` is a sealed class so the
   set is closed and exhaustively switchable.
 
-## `print_above` — the next step
+## `print_above`
 
 Inline mode renders a fixed region anchored at the cursor. `print_above` (the
-ratatui `insert_before` capability) lets inline-mode code emit log/output lines
-that scroll into the terminal scrollback **above** the region, without
+ratatui `insert_before` capability) lets inline-mode code emit log/output
+lines that scroll into the terminal scrollback **above** the region, without
 disturbing the region itself.
 
-It was deliberately scoped out of the inline-mode work — see the "Non-goals"
-and "Open questions deferred" sections of the
-[inline-mode spec](specs/2026-05-14-tui-step1-inline-mode-design.md). The core
-design tension: printing above the region shifts it down, so the region's
-absolute anchor row (`_originRow` in `terminal.dart`) drifts and must be kept
-in sync. The likely approach is a `Terminal.printAbove` that moves the cursor
-to the region's top, opens space with insert-line (`ESC[L`) or a scroll-region
-command, writes the lines, and bumps `_originRow`.
+`Terminal.printAbove` writes the new lines at the region's top row and lets
+the terminal scroll them into real scrollback, recomputes the region's anchor
+row (`_originRow`), then redraws the region by replaying the last `draw()`
+paint callback. `printTextAbove` is the plain-text convenience over it. See
+the [design spec](specs/2026-05-15-tui-print-above-design.md).
 
 ## Known limitations carried forward
 


### PR DESCRIPTION
## Summary

Adds `print_above` to the terminal UI engine's inline mode — the next item on the [TUI roadmap](docs/superpowers/tui-roadmap.md). It lets inline-mode code emit log/output lines that scroll into the terminal's real scrollback **above** the anchored region, while the region stays intact and correctly re-anchored.

- **`Terminal.printAbove(height, paint)`** — primitive: paints `height` rows into a fresh `CellBuffer` and inserts them into scrollback above the inline region. The `CellBuffer`-paint model is forward-compatible with a future widget layer. **`printTextAbove(...)`** is the plain-text convenience. Throws `StateError` in full-screen mode.
- **Mechanism** — natural-scroll (ratatui `insert_before` style): write the new lines at the region's top row so the terminal scrolls them into genuine scrollback, recompute the anchor via the pure `anchorRowAfterPrintAbove` helper, then redraw the region by replaying the last `draw()` callback. A `DECSTBM` scroll-region was rejected because terminals discard lines scrolled out of it.
- **`encodeRow`** — new `ansi.dart` helper encoding a single buffer row (`encodeDiff` can't be reused: it emits absolute moves, never the `\n` that drives scrolling).
- **`Terminal.originRow`** getter — exposes the live anchor row.
- **Demo** — `examples/tui/print_above_demo.dart`: an instrumented, step-through (`space`) / auto-play (`a`) walkthrough of the mechanism, with a live panel (anchor row, screen height, pin point, DRIFTING-vs-PINNED phase, scrollback counts) and a viewport gauge. Each emitted line narrates its own `printAbove` effect.

Design spec and implementation plan are committed under `docs/superpowers/`.

## Test Plan

- [x] `cd app && flutter test` — 98 tests pass (includes new `encodeRow` and `anchorRowAfterPrintAbove` tests)
- [x] `dart analyze` clean; `dart tool/prepare_submit.dart` clean
- [ ] Run `cd app && dart run examples/tui/print_above_demo.dart` in a real terminal: log lines stream into scrollback, region stays intact and re-anchors, scrollback preserved on exit, `q` quits cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)