### PR TITLE
Fix flaky passthrough PTY test: spawn with posix_spawn instead of forkpty

### DIFF
--- a/app/lib/src/passthrough/pty/bindings/libc_bindings.dart
+++ b/app/lib/src/passthrough/pty/bindings/libc_bindings.dart
@@ -1,9 +1,9 @@
 // ignore_for_file: non_constant_identifier_names, camel_case_types, constant_identifier_names, library_private_types_in_public_api
 //
-// Rationale: this file mirrors libc/libutil one-to-one for readability against
-// `man` pages. POSIX names are SCREAMING_CASE for signals and constants; the
-// private FFI typedefs (e.g. _ForkptyDart) are deliberately scoped to this
-// file to keep the public surface small.
+// Rationale: this file mirrors libc one-to-one for readability against `man`
+// pages. POSIX names are SCREAMING_CASE for signals and constants; the private
+// FFI typedefs (e.g. _SpawnDart) are deliberately scoped to this file to keep
+// the public surface small.
 
 import 'dart:ffi';
 import 'dart:io' show Platform;
@@ -27,6 +27,16 @@ final class WinSize extends Struct {
 // Linux: 0x5414
 int get TIOCSWINSZ => Platform.isMacOS ? 0x80087467 : 0x5414;
 
+// ---------- open(2) flags ----------
+const int O_RDWR = 0x0002;
+// O_NOCTTY differs between platforms.
+int get O_NOCTTY => Platform.isMacOS ? 0x20000 : 0x100;
+
+// ---------- posix_spawn attribute flags ----------
+// POSIX_SPAWN_SETSID makes the child a new session leader, so that opening the
+// PTY slave (without O_NOCTTY) acquires it as the child's controlling terminal.
+int get POSIX_SPAWN_SETSID => Platform.isMacOS ? 0x0400 : 0x80;
+
 // ---------- signal numbers (POSIX-portable subset) ----------
 const int SIGHUP = 1;
 const int SIGINT = 2;
@@ -40,20 +50,6 @@ bool WIFSIGNALED(int s) => ((s & 0x7f) + 1) >> 1 > 0;
 int WTERMSIG(int s) => s & 0x7f;
 
 // ---------- function typedefs ----------
-typedef _ForkptyNative = Int32 Function(
-    Pointer<Int32>, Pointer<Utf8>, Pointer<Void>, Pointer<WinSize>);
-typedef _ForkptyDart = int Function(
-    Pointer<Int32>, Pointer<Utf8>, Pointer<Void>, Pointer<WinSize>);
-
-typedef _ExecvpNative = Int32 Function(Pointer<Utf8>, Pointer<Pointer<Utf8>>);
-typedef _ExecvpDart = int Function(Pointer<Utf8>, Pointer<Pointer<Utf8>>);
-
-typedef _ExitNative = Void Function(Int32);
-typedef _ExitDart = void Function(int);
-
-typedef _ChdirNative = Int32 Function(Pointer<Utf8>);
-typedef _ChdirDart = int Function(Pointer<Utf8>);
-
 typedef _WaitpidNative = Int32 Function(Int32, Pointer<Int32>, Int32);
 typedef _WaitpidDart = int Function(int, Pointer<Int32>, int);
 
@@ -77,6 +73,48 @@ typedef _IoctlNative = Int32 Function(
     Int32, IntPtr, VarArgs<(Pointer<WinSize>,)>);
 typedef _IoctlDart = int Function(int, int, Pointer<WinSize>);
 
+typedef _IntFromIntNative = Int32 Function(Int32);
+typedef _IntFromIntDart = int Function(int);
+
+// open(2): declared with the 2-arg (no O_CREAT) form — the variadic mode
+// argument is only consulted when creating a file, which we never do here.
+typedef _OpenNative = Int32 Function(Pointer<Utf8>, Int32);
+typedef _OpenDart = int Function(Pointer<Utf8>, int);
+
+typedef _PtsnameNative = Pointer<Utf8> Function(Int32);
+typedef _PtsnameDart = Pointer<Utf8> Function(int);
+
+// posix_spawnp(pid*, file, file_actions*, attrp*, argv[], envp[])
+typedef _SpawnNative = Int32 Function(
+    Pointer<Int32>,
+    Pointer<Utf8>,
+    Pointer<Void>,
+    Pointer<Void>,
+    Pointer<Pointer<Utf8>>,
+    Pointer<Pointer<Utf8>>);
+typedef _SpawnDart = int Function(Pointer<Int32>, Pointer<Utf8>, Pointer<Void>,
+    Pointer<Void>, Pointer<Pointer<Utf8>>, Pointer<Pointer<Utf8>>);
+
+typedef _OpaqueInitNative = Int32 Function(Pointer<Void>);
+typedef _OpaqueInitDart = int Function(Pointer<Void>);
+
+typedef _FaAddopenNative = Int32 Function(
+    Pointer<Void>, Int32, Pointer<Utf8>, Int32, Uint32);
+typedef _FaAddopenDart = int Function(
+    Pointer<Void>, int, Pointer<Utf8>, int, int);
+
+typedef _FaAddupNative = Int32 Function(Pointer<Void>, Int32, Int32);
+typedef _FaAddupDart = int Function(Pointer<Void>, int, int);
+
+typedef _FaAddcloseNative = Int32 Function(Pointer<Void>, Int32);
+typedef _FaAddcloseDart = int Function(Pointer<Void>, int);
+
+typedef _FaAddchdirNative = Int32 Function(Pointer<Void>, Pointer<Utf8>);
+typedef _FaAddchdirDart = int Function(Pointer<Void>, Pointer<Utf8>);
+
+typedef _AttrSetflagsNative = Int32 Function(Pointer<Void>, Int16);
+typedef _AttrSetflagsDart = int Function(Pointer<Void>, int);
+
 typedef _GetpidNative = Int32 Function();
 typedef _GetpidDart = int Function();
 
@@ -84,43 +122,78 @@ typedef _GetpidDart = int Function();
 
 class LibcBindings {
   late final DynamicLibrary _libc;
-  late final DynamicLibrary _libutil;
 
   LibcBindings() {
     if (Platform.isMacOS) {
       _libc = DynamicLibrary.process();
-      _libutil = DynamicLibrary.process();
     } else if (Platform.isLinux) {
       _libc = DynamicLibrary.open('libc.so.6');
-      _libutil = DynamicLibrary.open('libutil.so.1');
     } else {
       throw UnsupportedError(
           'Passthrough PTY only supports macOS and Linux (got ${Platform.operatingSystem})');
     }
 
-    forkpty = _libutil.lookupFunction<_ForkptyNative, _ForkptyDart>('forkpty');
-    execvp = _libc.lookupFunction<_ExecvpNative, _ExecvpDart>('execvp');
-    _exit = _libc.lookupFunction<_ExitNative, _ExitDart>('_exit');
-    chdir = _libc.lookupFunction<_ChdirNative, _ChdirDart>('chdir');
     waitpid = _libc.lookupFunction<_WaitpidNative, _WaitpidDart>('waitpid');
     kill = _libc.lookupFunction<_KillNative, _KillDart>('kill');
     read = _libc.lookupFunction<_ReadNative, _ReadDart>('read');
     write = _libc.lookupFunction<_WriteNative, _WriteDart>('write');
     close = _libc.lookupFunction<_CloseNative, _CloseDart>('close');
+    openFile = _libc.lookupFunction<_OpenNative, _OpenDart>('open');
     ioctl = _libc.lookupFunction<_IoctlNative, _IoctlDart>('ioctl');
+
+    posixOpenpt = _libc
+        .lookupFunction<_IntFromIntNative, _IntFromIntDart>('posix_openpt');
+    grantpt =
+        _libc.lookupFunction<_IntFromIntNative, _IntFromIntDart>('grantpt');
+    unlockpt =
+        _libc.lookupFunction<_IntFromIntNative, _IntFromIntDart>('unlockpt');
+    ptsname = _libc.lookupFunction<_PtsnameNative, _PtsnameDart>('ptsname');
+
+    posixSpawnp =
+        _libc.lookupFunction<_SpawnNative, _SpawnDart>('posix_spawnp');
+    faInit = _libc.lookupFunction<_OpaqueInitNative, _OpaqueInitDart>(
+        'posix_spawn_file_actions_init');
+    faDestroy = _libc.lookupFunction<_OpaqueInitNative, _OpaqueInitDart>(
+        'posix_spawn_file_actions_destroy');
+    faAddopen = _libc.lookupFunction<_FaAddopenNative, _FaAddopenDart>(
+        'posix_spawn_file_actions_addopen');
+    faAdddup2 = _libc.lookupFunction<_FaAddupNative, _FaAddupDart>(
+        'posix_spawn_file_actions_adddup2');
+    faAddclose = _libc.lookupFunction<_FaAddcloseNative, _FaAddcloseDart>(
+        'posix_spawn_file_actions_addclose');
+    faAddchdir = _libc.lookupFunction<_FaAddchdirNative, _FaAddchdirDart>(
+        'posix_spawn_file_actions_addchdir_np');
+    attrInit = _libc.lookupFunction<_OpaqueInitNative, _OpaqueInitDart>(
+        'posix_spawnattr_init');
+    attrDestroy = _libc.lookupFunction<_OpaqueInitNative, _OpaqueInitDart>(
+        'posix_spawnattr_destroy');
+    attrSetflags = _libc.lookupFunction<_AttrSetflagsNative, _AttrSetflagsDart>(
+        'posix_spawnattr_setflags');
     getpid = _libc.lookupFunction<_GetpidNative, _GetpidDart>('getpid');
   }
 
-  late final _ForkptyDart forkpty;
-  late final _ExecvpDart execvp;
-  late final _ExitDart _exit;
-  void exitProcess(int code) => _exit(code);
-  late final _ChdirDart chdir;
   late final _WaitpidDart waitpid;
   late final _KillDart kill;
   late final _ReadDart read;
   late final _WriteDart write;
   late final _CloseDart close;
+  late final _OpenDart openFile;
   late final _IoctlDart ioctl;
+
+  late final _IntFromIntDart posixOpenpt;
+  late final _IntFromIntDart grantpt;
+  late final _IntFromIntDart unlockpt;
+  late final _PtsnameDart ptsname;
+
+  late final _SpawnDart posixSpawnp;
+  late final _OpaqueInitDart faInit;
+  late final _OpaqueInitDart faDestroy;
+  late final _FaAddopenDart faAddopen;
+  late final _FaAddupDart faAdddup2;
+  late final _FaAddcloseDart faAddclose;
+  late final _FaAddchdirDart faAddchdir;
+  late final _OpaqueInitDart attrInit;
+  late final _OpaqueInitDart attrDestroy;
+  late final _AttrSetflagsDart attrSetflags;
   late final _GetpidDart getpid;
 }

--- a/app/lib/src/passthrough/pty/pty_impl.dart
+++ b/app/lib/src/passthrough/pty/pty_impl.dart
@@ -15,7 +15,6 @@ class PtyProcessImpl implements PtyProcess {
   final LibcBindings _libc;
   final StreamController<Uint8List> _output;
   final Completer<int> _exitCode = Completer<int>();
-  late final ReceivePort _rp;
 
   PtyProcessImpl._(this._masterFd, this._pid, this._libc)
       : _output = StreamController<Uint8List>();
@@ -29,7 +28,39 @@ class PtyProcessImpl implements PtyProcess {
   }) async {
     final libc = LibcBindings();
 
-    // Build argv: [executable, ...arguments, nullptr]
+    // Open a PTY master. The child is spawned with posix_spawn, which does the
+    // fork+exec entirely inside libc — no Dart code runs in the child. That is
+    // deliberate: forkpty() returns into the caller in the child too, and
+    // running *any* Dart in a forked child of the multi-threaded Dart VM can
+    // deadlock if a GC/safepoint was in progress at fork() time.
+    final masterFd = libc.posixOpenpt(O_RDWR | O_NOCTTY);
+    if (masterFd < 0) {
+      throw PtyException('posix_openpt failed');
+    }
+    if (libc.grantpt(masterFd) != 0 || libc.unlockpt(masterFd) != 0) {
+      libc.close(masterFd);
+      throw PtyException('grantpt/unlockpt failed');
+    }
+    final slaveNamePtr = libc.ptsname(masterFd);
+    if (slaveNamePtr == nullptr) {
+      libc.close(masterFd);
+      throw PtyException('ptsname failed');
+    }
+    final slavePath = slaveNamePtr.toDartString();
+
+    // Set the initial window size. The slave's first open resets the PTY's
+    // winsize to 0x0, so the parent opens the slave once itself to absorb that
+    // reset, then sets the size. The fd is held open across posix_spawn (so the
+    // child's open is not the "first" one) and closed afterwards.
+    final slavePathPtr = slavePath.toNativeUtf8();
+    final parentSlaveFd = libc.openFile(slavePathPtr, O_RDWR | O_NOCTTY);
+    final ws = calloc<WinSize>()
+      ..ref.ws_col = cols ?? (stdout.hasTerminal ? stdout.terminalColumns : 80)
+      ..ref.ws_row = rows ?? (stdout.hasTerminal ? stdout.terminalLines : 24);
+    libc.ioctl(masterFd, TIOCSWINSZ, ws);
+    calloc.free(ws);
+
+    // argv: [executable, ...arguments, nullptr]
     final argv = calloc<Pointer<Utf8>>(arguments.length + 2);
     argv[0] = executable.toNativeUtf8();
     for (var i = 0; i < arguments.length; i++) {
@@ -37,74 +68,99 @@ class PtyProcessImpl implements PtyProcess {
     }
     argv[arguments.length + 1] = nullptr;
 
-    // Build winsize (use parent terminal size as default)
-    final ws = calloc<WinSize>()
-      ..ref.ws_col = cols ?? (stdout.hasTerminal ? stdout.terminalColumns : 80)
-      ..ref.ws_row = rows ?? (stdout.hasTerminal ? stdout.terminalLines : 24);
+    // envp: inherit the current process environment.
+    final env = Platform.environment;
+    final envp = calloc<Pointer<Utf8>>(env.length + 1);
+    var ei = 0;
+    env.forEach((k, v) {
+      envp[ei++] = '$k=$v'.toNativeUtf8();
+    });
+    envp[env.length] = nullptr;
 
-    final masterOut = calloc<Int32>();
+    // posix_spawn_file_actions_t / posix_spawnattr_t are opaque structs whose
+    // size differs by platform; a generously-sized zeroed buffer covers both.
+    final fileActions = calloc<Uint8>(1024);
+    final attr = calloc<Uint8>(1024);
     final exePtr = executable.toNativeUtf8();
     final cwdPtr =
         workingDirectory != null ? workingDirectory.toNativeUtf8() : nullptr;
+    final pidOut = calloc<Int32>();
 
-    final pid = libc.forkpty(masterOut, nullptr, nullptr, ws);
+    libc.faInit(fileActions.cast());
+    libc.attrInit(attr.cast());
+    libc.attrSetflags(attr.cast(), POSIX_SPAWN_SETSID);
 
-    if (pid < 0) {
-      _freeArgv(argv, arguments.length + 2);
-      calloc.free(ws);
-      calloc.free(masterOut);
-      calloc.free(exePtr);
-      if (cwdPtr != nullptr) calloc.free(cwdPtr);
-      throw PtyException('forkpty failed');
+    // The child opens the slave (without O_NOCTTY) as a fresh session leader,
+    // so the PTY becomes its controlling terminal, then mirrors it onto stdio.
+    libc.faAddopen(fileActions.cast(), 0, slavePathPtr, O_RDWR, 0);
+    libc.faAdddup2(fileActions.cast(), 0, 1);
+    libc.faAdddup2(fileActions.cast(), 0, 2);
+    // Don't leak the master fd into the child.
+    libc.faAddclose(fileActions.cast(), masterFd);
+    if (cwdPtr != nullptr) {
+      libc.faAddchdir(fileActions.cast(), cwdPtr);
     }
 
-    if (pid == 0) {
-      // ====== CHILD BRANCH ======
-      // Only async-signal-safe calls below.
-      if (cwdPtr != nullptr) {
-        final rc = libc.chdir(cwdPtr);
-        if (rc != 0) libc.exitProcess(127);
-      }
-      libc.execvp(exePtr, argv);
-      libc.exitProcess(127); // execvp failed
-      // Unreachable.
-    }
+    final rc = libc.posixSpawnp(
+      pidOut,
+      exePtr,
+      fileActions.cast(),
+      attr.cast(),
+      argv,
+      envp,
+    );
+    final pid = pidOut.value;
 
-    // ====== PARENT BRANCH ======
-    final masterFd = masterOut.value;
-    calloc.free(masterOut);
-    calloc.free(ws);
-    _freeArgv(argv, arguments.length + 2);
+    libc.faDestroy(fileActions.cast());
+    libc.attrDestroy(attr.cast());
+    if (parentSlaveFd >= 0) libc.close(parentSlaveFd);
+    calloc.free(fileActions);
+    calloc.free(attr);
+    calloc.free(pidOut);
     calloc.free(exePtr);
+    calloc.free(slavePathPtr);
     if (cwdPtr != nullptr) calloc.free(cwdPtr);
+    _freeStrArray(argv);
+    _freeStrArray(envp);
+
+    if (rc != 0) {
+      // posix_spawn could not exec the target (e.g. binary not found). Mirror
+      // the historical execvp-failure contract: exit code 127, no output.
+      libc.close(masterFd);
+      final impl = PtyProcessImpl._(masterFd, -1, libc);
+      impl._exitCode.complete(127);
+      unawaited(impl._output.close());
+      return impl;
+    }
 
     final impl = PtyProcessImpl._(masterFd, pid, libc);
     await impl._startReader();
     return impl;
   }
 
-  static void _freeArgv(Pointer<Pointer<Utf8>> argv, int count) {
-    for (var i = 0; i < count; i++) {
-      final p = argv[i];
-      if (p != nullptr) calloc.free(p);
+  static void _freeStrArray(Pointer<Pointer<Utf8>> arr) {
+    for (var i = 0;; i++) {
+      final p = arr[i];
+      if (p == nullptr) break;
+      calloc.free(p);
     }
-    calloc.free(argv);
+    calloc.free(arr);
   }
 
   Future<void> _startReader() async {
-    _rp = ReceivePort();
+    final rp = ReceivePort();
     await Isolate.spawn(
       _readerEntry,
-      _ReaderArgs(_masterFd, _pid, _rp.sendPort),
+      _ReaderArgs(_masterFd, _pid, rp.sendPort),
     );
-    _rp.listen((msg) {
+    rp.listen((msg) {
       if (msg is Uint8List) {
         _output.add(msg);
       } else if (msg is _ExitEvent) {
         if (!_exitCode.isCompleted) _exitCode.complete(msg.code);
         _output.close();
         _libc.close(_masterFd);
-        _rp.close();
+        rp.close();
       }
     });
   }
@@ -136,7 +192,7 @@ class PtyProcessImpl implements PtyProcess {
 
   @override
   void sendSignal(int signal) {
-    _libc.kill(_pid, signal);
+    if (_pid > 0) _libc.kill(_pid, signal);
   }
 }
 


### PR DESCRIPTION
## Summary

The CI-flaky `pty_test.dart` test `SIGINT death gives exit 130` (30s `TimeoutException`) was a symptom of a real bug in the passthrough PTY implementation, not a test problem.

`spawnPty` used `forkpty()`, which returns into the caller in **both** the parent and the child. The child branch then ran Dart code before `exec`ing. In a forked child of the multi-threaded Dart VM, only the forking thread survives — if a GC/safepoint was in progress at `fork()` time, the child deadlocks waiting on VM threads that no longer exist, never `exec`s the target, and keeps the PTY slave open, hanging the reader's `read()` on the master fd forever.

Reproduced deterministically with a stress loop (hung ~1 in 27 spawns); `sample` confirmed the stuck "child" was still a `dartvm` process that never became `bash`.

## Fix

Replaced `forkpty` with `posix_spawn`, which does the fork+exec entirely inside libc — **no Dart code runs in the child**, eliminating the deadlock class.

- `libc_bindings.dart` — swapped the `forkpty`/`execvp`/`chdir`/`_exit` bindings for `posix_openpt`, `grantpt`, `unlockpt`, `ptsname`, `open`, and the `posix_spawn` family.
- `pty_impl.dart` — `spawn()` opens a PTY master and spawns via `posix_spawnp` with `POSIX_SPAWN_SETSID` + file actions (open slave → dup onto stdio, close master). A `posix_spawn` failure maps to exit 127, preserving the old execvp-failure contract.

Two subtleties handled:
- **Controlling terminal**: `SETSID` + the child opening the slave without `O_NOCTTY` makes the PTY its controlling terminal (verified by the SIGWINCH `resize()` test).
- **Initial window size**: the slave's first open resets the PTY winsize to `0×0`, so the parent opens the slave once itself to absorb the reset before setting the size.

## Test plan

- [x] 12 consecutive full-file runs of `pty_test.dart` pass (previously flaked ~2/6)
- [x] 400-round stress loop (2000 spawns of the previously-deadlocking scenario) clean — old code hung at round 27
- [x] All 20 `test/passthrough/` tests pass
- [x] `flutter analyze` clean for `lib/src/passthrough/` and `test/passthrough/`
- [x] `dart tool/prepare_submit.dart` formatter applied
- [ ] CI green on Linux (beta channel) — `posix_spawn` path is portable but only exercised locally on macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)