### PR TITLE
TUI Stage 4.5b: Actions / Intents / Shortcuts

### DIFF
--- a/app/examples/tui/shortcuts_demo.dart
+++ b/app/examples/tui/shortcuts_demo.dart
@@ -1,0 +1,173 @@
+// Stage 4.5b shortcuts demo. Run in a real terminal:
+//   cd app && dart run examples/tui/shortcuts_demo.dart
+// Tab / Shift-Tab cycle focus, arrows move directionally. Enter increments the
+// focused panel's counter; panel D also accepts '+'. Escape or q quits.
+
+import 'dart:async';
+
+import 'package:flutterware_app/src/tui/tui.dart';
+
+/// An `Action<ActivateIntent>` that runs a callback.
+class _CallbackActivate extends Action<ActivateIntent> {
+  _CallbackActivate(this.onInvoke);
+  final void Function() onInvoke;
+  @override
+  Object? invoke(ActivateIntent intent) {
+    onInvoke();
+    return null;
+  }
+}
+
+/// An `Action<DismissIntent>` that runs a callback.
+class _CallbackDismiss extends Action<DismissIntent> {
+  _CallbackDismiss(this.onInvoke);
+  final void Function() onInvoke;
+  @override
+  Object? invoke(DismissIntent intent) {
+    onInvoke();
+    return null;
+  }
+}
+
+/// A focusable panel with a counter incremented via [ActivateIntent].
+///
+/// Wraps its [Focus] in an [Actions] so the focused-path lookup finds the
+/// increment action. When [activateKey] is set, an extra [Shortcuts] maps that
+/// key to [ActivateIntent] for this panel only.
+class CounterPanel extends StatefulWidget {
+  const CounterPanel({
+    required this.label,
+    this.autofocus = false,
+    this.activateKey,
+    super.key,
+  });
+
+  final String label;
+  final bool autofocus;
+  final KeyEvent? activateKey;
+
+  @override
+  State<CounterPanel> createState() => _CounterPanelState();
+}
+
+class _CounterPanelState extends State<CounterPanel> {
+  int _count = 0;
+
+  void _increment() => setState(() => _count++);
+
+  @override
+  Widget build(BuildContext context) {
+    Widget panel = Actions(
+      actions: {ActivateIntent: _CallbackActivate(_increment)},
+      child: Focus(
+        autofocus: widget.autofocus,
+        child: Builder(builder: (context) {
+          var focused = Focus.of(context).hasFocus;
+          var accent = focused ? Color.brightCyan : Color.brightBlack;
+          return DecoratedBox(
+            decoration: BoxDecoration(
+              border: BoxBorder(
+                chars: focused ? BorderChars.double() : BorderChars.rounded(),
+                fg: accent,
+              ),
+            ),
+            child: Padding(
+              padding: EdgeInsets.all(1),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  Text(widget.label, fg: accent, style: TextStyle.bold),
+                  Text('count: $_count',
+                      fg: focused ? Color.brightWhite : Color.brightBlack),
+                ],
+              ),
+            ),
+          );
+        }),
+      ),
+    );
+    var activateKey = widget.activateKey;
+    if (activateKey != null) {
+      panel = Shortcuts(
+        shortcuts: {activateKey: const ActivateIntent()},
+        child: panel,
+      );
+    }
+    return panel;
+  }
+}
+
+/// Root of the demo: a 2x2 grid wrapped in an Actions for Escape-to-quit.
+class ShortcutsDemoApp extends StatefulWidget {
+  const ShortcutsDemoApp({super.key});
+
+  @override
+  State<ShortcutsDemoApp> createState() => _ShortcutsDemoState();
+}
+
+class _ShortcutsDemoState extends State<ShortcutsDemoApp> {
+  StreamSubscription<KeyEvent>? _keySub;
+  bool _subscribed = false;
+
+  @override
+  void didChangeDependencies() {
+    if (_subscribed) return;
+    _subscribed = true;
+    var app = TerminalApp.of(context);
+    _keySub = app.keys.listen((event) {
+      if (event is CharKey && event.rune == 0x71 /* q */) {
+        app.exit();
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    unawaited(_keySub?.cancel());
+  }
+
+  Widget _row(List<Widget> panels) => Expanded(
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            for (var i = 0; i < panels.length; i++) ...[
+              if (i > 0) SizedBox(width: 1),
+              Expanded(child: panels[i]),
+            ],
+          ],
+        ),
+      );
+
+  @override
+  Widget build(BuildContext context) {
+    var exit = TerminalApp.of(context).exit;
+    return Actions(
+      actions: {DismissIntent: _CallbackDismiss(exit)},
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Text(
+            'shortcuts demo - Tab/arrows - Enter activates - Esc/q quits',
+            fg: Color.brightWhite,
+            style: TextStyle.bold,
+          ),
+          SizedBox(height: 1),
+          _row(const [
+            CounterPanel(label: 'panel A', autofocus: true),
+            CounterPanel(label: 'panel B'),
+          ]),
+          SizedBox(height: 1),
+          _row(const [
+            CounterPanel(label: 'panel C'),
+            CounterPanel(
+              label: 'panel D (+)',
+              activateKey: CharKey(rune: 0x2b /* + */, modifiers: {}),
+            ),
+          ]),
+        ],
+      ),
+    );
+  }
+}
+
+Future<void> main() => runApp(const ShortcutsDemoApp());

--- a/app/lib/src/tui/README.md
+++ b/app/lib/src/tui/README.md
@@ -6,7 +6,8 @@ declarative UI that renders to a character grid instead of pixels.
 The long-term goal mirrors Flutter's three-tree pipeline
 (Widget → Element → RenderObject), but the render and engine layers are
 terminal-shaped rather than Skia-shaped. **This package is currently at
-stage 4.5a: engine, paint kit, render tree, widget layer, and focus system.** See
+stage 4.5b: engine, paint kit, render tree, widget layer, focus system, and
+declarative actions/shortcuts.** See
 [the roadmap](../../../../docs/superpowers/tui-roadmap.md) for the staged
 plan.
 
@@ -29,6 +30,8 @@ plan.
 | `widgets/focus_manager.dart` | `FocusNode`, `FocusScopeNode`, `FocusManager`, `KeyEventResult` — the focus tree and key-event routing |
 | `widgets/focus_scope.dart` | `Focus` and `FocusScope` widgets — declarative wrappers around focus nodes |
 | `widgets/focus_traversal.dart` | `FocusTraversalPolicy`, `ReadingOrderTraversalPolicy`, `DirectionalFocusTraversalPolicy`, `FocusTraversalGroup` — Tab/Shift-Tab and arrow-key traversal |
+| `widgets/actions.dart` | `Intent`/`Action`/`Actions` — the declarative action layer |
+| `widgets/shortcuts.dart` | `Shortcuts`/`ShortcutManager` — key-event to intent bindings |
 
 Examples live in `app/examples/tui/`. The richest is `widget_showcase.dart`, an animated five-scene showcase reel (plasma, starfield, charts, layout lab, typography) with keyboard navigation — run it with `cd app && dart run examples/tui/widget_showcase.dart`.
 
@@ -141,14 +144,15 @@ current terminal size, and an `exit` hook.
 
 ## Current limitations
 
-Stage 4.5a is intentionally scoped. Not yet supported:
+Stage 4.5b is intentionally scoped. Not yet supported:
 
 - Repaint is whole-tree: with no layer model, `markNeedsPaint` repaints
   everything. Re-layout *is* localized to relayout boundaries.
 - No GlobalKey or animation/tickers — deferred to later stages.
 - The focus system (focus tree, traversal, key routing) is implemented as of
-  Stage 4.5a. The declarative `Actions`/`Intents`/`Shortcuts` key-binding layer
-  is deferred to Stage 4.5b.
+  Stage 4.5a, and the declarative `Actions`/`Intents`/`Shortcuts` key-binding
+  layer as of Stage 4.5b. Traversal and the Enter/Escape bindings are installed
+  by default on `rootScope`.
 - No render object clips its children. A child larger than its slot (e.g. a
   `FlexFit.loose` child, or content overflowing a panel) will bleed; a parent
   must opt into `Painter.clip` itself. A `RenderClipRect` is left for a later

--- a/app/lib/src/tui/tui.dart
+++ b/app/lib/src/tui/tui.dart
@@ -94,4 +94,6 @@ export 'widgets/widgets.dart'
         NextFocusAction,
         PreviousFocusAction,
         DirectionalFocusAction,
-        defaultTraversalActions;
+        defaultTraversalActions,
+        Shortcuts,
+        defaultShortcuts;

--- a/app/lib/src/tui/tui.dart
+++ b/app/lib/src/tui/tui.dart
@@ -87,4 +87,11 @@ export 'widgets/widgets.dart'
         ActivateIntent,
         DismissIntent,
         ShortcutMap,
-        ShortcutManager;
+        ShortcutManager,
+        NextFocusIntent,
+        PreviousFocusIntent,
+        DirectionalFocusIntent,
+        NextFocusAction,
+        PreviousFocusAction,
+        DirectionalFocusAction,
+        defaultTraversalActions;

--- a/app/lib/src/tui/tui.dart
+++ b/app/lib/src/tui/tui.dart
@@ -85,4 +85,6 @@ export 'widgets/widgets.dart'
         Action,
         Actions,
         ActivateIntent,
-        DismissIntent;
+        DismissIntent,
+        ShortcutMap,
+        ShortcutManager;

--- a/app/lib/src/tui/tui.dart
+++ b/app/lib/src/tui/tui.dart
@@ -80,4 +80,9 @@ export 'widgets/widgets.dart'
         ReadingOrderTraversalPolicy,
         DirectionalFocusTraversalPolicy,
         FocusScope,
-        FocusTraversalGroup;
+        FocusTraversalGroup,
+        Intent,
+        Action,
+        Actions,
+        ActivateIntent,
+        DismissIntent;

--- a/app/lib/src/tui/widgets/actions.dart
+++ b/app/lib/src/tui/widgets/actions.dart
@@ -1,0 +1,98 @@
+part of 'widgets.dart';
+
+/// A marker describing a desired action.
+///
+/// An [Intent] is an immutable value object. A [Shortcuts] widget maps a
+/// [KeyEvent] to an [Intent]; an [Actions] widget maps an [Intent]'s runtime
+/// type to an [Action] that performs it. Transcribed from Flutter.
+abstract class Intent {
+  const Intent();
+}
+
+/// Performs the work for an [Intent] of type [T].
+///
+/// Registered in an [Actions] widget keyed by intent type. [Action] is
+/// generic and Dart class generics are covariant, so an `Action<MyIntent>`
+/// stores into a `Map<Type, Action<Intent>>`; lookups are by
+/// `intent.runtimeType`, so the value passed to [invoke]/[isEnabled] always
+/// matches the action's real [T].
+abstract class Action<T extends Intent> {
+  /// Whether this action can run for [intent] right now. Defaults to true.
+  bool isEnabled(T intent) => true;
+
+  /// Performs the action. The return value is forwarded to the invoker.
+  Object? invoke(T intent);
+}
+
+/// "Activate the focused thing" — e.g. press a button.
+///
+/// Bound to Enter by [defaultShortcuts]; an app supplies the matching [Action]
+/// via an [Actions] widget. No default action ships with the framework.
+class ActivateIntent extends Intent {
+  const ActivateIntent();
+}
+
+/// "Dismiss / cancel" — e.g. close a dialog.
+///
+/// Bound to Escape by [defaultShortcuts]; an app supplies the matching
+/// [Action]. No default action ships with the framework.
+class DismissIntent extends Intent {
+  const DismissIntent();
+}
+
+/// Inherited marker carrying an [Action] map down the tree.
+///
+/// The element layer keeps only the nearest inherited element per type, so a
+/// chained lookup cannot see every [_ActionsMarker] at once. Each marker
+/// therefore holds a [parent] pointer to the enclosing marker, and [find]
+/// recurses outward.
+class _ActionsMarker extends InheritedWidget {
+  const _ActionsMarker({
+    required this.actions,
+    required this.parent,
+    required super.child,
+  });
+
+  final Map<Type, Action<Intent>> actions;
+  final _ActionsMarker? parent;
+
+  /// The nearest [Action] registered for [intentType], walking outward.
+  Action<Intent>? find(Type intentType) =>
+      actions[intentType] ?? parent?.find(intentType);
+
+  @override
+  bool updateShouldNotify(_ActionsMarker oldWidget) =>
+      actions != oldWidget.actions || !identical(parent, oldWidget.parent);
+}
+
+/// Maps [Intent] runtime types to the [Action]s that perform them.
+///
+/// Lookups walk outward through enclosing [Actions]: an inner [Actions]
+/// shadows an outer one for the same intent type, and an unmatched type falls
+/// through to the enclosing [Actions].
+class Actions extends StatelessWidget {
+  const Actions({super.key, required this.actions, required this.child});
+
+  /// Intent runtime type → [Action]. Build a map literal such as
+  /// `{ActivateIntent: MyActivateAction()}`.
+  final Map<Type, Action<Intent>> actions;
+
+  final Widget child;
+
+  /// The nearest [Action] registered for [intent]'s runtime type, or null.
+  ///
+  /// Does not register an inherited dependency — safe to call from a key
+  /// handler rather than a build method.
+  static Action<Intent>? maybeFind(BuildContext context, Intent intent) {
+    var marker = context.getInheritedWidgetOfExactType<_ActionsMarker>();
+    return marker?.find(intent.runtimeType);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // Depend on the enclosing marker: if an Actions is inserted above, this
+    // one must rebuild to refresh its parent pointer.
+    var parent = context.dependOnInheritedWidgetOfExactType<_ActionsMarker>();
+    return _ActionsMarker(actions: actions, parent: parent, child: child);
+  }
+}

--- a/app/lib/src/tui/widgets/binding.dart
+++ b/app/lib/src/tui/widgets/binding.dart
@@ -142,6 +142,10 @@ class TuiBinding {
   /// Owns the focus tree and routes key events.
   final FocusManager focusManager = FocusManager();
 
+  /// The default key bindings (traversal, activate, dismiss), wired onto
+  /// [FocusManager.rootScope] by [attachRootWidget].
+  late final ShortcutManager rootShortcutManager;
+
   /// The render-tree root.
   late final RenderTuiView renderView;
 
@@ -172,6 +176,11 @@ class TuiBinding {
     renderView.prepareInitialFrame();
     buildOwner.onBuildScheduled = () => onFrameNeeded?.call();
     focusManager.onFocusChange = () => onFrameNeeded?.call();
+    rootShortcutManager = ShortcutManager(
+      shortcuts: defaultShortcuts(),
+      fallbackActions: defaultTraversalActions(focusManager),
+    );
+    focusManager.rootScope.onKeyEvent = rootShortcutManager.handleFocusKeyEvent;
     buildOwner.buildScope(
         _rootElement!, () => _rootElement!.mountAsRoot(buildOwner));
   }

--- a/app/lib/src/tui/widgets/focus_manager.dart
+++ b/app/lib/src/tui/widgets/focus_manager.dart
@@ -250,11 +250,6 @@ class FocusManager {
   /// The [TuiBinding] wires this to its frame scheduler.
   void Function()? onFocusChange;
 
-  /// The traversal policy used by the built-in Tab/arrow fallback when no
-  /// [FocusTraversalGroup] overrides it.
-  final FocusTraversalPolicy defaultTraversalPolicy =
-      ReadingOrderTraversalPolicy();
-
   void _markNextFocus(FocusNode node) {
     _nextFocus = node;
     if (!_haveScheduledUpdate) {
@@ -292,9 +287,9 @@ class FocusManager {
   ///
   /// Calls [FocusNode.onKeyEvent] on the primary focus, then each ancestor up
   /// to [rootScope], stopping on [KeyEventResult.handled] or
-  /// [KeyEventResult.skipRemainingHandlers]. If the whole chain returns
-  /// [KeyEventResult.ignored], the built-in traversal fallback runs (see
-  /// [_handleTraversalKey]).
+  /// [KeyEventResult.skipRemainingHandlers]. The default key bindings
+  /// (traversal, activate, dismiss) live on `rootScope.onKeyEvent`, wired by
+  /// `attachRootWidget` — `rootScope` is the last node in every chain.
   KeyEventResult handleKeyEvent(KeyEvent event) {
     var chain = <FocusNode>[_primaryFocus, ..._primaryFocus.ancestors];
     for (var node in chain) {
@@ -306,53 +301,7 @@ class FocusManager {
         return result;
       }
     }
-    return _handleTraversalKey(event);
-  }
-
-  /// Built-in fallback for unhandled Tab/Shift-Tab and arrow keys.
-  ///
-  /// This is the deliberate seam between Stage 4.5a and 4.5b: when the
-  /// declarative `Shortcuts`/`Actions` layer lands, this method is removed and
-  /// the same keys route through it instead.
-  KeyEventResult _handleTraversalKey(KeyEvent event) {
-    if (event is! SpecialKey) return KeyEventResult.ignored;
-    var policy = _policyFor(_primaryFocus);
-    var moved = false;
-    switch (event.code) {
-      case SpecialKeyCode.tab:
-        moved = event.modifiers.contains(Modifier.shift)
-            ? policy.previous(_primaryFocus)
-            : policy.next(_primaryFocus);
-      case SpecialKeyCode.up:
-        moved = _directional(policy, TraversalDirection.up);
-      case SpecialKeyCode.down:
-        moved = _directional(policy, TraversalDirection.down);
-      case SpecialKeyCode.left:
-        moved = _directional(policy, TraversalDirection.left);
-      case SpecialKeyCode.right:
-        moved = _directional(policy, TraversalDirection.right);
-      case _:
-        return KeyEventResult.ignored;
-    }
-    return moved ? KeyEventResult.handled : KeyEventResult.ignored;
-  }
-
-  bool _directional(FocusTraversalPolicy policy, TraversalDirection dir) {
-    // Directional traversal always uses the directional policy, even when the
-    // ambient policy is reading-order.
-    var directional = policy is DirectionalFocusTraversalPolicy
-        ? policy
-        : DirectionalFocusTraversalPolicy();
-    return directional.inDirection(_primaryFocus, dir);
-  }
-
-  FocusTraversalPolicy _policyFor(FocusNode node) {
-    var context = node.context;
-    if (context != null) {
-      var policy = FocusTraversalGroup.maybeOf(context);
-      if (policy != null) return policy;
-    }
-    return defaultTraversalPolicy;
+    return KeyEventResult.ignored;
   }
 
   Set<FocusNode> _chainOf(FocusNode node) {

--- a/app/lib/src/tui/widgets/focus_manager.dart
+++ b/app/lib/src/tui/widgets/focus_manager.dart
@@ -38,6 +38,9 @@ class FocusNode {
   /// The focus node this node is attached under, or null if detached.
   FocusNode? get parent => _parent;
 
+  /// The [FocusManager] this node is attached to, or null if detached.
+  FocusManager? get manager => _manager;
+
   /// The build context of the owning [Focus] widget. Set by [Focus]'s state;
   /// used by traversal to compute this node's on-screen rectangle.
   BuildContext? context;

--- a/app/lib/src/tui/widgets/focus_traversal.dart
+++ b/app/lib/src/tui/widgets/focus_traversal.dart
@@ -27,16 +27,18 @@ abstract class FocusTraversalPolicy {
 
   bool _move(FocusNode currentNode, {required bool forward}) {
     var ordered = _candidates(currentNode);
-    if (ordered.length < 2) return false;
+    if (ordered.isEmpty) return false;
     var index = ordered.indexOf(currentNode);
-    int nextIndex;
     if (index < 0) {
-      nextIndex = forward ? 0 : ordered.length - 1;
-    } else {
-      nextIndex = forward
-          ? (index + 1) % ordered.length
-          : (index - 1 + ordered.length) % ordered.length;
+      // currentNode is not itself traversable (e.g. it is a scope node):
+      // focus the first or last node unconditionally.
+      (forward ? ordered.first : ordered.last).requestFocus();
+      return true;
     }
+    if (ordered.length < 2) return false;
+    var nextIndex = forward
+        ? (index + 1) % ordered.length
+        : (index - 1 + ordered.length) % ordered.length;
     ordered[nextIndex].requestFocus();
     return true;
   }

--- a/app/lib/src/tui/widgets/focus_traversal.dart
+++ b/app/lib/src/tui/widgets/focus_traversal.dart
@@ -148,3 +148,89 @@ class FocusTraversalGroup extends StatelessWidget {
   Widget build(BuildContext context) =>
       _FocusTraversalMarker(policy: policy, child: child);
 }
+
+/// Intent: move focus to the next node in traversal order.
+class NextFocusIntent extends Intent {
+  const NextFocusIntent();
+}
+
+/// Intent: move focus to the previous node in traversal order.
+class PreviousFocusIntent extends Intent {
+  const PreviousFocusIntent();
+}
+
+/// Intent: move focus in a direction (arrow keys).
+class DirectionalFocusIntent extends Intent {
+  const DirectionalFocusIntent(this.direction);
+  final TraversalDirection direction;
+}
+
+/// The traversal policy nearest [node], defaulting to reading order.
+///
+/// Reads the [FocusTraversalGroup] policy from [node]'s context when it has
+/// one; otherwise a fresh [ReadingOrderTraversalPolicy]. (Relocated from the
+/// Stage 4.5a `FocusManager._policyFor`.)
+FocusTraversalPolicy _policyFor(FocusNode node) {
+  var context = node.context;
+  if (context != null) {
+    var policy = FocusTraversalGroup.maybeOf(context);
+    if (policy != null) return policy;
+  }
+  return ReadingOrderTraversalPolicy();
+}
+
+/// Moves focus to the next traversable node.
+class NextFocusAction extends Action<NextFocusIntent> {
+  NextFocusAction(this.focusManager);
+  final FocusManager focusManager;
+
+  @override
+  Object? invoke(NextFocusIntent intent) {
+    var node = focusManager.primaryFocus;
+    _policyFor(node).next(node);
+    return null;
+  }
+}
+
+/// Moves focus to the previous traversable node.
+class PreviousFocusAction extends Action<PreviousFocusIntent> {
+  PreviousFocusAction(this.focusManager);
+  final FocusManager focusManager;
+
+  @override
+  Object? invoke(PreviousFocusIntent intent) {
+    var node = focusManager.primaryFocus;
+    _policyFor(node).previous(node);
+    return null;
+  }
+}
+
+/// Moves focus in [DirectionalFocusIntent.direction].
+///
+/// Directional traversal always uses a [DirectionalFocusTraversalPolicy], even
+/// when the ambient policy is reading-order. (Relocated from the Stage 4.5a
+/// `FocusManager._directional`.)
+class DirectionalFocusAction extends Action<DirectionalFocusIntent> {
+  DirectionalFocusAction(this.focusManager);
+  final FocusManager focusManager;
+
+  @override
+  Object? invoke(DirectionalFocusIntent intent) {
+    var node = focusManager.primaryFocus;
+    var policy = _policyFor(node);
+    var directional = policy is DirectionalFocusTraversalPolicy
+        ? policy
+        : DirectionalFocusTraversalPolicy();
+    directional.inDirection(node, intent.direction);
+    return null;
+  }
+}
+
+/// The default traversal action map for a root [ShortcutManager]'s
+/// `fallbackActions`.
+Map<Type, Action<Intent>> defaultTraversalActions(FocusManager focusManager) =>
+    {
+      NextFocusIntent: NextFocusAction(focusManager),
+      PreviousFocusIntent: PreviousFocusAction(focusManager),
+      DirectionalFocusIntent: DirectionalFocusAction(focusManager),
+    };

--- a/app/lib/src/tui/widgets/shortcuts.dart
+++ b/app/lib/src/tui/widgets/shortcuts.dart
@@ -105,11 +105,11 @@ class _ShortcutsState extends State<Shortcuts> {
       );
 }
 
-/// The framework default key bindings, auto-installed on
-/// [FocusManager.rootScope] by `attachRootWidget`.
+/// The framework default key bindings.
 ///
 /// Tab/Shift-Tab and the arrow keys drive focus traversal; Enter and Escape
 /// map to [ActivateIntent]/[DismissIntent] (an app supplies the actions).
+/// `attachRootWidget` installs these on [FocusManager.rootScope].
 ShortcutMap defaultShortcuts() => {
       const SpecialKey(code: SpecialKeyCode.tab, modifiers: {}):
           const NextFocusIntent(),

--- a/app/lib/src/tui/widgets/shortcuts.dart
+++ b/app/lib/src/tui/widgets/shortcuts.dart
@@ -1,0 +1,54 @@
+part of 'widgets.dart';
+
+/// A key-event-to-intent map.
+///
+/// [KeyEvent] has value equality and a `Set<Modifier>`, so it is a usable map
+/// key directly — the TUI needs no `LogicalKeySet`/`ShortcutActivator`
+/// machinery.
+typedef ShortcutMap = Map<KeyEvent, Intent>;
+
+/// Resolves a [KeyEvent] to an [Intent] and invokes the matching [Action].
+///
+/// One [ShortcutManager] backs each [Shortcuts] widget, and one — carrying the
+/// default bindings — is wired onto [FocusManager.rootScope]'s `onKeyEvent` by
+/// `attachRootWidget`. The only difference between an app manager and the root
+/// manager is that the root one carries [fallbackActions].
+class ShortcutManager {
+  ShortcutManager({
+    this.shortcuts = const {},
+    this.fallbackActions = const {},
+  });
+
+  /// The key bindings this manager owns.
+  ShortcutMap shortcuts;
+
+  /// Actions consulted when no enclosing [Actions] widget supplies one for a
+  /// resolved intent. Empty for app [Shortcuts]; the root manager carries the
+  /// default traversal actions here.
+  Map<Type, Action<Intent>> fallbackActions;
+
+  /// A [FocusOnKeyEventCallback]: used as `rootScope.onKeyEvent` and as the
+  /// [Shortcuts] widget's `Focus.onKeyEvent`.
+  ///
+  /// Looks [event] up in [shortcuts]; if it maps to an intent, resolves the
+  /// [Action] from the *focused* widget's context (so an [Actions] widget on
+  /// the focused path is honoured), then from [fallbackActions]. Returns
+  /// [KeyEventResult.handled] only when an enabled action ran.
+  KeyEventResult handleFocusKeyEvent(FocusNode node, KeyEvent event) {
+    var intent = shortcuts[event];
+    if (intent == null) return KeyEventResult.ignored;
+
+    var context = node.manager?.primaryFocus.context;
+    Action<Intent>? action;
+    if (context != null) {
+      action = Actions.maybeFind(context, intent);
+    }
+    action ??= fallbackActions[intent.runtimeType];
+
+    if (action == null || !action.isEnabled(intent)) {
+      return KeyEventResult.ignored;
+    }
+    action.invoke(intent);
+    return KeyEventResult.handled;
+  }
+}

--- a/app/lib/src/tui/widgets/shortcuts.dart
+++ b/app/lib/src/tui/widgets/shortcuts.dart
@@ -52,3 +52,79 @@ class ShortcutManager {
     return KeyEventResult.handled;
   }
 }
+
+/// Maps [KeyEvent]s to [Intent]s for a subtree.
+///
+/// Wraps [child] in a non-focusable, traversal-skipping [Focus] whose
+/// `onKeyEvent` is the [ShortcutManager]. Because that [Focus] joins the focus
+/// chain, a [Shortcuts] enclosing the focused subtree intercepts keys before
+/// the root defaults — giving scoped overrides.
+class Shortcuts extends StatefulWidget {
+  const Shortcuts({
+    super.key,
+    required this.shortcuts,
+    required this.child,
+    this.manager,
+  });
+
+  /// The key bindings for this subtree.
+  final ShortcutMap shortcuts;
+
+  /// An externally-owned manager to adopt. When null, one is created.
+  final ShortcutManager? manager;
+
+  final Widget child;
+
+  @override
+  State<Shortcuts> createState() => _ShortcutsState();
+}
+
+class _ShortcutsState extends State<Shortcuts> {
+  late ShortcutManager _manager;
+
+  @override
+  void initState() {
+    _manager = widget.manager ?? ShortcutManager();
+    _manager.shortcuts = widget.shortcuts;
+  }
+
+  @override
+  void didUpdateWidget(Shortcuts oldWidget) {
+    if (!identical(widget.manager, oldWidget.manager)) {
+      _manager = widget.manager ?? ShortcutManager();
+    }
+    _manager.shortcuts = widget.shortcuts;
+  }
+
+  @override
+  Widget build(BuildContext context) => Focus(
+        skipTraversal: true,
+        canRequestFocus: false,
+        onKeyEvent: _manager.handleFocusKeyEvent,
+        child: widget.child,
+      );
+}
+
+/// The framework default key bindings, auto-installed on
+/// [FocusManager.rootScope] by `attachRootWidget`.
+///
+/// Tab/Shift-Tab and the arrow keys drive focus traversal; Enter and Escape
+/// map to [ActivateIntent]/[DismissIntent] (an app supplies the actions).
+ShortcutMap defaultShortcuts() => {
+      const SpecialKey(code: SpecialKeyCode.tab, modifiers: {}):
+          const NextFocusIntent(),
+      const SpecialKey(code: SpecialKeyCode.tab, modifiers: {Modifier.shift}):
+          const PreviousFocusIntent(),
+      const SpecialKey(code: SpecialKeyCode.up, modifiers: {}):
+          const DirectionalFocusIntent(TraversalDirection.up),
+      const SpecialKey(code: SpecialKeyCode.down, modifiers: {}):
+          const DirectionalFocusIntent(TraversalDirection.down),
+      const SpecialKey(code: SpecialKeyCode.left, modifiers: {}):
+          const DirectionalFocusIntent(TraversalDirection.left),
+      const SpecialKey(code: SpecialKeyCode.right, modifiers: {}):
+          const DirectionalFocusIntent(TraversalDirection.right),
+      const SpecialKey(code: SpecialKeyCode.enter, modifiers: {}):
+          const ActivateIntent(),
+      const SpecialKey(code: SpecialKeyCode.escape, modifiers: {}):
+          const DismissIntent(),
+    };

--- a/app/lib/src/tui/widgets/widgets.dart
+++ b/app/lib/src/tui/widgets/widgets.dart
@@ -24,3 +24,4 @@ part 'focus_manager.dart';
 part 'focus_traversal.dart';
 part 'focus_scope.dart';
 part 'actions.dart';
+part 'shortcuts.dart';

--- a/app/lib/src/tui/widgets/widgets.dart
+++ b/app/lib/src/tui/widgets/widgets.dart
@@ -23,3 +23,4 @@ part 'binding.dart';
 part 'focus_manager.dart';
 part 'focus_traversal.dart';
 part 'focus_scope.dart';
+part 'actions.dart';

--- a/app/test/tui/widgets/actions_test.dart
+++ b/app/test/tui/widgets/actions_test.dart
@@ -1,0 +1,88 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutterware_app/src/tui/tui.dart';
+
+import 'harness.dart';
+
+class _IntentA extends Intent {
+  const _IntentA();
+}
+
+class _IntentB extends Intent {
+  const _IntentB();
+}
+
+/// An action that records that it was found, tagged so tests can tell
+/// instances apart.
+class _TaggedAction extends Action<Intent> {
+  _TaggedAction(this.tag);
+  final String tag;
+  @override
+  Object? invoke(Intent intent) => tag;
+}
+
+void main() {
+  test('maybeFind returns the action registered for the intent type', () {
+    Action<Intent>? found;
+    pump(Actions(
+      actions: {_IntentA: _TaggedAction('a')},
+      child: Builder(builder: (context) {
+        found = Actions.maybeFind(context, const _IntentA());
+        return SizedBox();
+      }),
+    ));
+    expect(found, isA<_TaggedAction>());
+    expect((found as _TaggedAction).tag, 'a');
+  });
+
+  test('maybeFind is null for an unregistered intent type', () {
+    Action<Intent>? found;
+    var sentinel = _TaggedAction('present');
+    pump(Actions(
+      actions: {_IntentA: sentinel},
+      child: Builder(builder: (context) {
+        found = Actions.maybeFind(context, const _IntentB());
+        return SizedBox();
+      }),
+    ));
+    expect(found, isNull);
+  });
+
+  test('maybeFind is null when there is no enclosing Actions', () {
+    Action<Intent>? found;
+    pump(Builder(builder: (context) {
+      found = Actions.maybeFind(context, const _IntentA());
+      return SizedBox();
+    }));
+    expect(found, isNull);
+  });
+
+  test('lookup falls through to an enclosing Actions', () {
+    Action<Intent>? found;
+    pump(Actions(
+      actions: {_IntentA: _TaggedAction('outer-a')},
+      child: Actions(
+        actions: {_IntentB: _TaggedAction('inner-b')},
+        child: Builder(builder: (context) {
+          found = Actions.maybeFind(context, const _IntentA());
+          return SizedBox();
+        }),
+      ),
+    ));
+    expect((found as _TaggedAction).tag, 'outer-a');
+  });
+
+  test('an inner Actions shadows an outer one for the same intent type', () {
+    Action<Intent>? found;
+    pump(Actions(
+      actions: {_IntentA: _TaggedAction('outer')},
+      child: Actions(
+        actions: {_IntentA: _TaggedAction('inner')},
+        child: Builder(builder: (context) {
+          found = Actions.maybeFind(context, const _IntentA());
+          return SizedBox();
+        }),
+      ),
+    ));
+    expect((found as _TaggedAction).tag, 'inner');
+  });
+}

--- a/app/test/tui/widgets/actions_test.dart
+++ b/app/test/tui/widgets/actions_test.dart
@@ -31,7 +31,7 @@ void main() {
       }),
     ));
     expect(found, isA<_TaggedAction>());
-    expect((found as _TaggedAction).tag, 'a');
+    expect((found! as _TaggedAction).tag, 'a');
   });
 
   test('maybeFind is null for an unregistered intent type', () {
@@ -68,7 +68,7 @@ void main() {
         }),
       ),
     ));
-    expect((found as _TaggedAction).tag, 'outer-a');
+    expect((found! as _TaggedAction).tag, 'outer-a');
   });
 
   test('an inner Actions shadows an outer one for the same intent type', () {
@@ -83,6 +83,6 @@ void main() {
         }),
       ),
     ));
-    expect((found as _TaggedAction).tag, 'inner');
+    expect((found! as _TaggedAction).tag, 'inner');
   });
 }

--- a/app/test/tui/widgets/focus_manager_test.dart
+++ b/app/test/tui/widgets/focus_manager_test.dart
@@ -1,14 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutterware_app/src/tui/tui.dart';
 
-/// A FocusNode with a fixed rect, so traversal works without a widget tree.
-class _RectNode extends FocusNode {
-  _RectNode(this.fixedRect);
-  final CellRect fixedRect;
-  @override
-  CellRect? get rect => fixedRect;
-}
-
 void main() {
   test('a fresh manager has rootScope as primary focus after apply', () {
     var manager = FocusManager();
@@ -119,51 +111,5 @@ void main() {
     };
     manager.handleKeyEvent(CharKey(rune: 0x61, modifiers: const {}));
     expect(rootCalled, isFalse);
-  });
-
-  test('unhandled Tab moves focus forward via the fallback', () {
-    var manager = FocusManager();
-    var a = _RectNode(CellRect.fromTLWH(0, 0, 4, 1));
-    var b = _RectNode(CellRect.fromTLWH(0, 10, 4, 1));
-    manager.rootScope.debugAttachChild(a);
-    manager.rootScope.debugAttachChild(b);
-    a.requestFocus();
-    manager.applyFocusChangesIfNeeded();
-
-    var result = manager.handleKeyEvent(
-        const SpecialKey(code: SpecialKeyCode.tab, modifiers: {}));
-    manager.applyFocusChangesIfNeeded();
-    expect(result, KeyEventResult.handled);
-    expect(manager.primaryFocus, b);
-  });
-
-  test('unhandled Shift-Tab moves focus backward', () {
-    var manager = FocusManager();
-    var a = _RectNode(CellRect.fromTLWH(0, 0, 4, 1));
-    var b = _RectNode(CellRect.fromTLWH(0, 10, 4, 1));
-    manager.rootScope.debugAttachChild(a);
-    manager.rootScope.debugAttachChild(b);
-    a.requestFocus();
-    manager.applyFocusChangesIfNeeded();
-
-    manager.handleKeyEvent(const SpecialKey(
-        code: SpecialKeyCode.tab, modifiers: {Modifier.shift}));
-    manager.applyFocusChangesIfNeeded();
-    expect(manager.primaryFocus, b); // wraps backward
-  });
-
-  test('unhandled arrow key moves focus directionally', () {
-    var manager = FocusManager();
-    var a = _RectNode(CellRect.fromTLWH(0, 0, 4, 3));
-    var b = _RectNode(CellRect.fromTLWH(0, 20, 4, 3));
-    manager.rootScope.debugAttachChild(a);
-    manager.rootScope.debugAttachChild(b);
-    a.requestFocus();
-    manager.applyFocusChangesIfNeeded();
-
-    manager.handleKeyEvent(
-        const SpecialKey(code: SpecialKeyCode.right, modifiers: {}));
-    manager.applyFocusChangesIfNeeded();
-    expect(manager.primaryFocus, b);
   });
 }

--- a/app/test/tui/widgets/focus_traversal_test.dart
+++ b/app/test/tui/widgets/focus_traversal_test.dart
@@ -107,18 +107,20 @@ void main() {
     expect(manager.primaryFocus, b);
   });
 
-  test('PreviousFocusAction wraps to the last node', () {
+  test('PreviousFocusAction moves to the preceding node', () {
     var manager = FocusManager();
     var a = _FixedNode(CellRect.fromTLWH(0, 0, 4, 1));
     var b = _FixedNode(CellRect.fromTLWH(0, 10, 4, 1));
+    var c = _FixedNode(CellRect.fromTLWH(0, 20, 4, 1));
     manager.rootScope.debugAttachChild(a);
     manager.rootScope.debugAttachChild(b);
-    a.requestFocus();
+    manager.rootScope.debugAttachChild(c);
+    b.requestFocus();
     manager.applyFocusChangesIfNeeded();
 
     PreviousFocusAction(manager).invoke(const PreviousFocusIntent());
     manager.applyFocusChangesIfNeeded();
-    expect(manager.primaryFocus, b);
+    expect(manager.primaryFocus, a);
   });
 
   test('DirectionalFocusAction moves focus in the given direction', () {
@@ -141,5 +143,31 @@ void main() {
     expect(actions[NextFocusIntent], isA<NextFocusAction>());
     expect(actions[PreviousFocusIntent], isA<PreviousFocusAction>());
     expect(actions[DirectionalFocusIntent], isA<DirectionalFocusAction>());
+  });
+
+  test('next from a scope with a single descendant focuses that descendant',
+      () {
+    var manager = FocusManager();
+    var policy = ReadingOrderTraversalPolicy();
+    var only = _FixedNode(CellRect.fromTLWH(0, 0, 4, 1));
+    manager.rootScope.debugAttachChild(only);
+    // primaryFocus is rootScope — a scope node, not itself a candidate.
+
+    expect(policy.next(manager.rootScope), isTrue);
+    manager.applyFocusChangesIfNeeded();
+    expect(manager.primaryFocus, only);
+  });
+
+  test('next from a lone candidate that is the current node does not move', () {
+    var manager = FocusManager();
+    var policy = ReadingOrderTraversalPolicy();
+    var only = _FixedNode(CellRect.fromTLWH(0, 0, 4, 1));
+    manager.rootScope.debugAttachChild(only);
+    only.requestFocus();
+    manager.applyFocusChangesIfNeeded();
+
+    expect(policy.next(only), isFalse);
+    manager.applyFocusChangesIfNeeded();
+    expect(manager.primaryFocus, only);
   });
 }

--- a/app/test/tui/widgets/focus_traversal_test.dart
+++ b/app/test/tui/widgets/focus_traversal_test.dart
@@ -92,4 +92,54 @@ void main() {
     manager.rootScope.debugAttachChild(only);
     expect(policy.inDirection(only, TraversalDirection.up), isFalse);
   });
+
+  test('NextFocusAction moves focus to the following node', () {
+    var manager = FocusManager();
+    var a = _FixedNode(CellRect.fromTLWH(0, 0, 4, 1));
+    var b = _FixedNode(CellRect.fromTLWH(0, 10, 4, 1));
+    manager.rootScope.debugAttachChild(a);
+    manager.rootScope.debugAttachChild(b);
+    a.requestFocus();
+    manager.applyFocusChangesIfNeeded();
+
+    NextFocusAction(manager).invoke(const NextFocusIntent());
+    manager.applyFocusChangesIfNeeded();
+    expect(manager.primaryFocus, b);
+  });
+
+  test('PreviousFocusAction wraps to the last node', () {
+    var manager = FocusManager();
+    var a = _FixedNode(CellRect.fromTLWH(0, 0, 4, 1));
+    var b = _FixedNode(CellRect.fromTLWH(0, 10, 4, 1));
+    manager.rootScope.debugAttachChild(a);
+    manager.rootScope.debugAttachChild(b);
+    a.requestFocus();
+    manager.applyFocusChangesIfNeeded();
+
+    PreviousFocusAction(manager).invoke(const PreviousFocusIntent());
+    manager.applyFocusChangesIfNeeded();
+    expect(manager.primaryFocus, b);
+  });
+
+  test('DirectionalFocusAction moves focus in the given direction', () {
+    var manager = FocusManager();
+    var left = _FixedNode(CellRect.fromTLWH(0, 0, 6, 3));
+    var right = _FixedNode(CellRect.fromTLWH(0, 20, 6, 3));
+    manager.rootScope.debugAttachChild(left);
+    manager.rootScope.debugAttachChild(right);
+    left.requestFocus();
+    manager.applyFocusChangesIfNeeded();
+
+    DirectionalFocusAction(manager)
+        .invoke(const DirectionalFocusIntent(TraversalDirection.right));
+    manager.applyFocusChangesIfNeeded();
+    expect(manager.primaryFocus, right);
+  });
+
+  test('defaultTraversalActions maps each traversal intent type', () {
+    var actions = defaultTraversalActions(FocusManager());
+    expect(actions[NextFocusIntent], isA<NextFocusAction>());
+    expect(actions[PreviousFocusIntent], isA<PreviousFocusAction>());
+    expect(actions[DirectionalFocusIntent], isA<DirectionalFocusAction>());
+  });
 }

--- a/app/test/tui/widgets/shortcuts_test.dart
+++ b/app/test/tui/widgets/shortcuts_test.dart
@@ -5,6 +5,17 @@ class _PingIntent extends Intent {
   const _PingIntent();
 }
 
+/// An `Action<ActivateIntent>` that runs a callback when invoked.
+class _CallbackActivate extends Action<ActivateIntent> {
+  _CallbackActivate(this.onInvoke);
+  final void Function() onInvoke;
+  @override
+  Object? invoke(ActivateIntent intent) {
+    onInvoke();
+    return null;
+  }
+}
+
 class _PingAction extends Action<_PingIntent> {
   bool invoked = false;
   bool enabled = true;
@@ -69,5 +80,75 @@ void main() {
     var sm = ShortcutManager(shortcuts: {pingKey: const _PingIntent()});
     var result = sm.handleFocusKeyEvent(fm.manager.rootScope, pingKey);
     expect(result, KeyEventResult.ignored);
+  });
+
+  test('defaultShortcuts binds Tab, arrows, Enter, and Escape', () {
+    var map = defaultShortcuts();
+    expect(map[const SpecialKey(code: SpecialKeyCode.tab, modifiers: {})],
+        isA<NextFocusIntent>());
+    expect(
+        map[const SpecialKey(
+            code: SpecialKeyCode.tab, modifiers: {Modifier.shift})],
+        isA<PreviousFocusIntent>());
+    expect(map[const SpecialKey(code: SpecialKeyCode.up, modifiers: {})],
+        isA<DirectionalFocusIntent>());
+    expect(map[const SpecialKey(code: SpecialKeyCode.enter, modifiers: {})],
+        isA<ActivateIntent>());
+    expect(map[const SpecialKey(code: SpecialKeyCode.escape, modifiers: {})],
+        isA<DismissIntent>());
+  });
+
+  test('a Shortcuts widget intercepts a key for its focused subtree', () {
+    var node = FocusNode();
+    var invoked = false;
+    var binding = TuiBinding();
+    binding.attachRootWidget(Shortcuts(
+      shortcuts: {
+        const CharKey(rune: 0x78 /* x */, modifiers: {}): const ActivateIntent()
+      },
+      child: Actions(
+        actions: {ActivateIntent: _CallbackActivate(() => invoked = true)},
+        child: Focus(
+            focusNode: node,
+            autofocus: true,
+            child: SizedBox(width: 4, height: 2)),
+      ),
+    ));
+    binding.handleResize(CellSize(8, 12));
+    binding.drawFrame(Painter(CellBuffer(8, 12)));
+
+    binding.focusManager
+        .handleKeyEvent(const CharKey(rune: 0x78, modifiers: {}));
+    expect(invoked, isTrue);
+  });
+
+  test('an inner Shortcuts shadows an outer one for the same key', () {
+    var node = FocusNode();
+    var hits = <String>[];
+    var binding = TuiBinding();
+    const xKey = CharKey(rune: 0x78 /* x */, modifiers: {});
+    binding.attachRootWidget(Shortcuts(
+      shortcuts: {xKey: const ActivateIntent()},
+      child: Actions(
+        actions: {ActivateIntent: _CallbackActivate(() => hits.add('outer'))},
+        child: Shortcuts(
+          shortcuts: {xKey: const ActivateIntent()},
+          child: Actions(
+            actions: {
+              ActivateIntent: _CallbackActivate(() => hits.add('inner'))
+            },
+            child: Focus(
+                focusNode: node,
+                autofocus: true,
+                child: SizedBox(width: 4, height: 2)),
+          ),
+        ),
+      ),
+    ));
+    binding.handleResize(CellSize(8, 12));
+    binding.drawFrame(Painter(CellBuffer(8, 12)));
+
+    binding.focusManager.handleKeyEvent(xKey);
+    expect(hits, ['inner']);
   });
 }

--- a/app/test/tui/widgets/shortcuts_test.dart
+++ b/app/test/tui/widgets/shortcuts_test.dart
@@ -92,6 +92,12 @@ void main() {
         isA<PreviousFocusIntent>());
     expect(map[const SpecialKey(code: SpecialKeyCode.up, modifiers: {})],
         isA<DirectionalFocusIntent>());
+    expect(map[const SpecialKey(code: SpecialKeyCode.down, modifiers: {})],
+        isA<DirectionalFocusIntent>());
+    expect(map[const SpecialKey(code: SpecialKeyCode.left, modifiers: {})],
+        isA<DirectionalFocusIntent>());
+    expect(map[const SpecialKey(code: SpecialKeyCode.right, modifiers: {})],
+        isA<DirectionalFocusIntent>());
     expect(map[const SpecialKey(code: SpecialKeyCode.enter, modifiers: {})],
         isA<ActivateIntent>());
     expect(map[const SpecialKey(code: SpecialKeyCode.escape, modifiers: {})],

--- a/app/test/tui/widgets/shortcuts_test.dart
+++ b/app/test/tui/widgets/shortcuts_test.dart
@@ -157,4 +157,60 @@ void main() {
     binding.focusManager.handleKeyEvent(xKey);
     expect(hits, ['inner']);
   });
+
+  test('default shortcuts route Tab through rootScope to move focus', () {
+    var first = FocusNode();
+    var second = FocusNode();
+    var binding = TuiBinding();
+    binding.attachRootWidget(Row(children: [
+      Focus(
+          focusNode: first,
+          autofocus: true,
+          child: SizedBox(width: 5, height: 3)),
+      Focus(focusNode: second, child: SizedBox(width: 5, height: 3)),
+    ]));
+    binding.handleResize(CellSize(10, 30));
+    binding.drawFrame(Painter(CellBuffer(10, 30)));
+    expect(binding.focusManager.primaryFocus, first);
+
+    binding.focusManager.handleKeyEvent(
+        const SpecialKey(code: SpecialKeyCode.tab, modifiers: {}));
+    binding.drawFrame(Painter(CellBuffer(10, 30)));
+    expect(binding.focusManager.primaryFocus, second);
+  });
+
+  test('Tab with nothing focused focuses the first node', () {
+    var only = FocusNode();
+    var binding = TuiBinding();
+    binding.attachRootWidget(
+      Focus(focusNode: only, child: SizedBox(width: 5, height: 3)),
+    );
+    binding.handleResize(CellSize(10, 30));
+    binding.drawFrame(Painter(CellBuffer(10, 30)));
+    expect(binding.focusManager.primaryFocus, binding.focusManager.rootScope);
+
+    binding.focusManager.handleKeyEvent(
+        const SpecialKey(code: SpecialKeyCode.tab, modifiers: {}));
+    binding.drawFrame(Painter(CellBuffer(10, 30)));
+    expect(binding.focusManager.primaryFocus, only);
+  });
+
+  test('Enter routes to an ActivateIntent action on the focused path', () {
+    var node = FocusNode();
+    var invoked = false;
+    var binding = TuiBinding();
+    binding.attachRootWidget(Actions(
+      actions: {ActivateIntent: _CallbackActivate(() => invoked = true)},
+      child: Focus(
+          focusNode: node,
+          autofocus: true,
+          child: SizedBox(width: 4, height: 2)),
+    ));
+    binding.handleResize(CellSize(8, 12));
+    binding.drawFrame(Painter(CellBuffer(8, 12)));
+
+    binding.focusManager.handleKeyEvent(
+        const SpecialKey(code: SpecialKeyCode.enter, modifiers: {}));
+    expect(invoked, isTrue);
+  });
 }

--- a/app/test/tui/widgets/shortcuts_test.dart
+++ b/app/test/tui/widgets/shortcuts_test.dart
@@ -1,0 +1,73 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutterware_app/src/tui/tui.dart';
+
+class _PingIntent extends Intent {
+  const _PingIntent();
+}
+
+class _PingAction extends Action<_PingIntent> {
+  bool invoked = false;
+  bool enabled = true;
+  @override
+  bool isEnabled(_PingIntent intent) => enabled;
+  @override
+  Object? invoke(_PingIntent intent) {
+    invoked = true;
+    return null;
+  }
+}
+
+void main() {
+  const pingKey = CharKey(rune: 0x70 /* p */, modifiers: {});
+
+  ({FocusManager manager, FocusNode node}) focusedManager() {
+    var manager = FocusManager();
+    var node = FocusNode();
+    manager.rootScope.debugAttachChild(node);
+    node.requestFocus();
+    manager.applyFocusChangesIfNeeded();
+    return (manager: manager, node: node);
+  }
+
+  test('a bound key invokes a fallback action and returns handled', () {
+    var fm = focusedManager();
+    var action = _PingAction();
+    var sm = ShortcutManager(
+      shortcuts: {pingKey: const _PingIntent()},
+      fallbackActions: {_PingIntent: action},
+    );
+    var result = sm.handleFocusKeyEvent(fm.manager.rootScope, pingKey);
+    expect(result, KeyEventResult.handled);
+    expect(action.invoked, isTrue);
+  });
+
+  test('an unbound key returns ignored', () {
+    var fm = focusedManager();
+    var sm = ShortcutManager(
+      shortcuts: {pingKey: const _PingIntent()},
+      fallbackActions: {_PingIntent: _PingAction()},
+    );
+    var result = sm.handleFocusKeyEvent(
+        fm.manager.rootScope, const CharKey(rune: 0x7a /* z */, modifiers: {}));
+    expect(result, KeyEventResult.ignored);
+  });
+
+  test('a disabled action returns ignored and is not invoked', () {
+    var fm = focusedManager();
+    var action = _PingAction()..enabled = false;
+    var sm = ShortcutManager(
+      shortcuts: {pingKey: const _PingIntent()},
+      fallbackActions: {_PingIntent: action},
+    );
+    var result = sm.handleFocusKeyEvent(fm.manager.rootScope, pingKey);
+    expect(result, KeyEventResult.ignored);
+    expect(action.invoked, isFalse);
+  });
+
+  test('a bound intent with no action anywhere returns ignored', () {
+    var fm = focusedManager();
+    var sm = ShortcutManager(shortcuts: {pingKey: const _PingIntent()});
+    var result = sm.handleFocusKeyEvent(fm.manager.rootScope, pingKey);
+    expect(result, KeyEventResult.ignored);
+  });
+}

--- a/docs/superpowers/plans/2026-05-17-tui-stage4.5b-actions-shortcuts.md
+++ b/docs/superpowers/plans/2026-05-17-tui-stage4.5b-actions-shortcuts.md
@@ -1,0 +1,1416 @@
+# TUI Stage 4.5b — Actions / Intents / Shortcuts Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add the declarative key-binding layer (`Intent`/`Action`/`Actions`, `Shortcuts`/`ShortcutManager`) to the TUI framework and migrate the Stage 4.5a built-in Tab/arrow traversal fallback onto it.
+
+**Architecture:** `Actions` widgets map `Intent` runtime types to `Action`s; `Shortcuts`/`ShortcutManager` map `KeyEvent`s to `Intent`s. A `ShortcutManager` resolves the matched intent's `Action` from the *focused* widget's context (falling back to a fixed action map) and invokes it. Default key bindings (Tab/arrows → traversal, Enter → Activate, Escape → Dismiss) are installed by `attachRootWidget` directly onto `rootScope.onKeyEvent` — the one focus node always present in every dispatch chain — so `FocusManager._handleTraversalKey` can be deleted entirely.
+
+**Tech Stack:** Dart, the existing `app/lib/src/tui/` framework (zero pub dependencies). Tests use `package:flutter_test`.
+
+**Reference spec:** [`docs/superpowers/specs/2026-05-17-tui-stage4.5b-actions-shortcuts-design.md`](../specs/2026-05-17-tui-stage4.5b-actions-shortcuts-design.md)
+
+---
+
+## File Structure
+
+**Create:**
+
+- `app/lib/src/tui/widgets/actions.dart` — `Intent`, `Action<T>`, `ActivateIntent`, `DismissIntent`, `Actions` widget, `_ActionsMarker`. A new `part` of the `widgets.dart` library.
+- `app/lib/src/tui/widgets/shortcuts.dart` — `ShortcutMap` typedef, `ShortcutManager`, `Shortcuts` widget, `defaultShortcuts()`. A new `part` of `widgets.dart`.
+- `app/examples/tui/shortcuts_demo.dart` — the manual-smoke demo.
+- `app/test/tui/widgets/actions_test.dart` — `Actions` lookup tests.
+- `app/test/tui/widgets/shortcuts_test.dart` — `ShortcutManager`, `Shortcuts` widget, and binding-integration tests.
+
+**Modify:**
+
+- `app/lib/src/tui/widgets/widgets.dart` — add two `part` directives.
+- `app/lib/src/tui/widgets/focus_manager.dart` — add `FocusNode.manager`; delete `_handleTraversalKey`/`_directional`/`_policyFor`/`defaultTraversalPolicy`; simplify `handleKeyEvent`.
+- `app/lib/src/tui/widgets/focus_traversal.dart` — add traversal intents, traversal actions, `_policyFor` helper, `defaultTraversalActions()`.
+- `app/lib/src/tui/widgets/binding.dart` — add `TuiBinding.rootShortcutManager`; wire `rootScope.onKeyEvent` in `attachRootWidget`.
+- `app/lib/src/tui/tui.dart` — export the new public types.
+- `app/test/tui/widgets/focus_manager_test.dart` — remove the three tests that exercised the deleted fallback, and the now-unused `_RectNode` helper.
+- `app/lib/src/tui/README.md`, `docs/superpowers/tui-roadmap.md` — mark 4.5b done.
+
+**Notes for the implementer (read once):**
+
+- `widgets.dart` is a single Dart library composed of `part` files. Every new file starts with `part of 'widgets.dart';` and has no `import`s of its own. All framework types (`Widget`, `StatelessWidget`, `InheritedWidget`, `BuildContext`, `FocusNode`, `KeyEvent`, …) are already visible in-library.
+- `Action<T extends Intent>` relies on Dart's covariant generics: an `Action<NextFocusIntent>` is assignable to `Action<Intent>` and stored in a `Map<Type, Action<Intent>>`. Invocations always look the action up by `intent.runtimeType`, so the value passed to `invoke`/`isEnabled` matches the action's real `T` and the implicit runtime covariance check passes. This is the same mechanism Flutter's `Actions` uses — do not add `covariant` keywords or casts.
+- Run a single test file with: `cd app && flutter test test/tui/widgets/<file>.dart`. The repo root is the parent of `app/`.
+- The pre-commit hook prints `deps not resolved — run 'flutter pub get'` and skips formatting; commits still succeed. If you can, run `flutter pub get` from the repo root once so the format hook is active; either way, run `dart tool/prepare_submit.dart` before the final task.
+
+---
+
+## Task 1: `Intent`, `Action`, and the `Actions` widget
+
+**Files:**
+- Create: `app/lib/src/tui/widgets/actions.dart`
+- Create: `app/test/tui/widgets/actions_test.dart`
+- Modify: `app/lib/src/tui/widgets/widgets.dart` (part directives, after line 25)
+- Modify: `app/lib/src/tui/tui.dart` (exports)
+
+- [ ] **Step 1: Add the `part` directive for `actions.dart`**
+
+In `app/lib/src/tui/widgets/widgets.dart`, the part list currently ends at line 25 with `part 'focus_scope.dart';`. Add one line after it:
+
+```dart
+part 'focus_scope.dart';
+part 'actions.dart';
+```
+
+(Building now will fail until Step 2 creates the file — that is expected.)
+
+- [ ] **Step 2: Create `actions.dart`**
+
+Create `app/lib/src/tui/widgets/actions.dart`:
+
+```dart
+part of 'widgets.dart';
+
+/// A marker describing a desired action.
+///
+/// An [Intent] is an immutable value object. A [Shortcuts] widget maps a
+/// [KeyEvent] to an [Intent]; an [Actions] widget maps an [Intent]'s runtime
+/// type to an [Action] that performs it. Transcribed from Flutter.
+abstract class Intent {
+  const Intent();
+}
+
+/// Performs the work for an [Intent] of type [T].
+///
+/// Registered in an [Actions] widget keyed by intent type. [Action] is
+/// generic and Dart class generics are covariant, so an `Action<MyIntent>`
+/// stores into a `Map<Type, Action<Intent>>`; lookups are by
+/// `intent.runtimeType`, so the value passed to [invoke]/[isEnabled] always
+/// matches the action's real [T].
+abstract class Action<T extends Intent> {
+  /// Whether this action can run for [intent] right now. Defaults to true.
+  bool isEnabled(T intent) => true;
+
+  /// Performs the action. The return value is forwarded to the invoker.
+  Object? invoke(T intent);
+}
+
+/// "Activate the focused thing" — e.g. press a button.
+///
+/// Bound to Enter by [defaultShortcuts]; an app supplies the matching [Action]
+/// via an [Actions] widget. No default action ships with the framework.
+class ActivateIntent extends Intent {
+  const ActivateIntent();
+}
+
+/// "Dismiss / cancel" — e.g. close a dialog.
+///
+/// Bound to Escape by [defaultShortcuts]; an app supplies the matching
+/// [Action]. No default action ships with the framework.
+class DismissIntent extends Intent {
+  const DismissIntent();
+}
+
+/// Inherited marker carrying an [Action] map down the tree.
+///
+/// The element layer keeps only the nearest inherited element per type, so a
+/// chained lookup cannot see every [_ActionsMarker] at once. Each marker
+/// therefore holds a [parent] pointer to the enclosing marker, and [find]
+/// recurses outward.
+class _ActionsMarker extends InheritedWidget {
+  const _ActionsMarker({
+    required this.actions,
+    required this.parent,
+    required super.child,
+  });
+
+  final Map<Type, Action<Intent>> actions;
+  final _ActionsMarker? parent;
+
+  /// The nearest [Action] registered for [intentType], walking outward.
+  Action<Intent>? find(Type intentType) =>
+      actions[intentType] ?? parent?.find(intentType);
+
+  @override
+  bool updateShouldNotify(_ActionsMarker oldWidget) =>
+      actions != oldWidget.actions || !identical(parent, oldWidget.parent);
+}
+
+/// Maps [Intent] runtime types to the [Action]s that perform them.
+///
+/// Lookups walk outward through enclosing [Actions]: an inner [Actions]
+/// shadows an outer one for the same intent type, and an unmatched type falls
+/// through to the enclosing [Actions].
+class Actions extends StatelessWidget {
+  const Actions({super.key, required this.actions, required this.child});
+
+  /// Intent runtime type → [Action]. Build a map literal such as
+  /// `{ActivateIntent: MyActivateAction()}`.
+  final Map<Type, Action<Intent>> actions;
+
+  final Widget child;
+
+  /// The nearest [Action] registered for [intent]'s runtime type, or null.
+  ///
+  /// Does not register an inherited dependency — safe to call from a key
+  /// handler rather than a build method.
+  static Action<Intent>? maybeFind(BuildContext context, Intent intent) {
+    var marker = context.getInheritedWidgetOfExactType<_ActionsMarker>();
+    return marker?.find(intent.runtimeType);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // Depend on the enclosing marker: if an Actions is inserted above, this
+    // one must rebuild to refresh its parent pointer.
+    var parent = context.dependOnInheritedWidgetOfExactType<_ActionsMarker>();
+    return _ActionsMarker(actions: actions, parent: parent, child: child);
+  }
+}
+```
+
+- [ ] **Step 3: Add exports to `tui.dart`**
+
+In `app/lib/src/tui/tui.dart`, the `widgets/widgets.dart` export ends with `FocusTraversalGroup;` (the last item in the `show` list). Add the new names to that `show` list, immediately before the closing `;`:
+
+```dart
+        FocusScope,
+        FocusTraversalGroup,
+        Intent,
+        Action,
+        Actions,
+        ActivateIntent,
+        DismissIntent;
+```
+
+- [ ] **Step 4: Write the failing test**
+
+Create `app/test/tui/widgets/actions_test.dart`:
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutterware_app/src/tui/tui.dart';
+
+import 'harness.dart';
+
+class _IntentA extends Intent {
+  const _IntentA();
+}
+
+class _IntentB extends Intent {
+  const _IntentB();
+}
+
+/// An action that records that it was found, tagged so tests can tell
+/// instances apart.
+class _TaggedAction extends Action<Intent> {
+  _TaggedAction(this.tag);
+  final String tag;
+  @override
+  Object? invoke(Intent intent) => tag;
+}
+
+void main() {
+  test('maybeFind returns the action registered for the intent type', () {
+    Action<Intent>? found;
+    pump(Actions(
+      actions: {_IntentA: _TaggedAction('a')},
+      child: Builder(builder: (context) {
+        found = Actions.maybeFind(context, const _IntentA());
+        return SizedBox();
+      }),
+    ));
+    expect(found, isA<_TaggedAction>());
+    expect((found as _TaggedAction).tag, 'a');
+  });
+
+  test('maybeFind is null for an unregistered intent type', () {
+    Action<Intent>? found;
+    var sentinel = _TaggedAction('present');
+    pump(Actions(
+      actions: {_IntentA: sentinel},
+      child: Builder(builder: (context) {
+        found = Actions.maybeFind(context, const _IntentB());
+        return SizedBox();
+      }),
+    ));
+    expect(found, isNull);
+  });
+
+  test('maybeFind is null when there is no enclosing Actions', () {
+    Action<Intent>? found;
+    pump(Builder(builder: (context) {
+      found = Actions.maybeFind(context, const _IntentA());
+      return SizedBox();
+    }));
+    expect(found, isNull);
+  });
+
+  test('lookup falls through to an enclosing Actions', () {
+    Action<Intent>? found;
+    pump(Actions(
+      actions: {_IntentA: _TaggedAction('outer-a')},
+      child: Actions(
+        actions: {_IntentB: _TaggedAction('inner-b')},
+        child: Builder(builder: (context) {
+          found = Actions.maybeFind(context, const _IntentA());
+          return SizedBox();
+        }),
+      ),
+    ));
+    expect((found as _TaggedAction).tag, 'outer-a');
+  });
+
+  test('an inner Actions shadows an outer one for the same intent type', () {
+    Action<Intent>? found;
+    pump(Actions(
+      actions: {_IntentA: _TaggedAction('outer')},
+      child: Actions(
+        actions: {_IntentA: _TaggedAction('inner')},
+        child: Builder(builder: (context) {
+          found = Actions.maybeFind(context, const _IntentA());
+          return SizedBox();
+        }),
+      ),
+    ));
+    expect((found as _TaggedAction).tag, 'inner');
+  });
+}
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `cd app && flutter test test/tui/widgets/actions_test.dart`
+Expected: all 5 tests PASS. (The implementation in Step 2 satisfies them; the "failing" state was the compile error between Steps 1 and 2.)
+
+- [ ] **Step 6: Verify the whole widget suite still compiles and passes**
+
+Run: `cd app && flutter test test/tui/widgets/`
+Expected: all existing suites still PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/lib/src/tui/widgets/actions.dart app/lib/src/tui/widgets/widgets.dart app/lib/src/tui/tui.dart app/test/tui/widgets/actions_test.dart
+git commit -m "TUI 4.5b: Intent, Action, and the Actions widget"
+```
+
+---
+
+## Task 2: `FocusNode.manager` and `ShortcutManager`
+
+**Files:**
+- Modify: `app/lib/src/tui/widgets/focus_manager.dart:39` (add `manager` getter)
+- Create: `app/lib/src/tui/widgets/shortcuts.dart`
+- Modify: `app/lib/src/tui/widgets/widgets.dart` (part directive)
+- Modify: `app/lib/src/tui/tui.dart` (exports)
+- Create: `app/test/tui/widgets/shortcuts_test.dart`
+
+- [ ] **Step 1: Add the `FocusNode.manager` getter**
+
+In `app/lib/src/tui/widgets/focus_manager.dart`, just after the `parent` getter (lines 38–39):
+
+```dart
+  /// The focus node this node is attached under, or null if detached.
+  FocusNode? get parent => _parent;
+
+  /// The [FocusManager] this node is attached to, or null if detached.
+  FocusManager? get manager => _manager;
+```
+
+- [ ] **Step 2: Add the `part` directive for `shortcuts.dart`**
+
+In `app/lib/src/tui/widgets/widgets.dart`, after the `part 'actions.dart';` line added in Task 1:
+
+```dart
+part 'actions.dart';
+part 'shortcuts.dart';
+```
+
+- [ ] **Step 3: Create `shortcuts.dart` with `ShortcutMap` and `ShortcutManager`**
+
+Create `app/lib/src/tui/widgets/shortcuts.dart`. (The `Shortcuts` widget and `defaultShortcuts()` are added in Task 4 — this file grows.)
+
+```dart
+part of 'widgets.dart';
+
+/// A key-event-to-intent map.
+///
+/// [KeyEvent] has value equality and a `Set<Modifier>`, so it is a usable map
+/// key directly — the TUI needs no `LogicalKeySet`/`ShortcutActivator`
+/// machinery.
+typedef ShortcutMap = Map<KeyEvent, Intent>;
+
+/// Resolves a [KeyEvent] to an [Intent] and invokes the matching [Action].
+///
+/// One [ShortcutManager] backs each [Shortcuts] widget, and one — carrying the
+/// default bindings — is wired onto [FocusManager.rootScope]'s `onKeyEvent` by
+/// `attachRootWidget`. The only difference between an app manager and the root
+/// manager is that the root one carries [fallbackActions].
+class ShortcutManager {
+  ShortcutManager({
+    ShortcutMap shortcuts = const {},
+    Map<Type, Action<Intent>> fallbackActions = const {},
+  })  : shortcuts = shortcuts,
+        fallbackActions = fallbackActions;
+
+  /// The key bindings this manager owns.
+  ShortcutMap shortcuts;
+
+  /// Actions consulted when no enclosing [Actions] widget supplies one for a
+  /// resolved intent. Empty for app [Shortcuts]; the root manager carries the
+  /// default traversal actions here.
+  Map<Type, Action<Intent>> fallbackActions;
+
+  /// A [FocusOnKeyEventCallback]: used as `rootScope.onKeyEvent` and as the
+  /// [Shortcuts] widget's `Focus.onKeyEvent`.
+  ///
+  /// Looks [event] up in [shortcuts]; if it maps to an intent, resolves the
+  /// [Action] from the *focused* widget's context (so an [Actions] widget on
+  /// the focused path is honoured), then from [fallbackActions]. Returns
+  /// [KeyEventResult.handled] only when an enabled action ran.
+  KeyEventResult handleFocusKeyEvent(FocusNode node, KeyEvent event) {
+    var intent = shortcuts[event];
+    if (intent == null) return KeyEventResult.ignored;
+
+    var context = node.manager?.primaryFocus.context;
+    Action<Intent>? action;
+    if (context != null) {
+      action = Actions.maybeFind(context, intent);
+    }
+    action ??= fallbackActions[intent.runtimeType];
+
+    if (action == null || !action.isEnabled(intent)) {
+      return KeyEventResult.ignored;
+    }
+    action.invoke(intent);
+    return KeyEventResult.handled;
+  }
+}
+```
+
+- [ ] **Step 4: Add exports to `tui.dart`**
+
+In `app/lib/src/tui/tui.dart`, extend the `widgets/widgets.dart` `show` list (it now ends with `DismissIntent` from Task 1):
+
+```dart
+        ActivateIntent,
+        DismissIntent,
+        ShortcutMap,
+        ShortcutManager;
+```
+
+- [ ] **Step 5: Write the failing test**
+
+Create `app/test/tui/widgets/shortcuts_test.dart`:
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutterware_app/src/tui/tui.dart';
+
+class _PingIntent extends Intent {
+  const _PingIntent();
+}
+
+class _PingAction extends Action<_PingIntent> {
+  bool invoked = false;
+  bool enabled = true;
+  @override
+  bool isEnabled(_PingIntent intent) => enabled;
+  @override
+  Object? invoke(_PingIntent intent) {
+    invoked = true;
+    return null;
+  }
+}
+
+void main() {
+  const pingKey = CharKey(rune: 0x70 /* p */, modifiers: {});
+
+  ({FocusManager manager, FocusNode node}) focusedManager() {
+    var manager = FocusManager();
+    var node = FocusNode();
+    manager.rootScope.debugAttachChild(node);
+    node.requestFocus();
+    manager.applyFocusChangesIfNeeded();
+    return (manager: manager, node: node);
+  }
+
+  test('a bound key invokes a fallback action and returns handled', () {
+    var fm = focusedManager();
+    var action = _PingAction();
+    var sm = ShortcutManager(
+      shortcuts: {pingKey: const _PingIntent()},
+      fallbackActions: {_PingIntent: action},
+    );
+    var result = sm.handleFocusKeyEvent(fm.manager.rootScope, pingKey);
+    expect(result, KeyEventResult.handled);
+    expect(action.invoked, isTrue);
+  });
+
+  test('an unbound key returns ignored', () {
+    var fm = focusedManager();
+    var sm = ShortcutManager(
+      shortcuts: {pingKey: const _PingIntent()},
+      fallbackActions: {_PingIntent: _PingAction()},
+    );
+    var result = sm.handleFocusKeyEvent(
+        fm.manager.rootScope, const CharKey(rune: 0x7a /* z */, modifiers: {}));
+    expect(result, KeyEventResult.ignored);
+  });
+
+  test('a disabled action returns ignored and is not invoked', () {
+    var fm = focusedManager();
+    var action = _PingAction()..enabled = false;
+    var sm = ShortcutManager(
+      shortcuts: {pingKey: const _PingIntent()},
+      fallbackActions: {_PingIntent: action},
+    );
+    var result = sm.handleFocusKeyEvent(fm.manager.rootScope, pingKey);
+    expect(result, KeyEventResult.ignored);
+    expect(action.invoked, isFalse);
+  });
+
+  test('a bound intent with no action anywhere returns ignored', () {
+    var fm = focusedManager();
+    var sm = ShortcutManager(shortcuts: {pingKey: const _PingIntent()});
+    var result = sm.handleFocusKeyEvent(fm.manager.rootScope, pingKey);
+    expect(result, KeyEventResult.ignored);
+  });
+}
+```
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+Run: `cd app && flutter test test/tui/widgets/shortcuts_test.dart`
+Expected: all 4 tests PASS.
+
+- [ ] **Step 7: Verify the whole widget suite still passes**
+
+Run: `cd app && flutter test test/tui/widgets/`
+Expected: all suites PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add app/lib/src/tui/widgets/focus_manager.dart app/lib/src/tui/widgets/shortcuts.dart app/lib/src/tui/widgets/widgets.dart app/lib/src/tui/tui.dart app/test/tui/widgets/shortcuts_test.dart
+git commit -m "TUI 4.5b: ShortcutManager and FocusNode.manager"
+```
+
+---
+
+## Task 3: Traversal intents and actions
+
+**Files:**
+- Modify: `app/lib/src/tui/widgets/focus_traversal.dart` (append new types at end of file)
+- Modify: `app/lib/src/tui/tui.dart` (exports)
+- Modify: `app/test/tui/widgets/focus_traversal_test.dart` (add tests)
+
+- [ ] **Step 1: Append traversal intents, actions, and helpers to `focus_traversal.dart`**
+
+At the end of `app/lib/src/tui/widgets/focus_traversal.dart` (after the `FocusTraversalGroup` class, line 150), append:
+
+```dart
+
+/// Intent: move focus to the next node in traversal order.
+class NextFocusIntent extends Intent {
+  const NextFocusIntent();
+}
+
+/// Intent: move focus to the previous node in traversal order.
+class PreviousFocusIntent extends Intent {
+  const PreviousFocusIntent();
+}
+
+/// Intent: move focus in a direction (arrow keys).
+class DirectionalFocusIntent extends Intent {
+  const DirectionalFocusIntent(this.direction);
+  final TraversalDirection direction;
+}
+
+/// The traversal policy nearest [node], defaulting to reading order.
+///
+/// Reads the [FocusTraversalGroup] policy from [node]'s context when it has
+/// one; otherwise a fresh [ReadingOrderTraversalPolicy]. (Relocated from the
+/// Stage 4.5a `FocusManager._policyFor`.)
+FocusTraversalPolicy _policyFor(FocusNode node) {
+  var context = node.context;
+  if (context != null) {
+    var policy = FocusTraversalGroup.maybeOf(context);
+    if (policy != null) return policy;
+  }
+  return ReadingOrderTraversalPolicy();
+}
+
+/// Moves focus to the next traversable node.
+class NextFocusAction extends Action<NextFocusIntent> {
+  NextFocusAction(this.focusManager);
+  final FocusManager focusManager;
+
+  @override
+  Object? invoke(NextFocusIntent intent) {
+    var node = focusManager.primaryFocus;
+    _policyFor(node).next(node);
+    return null;
+  }
+}
+
+/// Moves focus to the previous traversable node.
+class PreviousFocusAction extends Action<PreviousFocusIntent> {
+  PreviousFocusAction(this.focusManager);
+  final FocusManager focusManager;
+
+  @override
+  Object? invoke(PreviousFocusIntent intent) {
+    var node = focusManager.primaryFocus;
+    _policyFor(node).previous(node);
+    return null;
+  }
+}
+
+/// Moves focus in [DirectionalFocusIntent.direction].
+///
+/// Directional traversal always uses a [DirectionalFocusTraversalPolicy], even
+/// when the ambient policy is reading-order. (Relocated from the Stage 4.5a
+/// `FocusManager._directional`.)
+class DirectionalFocusAction extends Action<DirectionalFocusIntent> {
+  DirectionalFocusAction(this.focusManager);
+  final FocusManager focusManager;
+
+  @override
+  Object? invoke(DirectionalFocusIntent intent) {
+    var node = focusManager.primaryFocus;
+    var policy = _policyFor(node);
+    var directional = policy is DirectionalFocusTraversalPolicy
+        ? policy
+        : DirectionalFocusTraversalPolicy();
+    directional.inDirection(node, intent.direction);
+    return null;
+  }
+}
+
+/// The default traversal action map for a root [ShortcutManager]'s
+/// `fallbackActions`.
+Map<Type, Action<Intent>> defaultTraversalActions(FocusManager focusManager) =>
+    {
+      NextFocusIntent: NextFocusAction(focusManager),
+      PreviousFocusIntent: PreviousFocusAction(focusManager),
+      DirectionalFocusIntent: DirectionalFocusAction(focusManager),
+    };
+```
+
+- [ ] **Step 2: Add exports to `tui.dart`**
+
+In `app/lib/src/tui/tui.dart`, extend the `show` list (now ending with `ShortcutManager` from Task 2):
+
+```dart
+        ShortcutMap,
+        ShortcutManager,
+        NextFocusIntent,
+        PreviousFocusIntent,
+        DirectionalFocusIntent,
+        NextFocusAction,
+        PreviousFocusAction,
+        DirectionalFocusAction,
+        defaultTraversalActions;
+```
+
+- [ ] **Step 3: Write the failing tests**
+
+In `app/test/tui/widgets/focus_traversal_test.dart`, add these tests inside `main()`, after the existing last test (before the closing `}` of `main`):
+
+```dart
+  test('NextFocusAction moves focus to the following node', () {
+    var manager = FocusManager();
+    var a = _FixedNode(CellRect.fromTLWH(0, 0, 4, 1));
+    var b = _FixedNode(CellRect.fromTLWH(0, 10, 4, 1));
+    manager.rootScope.debugAttachChild(a);
+    manager.rootScope.debugAttachChild(b);
+    a.requestFocus();
+    manager.applyFocusChangesIfNeeded();
+
+    NextFocusAction(manager).invoke(const NextFocusIntent());
+    manager.applyFocusChangesIfNeeded();
+    expect(manager.primaryFocus, b);
+  });
+
+  test('PreviousFocusAction wraps to the last node', () {
+    var manager = FocusManager();
+    var a = _FixedNode(CellRect.fromTLWH(0, 0, 4, 1));
+    var b = _FixedNode(CellRect.fromTLWH(0, 10, 4, 1));
+    manager.rootScope.debugAttachChild(a);
+    manager.rootScope.debugAttachChild(b);
+    a.requestFocus();
+    manager.applyFocusChangesIfNeeded();
+
+    PreviousFocusAction(manager).invoke(const PreviousFocusIntent());
+    manager.applyFocusChangesIfNeeded();
+    expect(manager.primaryFocus, b);
+  });
+
+  test('DirectionalFocusAction moves focus in the given direction', () {
+    var manager = FocusManager();
+    var left = _FixedNode(CellRect.fromTLWH(0, 0, 6, 3));
+    var right = _FixedNode(CellRect.fromTLWH(0, 20, 6, 3));
+    manager.rootScope.debugAttachChild(left);
+    manager.rootScope.debugAttachChild(right);
+    left.requestFocus();
+    manager.applyFocusChangesIfNeeded();
+
+    DirectionalFocusAction(manager)
+        .invoke(const DirectionalFocusIntent(TraversalDirection.right));
+    manager.applyFocusChangesIfNeeded();
+    expect(manager.primaryFocus, right);
+  });
+
+  test('defaultTraversalActions maps each traversal intent type', () {
+    var actions = defaultTraversalActions(FocusManager());
+    expect(actions[NextFocusIntent], isA<NextFocusAction>());
+    expect(actions[PreviousFocusIntent], isA<PreviousFocusAction>());
+    expect(actions[DirectionalFocusIntent], isA<DirectionalFocusAction>());
+  });
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd app && flutter test test/tui/widgets/focus_traversal_test.dart`
+Expected: all tests PASS (the 6 pre-existing + 4 new).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/lib/src/tui/widgets/focus_traversal.dart app/lib/src/tui/tui.dart app/test/tui/widgets/focus_traversal_test.dart
+git commit -m "TUI 4.5b: traversal intents and actions"
+```
+
+---
+
+## Task 4: The `Shortcuts` widget and `defaultShortcuts`
+
+**Files:**
+- Modify: `app/lib/src/tui/widgets/shortcuts.dart` (append `Shortcuts`, `_ShortcutsState`, `defaultShortcuts`)
+- Modify: `app/lib/src/tui/tui.dart` (exports)
+- Modify: `app/test/tui/widgets/shortcuts_test.dart` (add tests)
+
+- [ ] **Step 1: Append the `Shortcuts` widget and `defaultShortcuts` to `shortcuts.dart`**
+
+At the end of `app/lib/src/tui/widgets/shortcuts.dart` (after the `ShortcutManager` class), append:
+
+```dart
+
+/// Maps [KeyEvent]s to [Intent]s for a subtree.
+///
+/// Wraps [child] in a non-focusable, traversal-skipping [Focus] whose
+/// `onKeyEvent` is the [ShortcutManager]. Because that [Focus] joins the focus
+/// chain, a [Shortcuts] enclosing the focused subtree intercepts keys before
+/// the root defaults — giving scoped overrides.
+class Shortcuts extends StatefulWidget {
+  const Shortcuts({
+    super.key,
+    required this.shortcuts,
+    required this.child,
+    this.manager,
+  });
+
+  /// The key bindings for this subtree.
+  final ShortcutMap shortcuts;
+
+  /// An externally-owned manager to adopt. When null, one is created.
+  final ShortcutManager? manager;
+
+  final Widget child;
+
+  @override
+  State<Shortcuts> createState() => _ShortcutsState();
+}
+
+class _ShortcutsState extends State<Shortcuts> {
+  late ShortcutManager _manager;
+
+  @override
+  void initState() {
+    _manager = widget.manager ?? ShortcutManager();
+    _manager.shortcuts = widget.shortcuts;
+  }
+
+  @override
+  void didUpdateWidget(Shortcuts oldWidget) {
+    if (!identical(widget.manager, oldWidget.manager)) {
+      _manager = widget.manager ?? ShortcutManager();
+    }
+    _manager.shortcuts = widget.shortcuts;
+  }
+
+  @override
+  Widget build(BuildContext context) => Focus(
+        skipTraversal: true,
+        canRequestFocus: false,
+        onKeyEvent: _manager.handleFocusKeyEvent,
+        child: widget.child,
+      );
+}
+
+/// The framework default key bindings, auto-installed on
+/// [FocusManager.rootScope] by `attachRootWidget`.
+///
+/// Tab/Shift-Tab and the arrow keys drive focus traversal; Enter and Escape
+/// map to [ActivateIntent]/[DismissIntent] (an app supplies the actions).
+ShortcutMap defaultShortcuts() => {
+      const SpecialKey(code: SpecialKeyCode.tab, modifiers: {}):
+          const NextFocusIntent(),
+      const SpecialKey(code: SpecialKeyCode.tab, modifiers: {Modifier.shift}):
+          const PreviousFocusIntent(),
+      const SpecialKey(code: SpecialKeyCode.up, modifiers: {}):
+          const DirectionalFocusIntent(TraversalDirection.up),
+      const SpecialKey(code: SpecialKeyCode.down, modifiers: {}):
+          const DirectionalFocusIntent(TraversalDirection.down),
+      const SpecialKey(code: SpecialKeyCode.left, modifiers: {}):
+          const DirectionalFocusIntent(TraversalDirection.left),
+      const SpecialKey(code: SpecialKeyCode.right, modifiers: {}):
+          const DirectionalFocusIntent(TraversalDirection.right),
+      const SpecialKey(code: SpecialKeyCode.enter, modifiers: {}):
+          const ActivateIntent(),
+      const SpecialKey(code: SpecialKeyCode.escape, modifiers: {}):
+          const DismissIntent(),
+    };
+```
+
+- [ ] **Step 2: Add exports to `tui.dart`**
+
+In `app/lib/src/tui/tui.dart`, extend the `show` list (now ending with `defaultTraversalActions` from Task 3):
+
+```dart
+        DirectionalFocusAction,
+        defaultTraversalActions,
+        Shortcuts,
+        defaultShortcuts;
+```
+
+- [ ] **Step 3: Write the failing tests**
+
+In `app/test/tui/widgets/shortcuts_test.dart`, add the imports for the harness and painting types at the top (after the existing imports):
+
+```dart
+import 'package:flutterware_app/src/tui/tui.dart';
+
+import 'harness.dart';
+```
+
+(The file already imports `flutter_test` and `tui.dart`; add only the `harness.dart` import — if `tui.dart` is already imported, do not duplicate it.)
+
+Then add a shared callback action class after the existing `_PingAction` class:
+
+```dart
+/// An Action<ActivateIntent> that runs a callback when invoked.
+class _CallbackActivate extends Action<ActivateIntent> {
+  _CallbackActivate(this.onInvoke);
+  final void Function() onInvoke;
+  @override
+  Object? invoke(ActivateIntent intent) {
+    onInvoke();
+    return null;
+  }
+}
+```
+
+Add these tests inside `main()`, after the existing tests:
+
+```dart
+  test('defaultShortcuts binds Tab, arrows, Enter, and Escape', () {
+    var map = defaultShortcuts();
+    expect(map[const SpecialKey(code: SpecialKeyCode.tab, modifiers: {})],
+        isA<NextFocusIntent>());
+    expect(
+        map[const SpecialKey(
+            code: SpecialKeyCode.tab, modifiers: {Modifier.shift})],
+        isA<PreviousFocusIntent>());
+    expect(map[const SpecialKey(code: SpecialKeyCode.up, modifiers: {})],
+        isA<DirectionalFocusIntent>());
+    expect(map[const SpecialKey(code: SpecialKeyCode.enter, modifiers: {})],
+        isA<ActivateIntent>());
+    expect(map[const SpecialKey(code: SpecialKeyCode.escape, modifiers: {})],
+        isA<DismissIntent>());
+  });
+
+  test('a Shortcuts widget intercepts a key for its focused subtree', () {
+    var node = FocusNode();
+    var invoked = false;
+    var binding = TuiBinding();
+    binding.attachRootWidget(Shortcuts(
+      shortcuts: {const CharKey(rune: 0x78 /* x */, modifiers: {}):
+          const ActivateIntent()},
+      child: Actions(
+        actions: {ActivateIntent: _CallbackActivate(() => invoked = true)},
+        child: Focus(
+            focusNode: node,
+            autofocus: true,
+            child: SizedBox(width: 4, height: 2)),
+      ),
+    ));
+    binding.handleResize(CellSize(8, 12));
+    binding.drawFrame(Painter(CellBuffer(8, 12)));
+
+    binding.focusManager
+        .handleKeyEvent(const CharKey(rune: 0x78, modifiers: {}));
+    expect(invoked, isTrue);
+  });
+
+  test('an inner Shortcuts shadows an outer one for the same key', () {
+    var node = FocusNode();
+    var hits = <String>[];
+    var binding = TuiBinding();
+    const xKey = CharKey(rune: 0x78 /* x */, modifiers: {});
+    binding.attachRootWidget(Shortcuts(
+      shortcuts: {xKey: const ActivateIntent()},
+      child: Actions(
+        actions: {ActivateIntent: _CallbackActivate(() => hits.add('outer'))},
+        child: Shortcuts(
+          shortcuts: {xKey: const ActivateIntent()},
+          child: Actions(
+            actions: {
+              ActivateIntent: _CallbackActivate(() => hits.add('inner'))
+            },
+            child: Focus(
+                focusNode: node,
+                autofocus: true,
+                child: SizedBox(width: 4, height: 2)),
+          ),
+        ),
+      ),
+    ));
+    binding.handleResize(CellSize(8, 12));
+    binding.drawFrame(Painter(CellBuffer(8, 12)));
+
+    binding.focusManager.handleKeyEvent(xKey);
+    expect(hits, ['inner']);
+  });
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd app && flutter test test/tui/widgets/shortcuts_test.dart`
+Expected: all tests PASS (the 4 from Task 2 + 3 new).
+
+Note: the two widget tests rely on `Focus` key dispatch already routing through the chain (Stage 4.5a). They do *not* yet rely on the root defaults — `attachRootWidget` wiring lands in Task 5.
+
+- [ ] **Step 5: Verify the whole widget suite still passes**
+
+Run: `cd app && flutter test test/tui/widgets/`
+Expected: all suites PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/lib/src/tui/widgets/shortcuts.dart app/lib/src/tui/tui.dart app/test/tui/widgets/shortcuts_test.dart
+git commit -m "TUI 4.5b: Shortcuts widget and default shortcut map"
+```
+
+---
+
+## Task 5: Wire the root defaults in `TuiBinding`
+
+**Files:**
+- Modify: `app/lib/src/tui/widgets/binding.dart` (add `rootShortcutManager`; wire `attachRootWidget`)
+- Modify: `app/test/tui/widgets/shortcuts_test.dart` (add binding-integration tests)
+
+- [ ] **Step 1: Add the `rootShortcutManager` field to `TuiBinding`**
+
+In `app/lib/src/tui/widgets/binding.dart`, after the `focusManager` field (lines 142–143):
+
+```dart
+  /// Owns the focus tree and routes key events.
+  final FocusManager focusManager = FocusManager();
+
+  /// The default key bindings (traversal, activate, dismiss), wired onto
+  /// [FocusManager.rootScope] by [attachRootWidget].
+  late final ShortcutManager rootShortcutManager;
+```
+
+- [ ] **Step 2: Wire `rootScope.onKeyEvent` in `attachRootWidget`**
+
+In `app/lib/src/tui/widgets/binding.dart`, in `attachRootWidget`, the body currently has (lines 173–176):
+
+```dart
+    buildOwner.onBuildScheduled = () => onFrameNeeded?.call();
+    focusManager.onFocusChange = () => onFrameNeeded?.call();
+    buildOwner.buildScope(
+        _rootElement!, () => _rootElement!.mountAsRoot(buildOwner));
+```
+
+Insert the root-shortcut wiring between the `focusManager.onFocusChange` line and the `buildOwner.buildScope` call:
+
+```dart
+    buildOwner.onBuildScheduled = () => onFrameNeeded?.call();
+    focusManager.onFocusChange = () => onFrameNeeded?.call();
+    rootShortcutManager = ShortcutManager(
+      shortcuts: defaultShortcuts(),
+      fallbackActions: defaultTraversalActions(focusManager),
+    );
+    focusManager.rootScope.onKeyEvent = rootShortcutManager.handleFocusKeyEvent;
+    buildOwner.buildScope(
+        _rootElement!, () => _rootElement!.mountAsRoot(buildOwner));
+```
+
+- [ ] **Step 3: Write the failing tests**
+
+In `app/test/tui/widgets/shortcuts_test.dart`, add these tests inside `main()`, after the Task 4 tests:
+
+```dart
+  test('default shortcuts route Tab through rootScope to move focus', () {
+    var first = FocusNode();
+    var second = FocusNode();
+    var binding = TuiBinding();
+    binding.attachRootWidget(Row(children: [
+      Focus(
+          focusNode: first,
+          autofocus: true,
+          child: SizedBox(width: 5, height: 3)),
+      Focus(focusNode: second, child: SizedBox(width: 5, height: 3)),
+    ]));
+    binding.handleResize(CellSize(10, 30));
+    binding.drawFrame(Painter(CellBuffer(10, 30)));
+    expect(binding.focusManager.primaryFocus, first);
+
+    binding.focusManager
+        .handleKeyEvent(const SpecialKey(code: SpecialKeyCode.tab, modifiers: {}));
+    binding.drawFrame(Painter(CellBuffer(10, 30)));
+    expect(binding.focusManager.primaryFocus, second);
+  });
+
+  test('Tab with nothing focused focuses the first node', () {
+    var only = FocusNode();
+    var binding = TuiBinding();
+    binding.attachRootWidget(
+      Focus(focusNode: only, child: SizedBox(width: 5, height: 3)),
+    );
+    binding.handleResize(CellSize(10, 30));
+    binding.drawFrame(Painter(CellBuffer(10, 30)));
+    expect(binding.focusManager.primaryFocus, binding.focusManager.rootScope);
+
+    binding.focusManager
+        .handleKeyEvent(const SpecialKey(code: SpecialKeyCode.tab, modifiers: {}));
+    binding.drawFrame(Painter(CellBuffer(10, 30)));
+    expect(binding.focusManager.primaryFocus, only);
+  });
+
+  test('Enter routes to an ActivateIntent action on the focused path', () {
+    var node = FocusNode();
+    var invoked = false;
+    var binding = TuiBinding();
+    binding.attachRootWidget(Actions(
+      actions: {ActivateIntent: _CallbackActivate(() => invoked = true)},
+      child: Focus(
+          focusNode: node,
+          autofocus: true,
+          child: SizedBox(width: 4, height: 2)),
+    ));
+    binding.handleResize(CellSize(8, 12));
+    binding.drawFrame(Painter(CellBuffer(8, 12)));
+
+    binding.focusManager.handleKeyEvent(
+        const SpecialKey(code: SpecialKeyCode.enter, modifiers: {}));
+    expect(invoked, isTrue);
+  });
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd app && flutter test test/tui/widgets/shortcuts_test.dart`
+Expected: all tests PASS.
+
+- [ ] **Step 5: Verify the whole widget suite still passes**
+
+Run: `cd app && flutter test test/tui/widgets/`
+Expected: all suites PASS — in particular `focus_routing_test.dart`'s "unhandled Tab moves focus between two Focus widgets" still passes, now served by the root `ShortcutManager` rather than the (still-present) `_handleTraversalKey` fallback.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/lib/src/tui/widgets/binding.dart app/test/tui/widgets/shortcuts_test.dart
+git commit -m "TUI 4.5b: wire default shortcuts onto rootScope"
+```
+
+---
+
+## Task 6: Delete the Stage 4.5a traversal fallback
+
+**Files:**
+- Modify: `app/lib/src/tui/widgets/focus_manager.dart` (delete fallback; simplify `handleKeyEvent`)
+- Modify: `app/test/tui/widgets/focus_manager_test.dart` (remove fallback tests and unused helper)
+
+- [ ] **Step 1: Delete the `defaultTraversalPolicy` field**
+
+In `app/lib/src/tui/widgets/focus_manager.dart`, delete these lines (251–253):
+
+```dart
+  /// The traversal policy used by the built-in Tab/arrow fallback when no
+  /// [FocusTraversalGroup] overrides it.
+  final FocusTraversalPolicy defaultTraversalPolicy =
+      ReadingOrderTraversalPolicy();
+```
+
+- [ ] **Step 2: Simplify `handleKeyEvent`**
+
+In the same file, `handleKeyEvent` and its doc comment currently span lines 288–307. Replace the whole block — the doc comment starting `/// Routes [event] through the focus chain.` through the method's closing `}` — with:
+
+```dart
+  /// Routes [event] through the focus chain.
+  ///
+  /// Calls [FocusNode.onKeyEvent] on the primary focus, then each ancestor up
+  /// to [rootScope], stopping on [KeyEventResult.handled] or
+  /// [KeyEventResult.skipRemainingHandlers]. The default key bindings
+  /// (traversal, activate, dismiss) live on `rootScope.onKeyEvent`, wired by
+  /// `attachRootWidget` — `rootScope` is the last node in every chain.
+  KeyEventResult handleKeyEvent(KeyEvent event) {
+    var chain = <FocusNode>[_primaryFocus, ..._primaryFocus.ancestors];
+    for (var node in chain) {
+      var callback = node.onKeyEvent;
+      if (callback == null) continue;
+      var result = callback(node, event);
+      if (result == KeyEventResult.handled ||
+          result == KeyEventResult.skipRemainingHandlers) {
+        return result;
+      }
+    }
+    return KeyEventResult.ignored;
+  }
+```
+
+- [ ] **Step 3: Delete `_handleTraversalKey`, `_directional`, and `_policyFor`**
+
+In the same file, delete the three private methods that followed `handleKeyEvent` — the block from the `/// Built-in fallback for unhandled Tab/Shift-Tab and arrow keys.` doc comment through the closing `}` of `_policyFor` (originally lines 309–353). Leave `_chainOf` (the method after them) intact.
+
+After this edit, `FocusManager` no longer references `FocusTraversalPolicy`, `ReadingOrderTraversalPolicy`, `DirectionalFocusTraversalPolicy`, `TraversalDirection`, or `FocusTraversalGroup`.
+
+- [ ] **Step 4: Verify the fallback is gone**
+
+Run: `cd app && grep -n "_handleTraversalKey\|_directional\|_policyFor\|defaultTraversalPolicy" lib/src/tui/widgets/focus_manager.dart`
+Expected: no output (exit status 1).
+
+- [ ] **Step 5: Remove the fallback tests from `focus_manager_test.dart`**
+
+In `app/test/tui/widgets/focus_manager_test.dart`:
+
+1. Delete the three tests that exercised the deleted fallback: `'unhandled Tab moves focus forward via the fallback'`, `'unhandled Shift-Tab moves focus backward'`, and `'unhandled arrow key moves focus directionally'` (originally lines 124–168).
+2. Delete the now-unused `_RectNode` helper class at the top of the file (originally lines 4–10):
+
+```dart
+/// A FocusNode with a fixed rect, so traversal works without a widget tree.
+class _RectNode extends FocusNode {
+  _RectNode(this.fixedRect);
+  final CellRect fixedRect;
+  @override
+  CellRect? get rect => fixedRect;
+}
+```
+
+The remaining tests in the file (`handleKeyEvent dispatches to the primary focus first`, `… bubbles to ancestors when ignored`, `… stops bubbling once handled`, and the focus-change tests) stay — they do not use the fallback or `_RectNode`.
+
+- [ ] **Step 6: Run the affected suites**
+
+Run: `cd app && flutter test test/tui/widgets/focus_manager_test.dart test/tui/widgets/focus_routing_test.dart`
+Expected: both PASS. `focus_routing_test.dart` is unchanged — its Tab test now routes through `rootScope.onKeyEvent`.
+
+- [ ] **Step 7: Run the full app test suite**
+
+Run: `cd app && flutter test`
+Expected: all tests PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add app/lib/src/tui/widgets/focus_manager.dart app/test/tui/widgets/focus_manager_test.dart
+git commit -m "TUI 4.5b: delete the 4.5a built-in traversal fallback"
+```
+
+---
+
+## Task 7: The `shortcuts_demo.dart` demo
+
+**Files:**
+- Create: `app/examples/tui/shortcuts_demo.dart`
+
+- [ ] **Step 1: Create the demo**
+
+Create `app/examples/tui/shortcuts_demo.dart`:
+
+```dart
+// Stage 4.5b shortcuts demo. Run in a real terminal:
+//   cd app && dart run examples/tui/shortcuts_demo.dart
+// Tab / Shift-Tab cycle focus, arrows move directionally. Enter increments the
+// focused panel's counter; panel D also accepts '+'. Escape or q quits.
+
+import 'dart:async';
+
+import 'package:flutterware_app/src/tui/tui.dart';
+
+/// An Action<ActivateIntent> that runs a callback.
+class _CallbackActivate extends Action<ActivateIntent> {
+  _CallbackActivate(this.onInvoke);
+  final void Function() onInvoke;
+  @override
+  Object? invoke(ActivateIntent intent) {
+    onInvoke();
+    return null;
+  }
+}
+
+/// An Action<DismissIntent> that runs a callback.
+class _CallbackDismiss extends Action<DismissIntent> {
+  _CallbackDismiss(this.onInvoke);
+  final void Function() onInvoke;
+  @override
+  Object? invoke(DismissIntent intent) {
+    onInvoke();
+    return null;
+  }
+}
+
+/// A focusable panel with a counter incremented via [ActivateIntent].
+///
+/// Wraps its [Focus] in an [Actions] so the focused-path lookup finds the
+/// increment action. When [activateKey] is set, an extra [Shortcuts] maps that
+/// key to [ActivateIntent] for this panel only.
+class CounterPanel extends StatefulWidget {
+  const CounterPanel({
+    required this.label,
+    this.autofocus = false,
+    this.activateKey,
+    super.key,
+  });
+
+  final String label;
+  final bool autofocus;
+  final KeyEvent? activateKey;
+
+  @override
+  State<CounterPanel> createState() => _CounterPanelState();
+}
+
+class _CounterPanelState extends State<CounterPanel> {
+  int _count = 0;
+
+  void _increment() => setState(() => _count++);
+
+  @override
+  Widget build(BuildContext context) {
+    Widget panel = Actions(
+      actions: {ActivateIntent: _CallbackActivate(_increment)},
+      child: Focus(
+        autofocus: widget.autofocus,
+        child: Builder(builder: (context) {
+          var focused = Focus.of(context).hasFocus;
+          var accent = focused ? Color.brightCyan : Color.brightBlack;
+          return DecoratedBox(
+            decoration: BoxDecoration(
+              border: BoxBorder(
+                chars: focused ? BorderChars.double() : BorderChars.rounded(),
+                fg: accent,
+              ),
+            ),
+            child: Padding(
+              padding: EdgeInsets.all(1),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  Text(widget.label, fg: accent, style: TextStyle.bold),
+                  Text('count: $_count',
+                      fg: focused ? Color.brightWhite : Color.brightBlack),
+                ],
+              ),
+            ),
+          );
+        }),
+      ),
+    );
+    var activateKey = widget.activateKey;
+    if (activateKey != null) {
+      panel = Shortcuts(
+        shortcuts: {activateKey: const ActivateIntent()},
+        child: panel,
+      );
+    }
+    return panel;
+  }
+}
+
+/// Root of the demo: a 2x2 grid wrapped in an Actions for Escape-to-quit.
+class ShortcutsDemoApp extends StatefulWidget {
+  const ShortcutsDemoApp({super.key});
+
+  @override
+  State<ShortcutsDemoApp> createState() => _ShortcutsDemoState();
+}
+
+class _ShortcutsDemoState extends State<ShortcutsDemoApp> {
+  StreamSubscription<KeyEvent>? _keySub;
+  bool _subscribed = false;
+
+  @override
+  void didChangeDependencies() {
+    if (_subscribed) return;
+    _subscribed = true;
+    var app = TerminalApp.of(context);
+    _keySub = app.keys.listen((event) {
+      if (event is CharKey && event.rune == 0x71 /* q */) {
+        app.exit();
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    unawaited(_keySub?.cancel());
+  }
+
+  Widget _row(List<Widget> panels) => Expanded(
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            for (var i = 0; i < panels.length; i++) ...[
+              if (i > 0) SizedBox(width: 1),
+              Expanded(child: panels[i]),
+            ],
+          ],
+        ),
+      );
+
+  @override
+  Widget build(BuildContext context) {
+    var exit = TerminalApp.of(context).exit;
+    return Actions(
+      actions: {DismissIntent: _CallbackDismiss(exit)},
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Text(
+            'shortcuts demo - Tab/arrows - Enter activates - Esc/q quits',
+            fg: Color.brightWhite,
+            style: TextStyle.bold,
+          ),
+          SizedBox(height: 1),
+          _row(const [
+            CounterPanel(label: 'panel A', autofocus: true),
+            CounterPanel(label: 'panel B'),
+          ]),
+          SizedBox(height: 1),
+          _row(const [
+            CounterPanel(label: 'panel C'),
+            CounterPanel(
+              label: "panel D (+)",
+              activateKey: CharKey(rune: 0x2b /* + */, modifiers: {}),
+            ),
+          ]),
+        ],
+      ),
+    );
+  }
+}
+
+Future<void> main() => runApp(const ShortcutsDemoApp());
+```
+
+- [ ] **Step 2: Static-analyze the demo**
+
+Run: `cd app && dart analyze examples/tui/shortcuts_demo.dart`
+Expected: "No issues found!"
+
+- [ ] **Step 3: Manual smoke test (real terminal)**
+
+Run: `cd app && dart run examples/tui/shortcuts_demo.dart`
+Verify:
+- The 2×2 grid renders; panel A starts focused (double-line border).
+- Tab/Shift-Tab cycle focus through the panels; arrow keys move directionally; the focus highlight follows.
+- Pressing Enter increments the focused panel's `count`.
+- Pressing `+` increments panel D's count (only while panel D is focused).
+- Escape and `q` both exit cleanly and restore the terminal.
+
+If running in a non-interactive environment where a real terminal is unavailable, note that this step is unverified and proceed.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/examples/tui/shortcuts_demo.dart
+git commit -m "TUI 4.5b: shortcuts_demo example"
+```
+
+---
+
+## Task 8: Documentation and final verification
+
+**Files:**
+- Modify: `app/lib/src/tui/README.md`
+- Modify: `docs/superpowers/tui-roadmap.md`
+
+- [ ] **Step 1: Update the roadmap**
+
+In `docs/superpowers/tui-roadmap.md`:
+
+1. In the Stages table, add a row after the `4.5a Focus` row:
+
+```
+| **4.5b Shortcuts** | `Actions`/`Intent`/`Action`, `Shortcuts`/`ShortcutManager`, default key bindings | ✅ Done |
+```
+
+2. In "Detailed docs per stage", add after the Stage 4.5a bullet:
+
+```
+- Stage 4.5b — [spec](specs/2026-05-17-tui-stage4.5b-actions-shortcuts-design.md) ·
+  [plan](plans/2026-05-17-tui-stage4.5b-actions-shortcuts.md)
+```
+
+3. In "Known limitations carried forward", replace the focus-system bullet that ends "The declarative `Actions`/`Intents`/`Shortcuts` key-binding layer is deferred to Stage 4.5b." with:
+
+```
+- A focus system (focus tree, `FocusManager`, `Focus`/`FocusScope`, Tab/arrow
+  traversal, key routing) was added in Stage 4.5a, and the declarative
+  `Actions`/`Intents`/`Shortcuts` key-binding layer in Stage 4.5b. Traversal
+  and the Enter/Escape bindings are installed by default on `rootScope`.
+```
+
+- [ ] **Step 2: Update `app/lib/src/tui/README.md`**
+
+Open `app/lib/src/tui/README.md` and read it first. Update it consistently with how it recorded Stage 4.5a: add `actions.dart` and `shortcuts.dart` to the `widgets/` file table (descriptions: "Intent/Action/Actions — the declarative action layer" and "Shortcuts/ShortcutManager — key-event to intent bindings"), note that Stage 4.5b is done, and update any "Actions/Shortcuts deferred" limitation to "done". Match the file's existing structure and tone; do not restructure it.
+
+- [ ] **Step 3: Run the formatter**
+
+Run: `dart tool/prepare_submit.dart` (from the repo root)
+Expected: it formats the workspace. Review `git diff` — it should only touch whitespace/formatting in files this plan created or modified.
+
+- [ ] **Step 4: Full verification**
+
+Run, from the repo root:
+- `flutter analyze` — expected: no issues.
+- `cd app && flutter test` — expected: all tests PASS.
+- `cd .. && dart tool/prepare_submit.dart` then `git status` — expected: no diff (working tree clean after the Step 5 commit, or only the intended changes staged).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/lib/src/tui/README.md docs/superpowers/tui-roadmap.md
+git commit -m "TUI 4.5b: docs — mark stage 4.5b done"
+```
+
+If `dart tool/prepare_submit.dart` reformatted any source files in earlier tasks, stage and commit those separately first with `git commit -m "TUI 4.5b: apply formatter"`.
+
+---
+
+## Self-Review
+
+**Spec coverage** — every spec section maps to a task:
+
+- `Intent`/`Action` (spec §"`Intent` / `Action`") → Task 1.
+- `Actions` widget + chained lookup (spec §"`Actions` widget") → Task 1.
+- `ActivateIntent`/`DismissIntent` (spec §goal 4) → Task 1.
+- `ShortcutMap`/`ShortcutManager` (spec §"`Shortcuts` / `ShortcutManager`") → Task 2.
+- `FocusNode.manager` (spec §"`FocusManager` / `FocusNode` changes") → Task 2.
+- Traversal intents/actions, `_policyFor`, `defaultTraversalActions` (spec §"Traversal intents & actions") → Task 3.
+- `Shortcuts` widget, `defaultShortcuts()` (spec §"`Shortcuts` widget", §"Default bindings") → Task 4.
+- `TuiBinding.rootShortcutManager`, `attachRootWidget` wiring (spec §"`TuiBinding` / `runApp` integration") → Task 5.
+- Delete `_handleTraversalKey`/`_directional`/`_policyFor`/`defaultTraversalPolicy`, simplify `handleKeyEvent` (spec §"`FocusManager` / `FocusNode` changes", §goal 6) → Task 6.
+- Update `focus_manager_test.dart` (spec §"Files touched") → Task 6.
+- `shortcuts_demo.dart` (spec §"The demo") → Task 7.
+- `tui.dart` exports (spec §"Files touched") → Tasks 1–4 incrementally.
+- `README.md`, roadmap (spec §"Files touched") → Task 8.
+- Testing strategy cases (spec §"Testing strategy") → `actions_test.dart` (Task 1), `shortcuts_test.dart` (Tasks 2/4/5), `focus_traversal_test.dart` additions (Task 3).
+- Success criterion "`FocusManager` no longer contains `_handleTraversalKey`" → Task 6 Step 4 grep.
+
+**Placeholder scan** — no TBD/TODO; every code step shows complete code; every test step shows the assertions.
+
+**Type consistency** — checked across tasks: `Action<T>` with `isEnabled(T)`/`invoke(T)`; `Map<Type, Action<Intent>>` everywhere (`Actions.actions`, `_ActionsMarker.actions`, `ShortcutManager.fallbackActions`, `defaultTraversalActions` return); `ShortcutMap = Map<KeyEvent, Intent>`; `ShortcutManager.handleFocusKeyEvent(FocusNode, KeyEvent)` matches the `FocusOnKeyEventCallback` typedef and is used both as `rootScope.onKeyEvent` (Task 5) and the `Shortcuts` widget's `Focus.onKeyEvent` (Task 4); `Actions.maybeFind(BuildContext, Intent)` used by `ShortcutManager` (Task 2) and tested directly (Task 1); `FocusNode.manager` added in Task 2 and read by `ShortcutManager`. The demo's `_CallbackActivate` mirrors the test helper of the same name (independent copies — the demo and tests do not share files).

--- a/docs/superpowers/specs/2026-05-17-tui-stage4.5b-actions-shortcuts-design.md
+++ b/docs/superpowers/specs/2026-05-17-tui-stage4.5b-actions-shortcuts-design.md
@@ -1,0 +1,555 @@
+# TUI Stage 4.5b — Actions / Intents / Shortcuts
+
+**Status:** Draft
+**Date:** 2026-05-17
+**Scope:** Add the declarative key-binding layer — `Intent`, `Action`,
+`Actions`, `Shortcuts`, `ShortcutManager` — and migrate the Stage 4.5a built-in
+Tab/arrow traversal fallback onto it. The second half of the "interactivity"
+stage.
+
+**Extends:** [`2026-05-16-tui-stage4.5a-focus-system-design.md`](./2026-05-16-tui-stage4.5a-focus-system-design.md)
+
+---
+
+## Context
+
+Stage 4.5a delivered the focus system: the focus-node tree, `FocusManager`,
+`Focus`/`FocusScope` widgets, traversal policies, and key-event routing.
+`FocusManager.handleKeyEvent` walks the focus chain (`primaryFocus` →
+ancestors → `rootScope`) calling each node's `onKeyEvent`, and — when the whole
+chain returns `ignored` — runs a **built-in traversal fallback**
+(`FocusManager._handleTraversalKey`) that hard-codes Tab/Shift-Tab → traversal
+policy and arrow keys → directional traversal.
+
+That fallback was deliberately built as a seam. 4.5a's spec records it:
+"In 4.5a the Tab/arrow traversal fallback lives directly in `FocusManager`;
+4.5b replaces that block with `Shortcuts`→`Actions` routing." This stage closes
+that seam.
+
+The roadmap's standing decision is "reimplement the engine; transcribe the
+framework." The `Actions`/`Intents`/`Shortcuts` system is framework-shaped and
+backend-agnostic, so it is transcribed from `package:flutter`'s `actions.dart`
+and `shortcuts.dart` — adapted to the TUI's key model and trimmed where Flutter
+machinery does not earn its place in a terminal UI (see "Divergences from
+Flutter" and "Non-goals").
+
+After 4.5b, an app declares key behaviour the Flutter way: a `Shortcuts` widget
+maps key events to `Intent`s, and an `Actions` widget maps `Intent` types to
+`Action`s that run. Traversal becomes just another set of default bindings, not
+special-cased framework code. Stage 5 then builds the real flutterware CLI app
+on top.
+
+## Goals
+
+1. **`Intent` / `Action`** — `Intent` is a marker base for a desired action;
+   `Action<T extends Intent>` has `isEnabled(intent)` and `invoke(intent)`.
+2. **`Actions` widget** — maps `Intent` runtime type → `Action`. Chained
+   lookup: an inner `Actions` shadows an outer one, and an unmatched type falls
+   through to the enclosing `Actions`. `Actions.maybeFind` resolves the nearest
+   registered `Action` for an intent.
+3. **`Shortcuts` widget / `ShortcutManager`** — `Shortcuts` maps `KeyEvent` →
+   `Intent` over a subtree; `ShortcutManager` does the lookup-and-invoke and is
+   the single mechanism shared by app `Shortcuts` widgets and the auto-installed
+   root defaults.
+4. **Standard intents** — `NextFocusIntent`, `PreviousFocusIntent`,
+   `DirectionalFocusIntent` (with traversal `Action`s), plus the marker intents
+   `ActivateIntent` and `DismissIntent` (no default action — apps supply one).
+5. **Default key bindings, auto-installed** — `attachRootWidget` wires a root
+   `ShortcutManager` onto `rootScope.onKeyEvent`, binding Tab/Shift-Tab/arrows
+   to traversal and Enter→`ActivateIntent`, Escape→`DismissIntent`. Traversal
+   works out of the box, exactly as it did in 4.5a.
+6. **Migrate the 4.5a fallback** — delete `FocusManager._handleTraversalKey`
+   (and its `_directional`/`_policyFor`/`defaultTraversalPolicy` helpers); the
+   traversal logic moves into the traversal `Action`s. `FocusManager` no longer
+   knows about traversal.
+7. **A demo** (`shortcuts_demo.dart`) — a 2×2 grid exercising default traversal,
+   per-panel Enter-to-activate counters via `Actions`, a local `Shortcuts`
+   override, and Escape-to-quit via `DismissIntent`.
+
+## Non-goals (for this round — later or never)
+
+- **No `ActionDispatcher`.** Flutter's overridable invoke-indirection earns its
+  place in a large app for global interception/logging; a TUI does not need it.
+  `Actions`/`Shortcuts` invoke `Action.invoke` directly.
+- **No `ContextAction`.** No `Action` variant whose `invoke` receives a
+  `BuildContext`. The traversal actions close over the binding's `FocusManager`;
+  the focused widget's context is reached through `FocusManager.primaryFocus`
+  when needed. App actions that need inherited widgets can capture context in
+  their closure.
+- **No `Action` enabled-state listenable / `consumesKey`.** `isEnabled` is a
+  plain method; there is no change-notification when enablement flips and no
+  `FocusableActionDetector` (it depends on the listenable and is out of scope
+  per 4.5a).
+- **No `LogicalKeySet` / `SingleActivator` / `ShortcutActivator`.** The TUI's
+  `KeyEvent` already has value equality and a `Set<Modifier>`, so a
+  `Map<KeyEvent, Intent>` *is* the shortcut map. No activator abstraction.
+- **No animation, no `GlobalKey`, no repaint/layer model.** Unchanged from
+  earlier stages.
+- **No changes to the stage 1–3 engine, paint kit, or render objects.** The
+  one engine-adjacent touch is a single additive getter on `FocusNode`.
+
+## Architecture
+
+```
+Widget tree                     Focus tree / dispatch
+───────────                     ─────────────────────
+RootWidget                      rootScope  ◀── onKeyEvent = rootShortcutManager
+  …                                │            (set by attachRootWidget)
+  Actions  ──┐                     │
+   Shortcuts │ (app-scoped)   ──▶ FocusNode (Shortcuts' own, skipTraversal)
+    …        │                     │
+     Focus ──┘                ──▶ FocusNode  ★ primary
+      <child>
+
+terminal.keys ─▶ FocusManager.handleKeyEvent(KeyEvent)
+   → chain: primaryFocus ▶ ancestors ▶ … ▶ rootScope
+   → call node.onKeyEvent along the chain; stop on handled
+   → rootScope.onKeyEvent (the last node) = rootShortcutManager.handleFocusKeyEvent
+        → KeyEvent → Intent (default map) → Action (focused context, else
+          fallback traversal actions) → invoke
+```
+
+Key routing is unchanged from 4.5a *except* that `FocusManager` no longer has a
+fallback after the chain. Instead, the chain's **last node, `rootScope`, gets
+an `onKeyEvent`** — the root `ShortcutManager`. `rootScope` is in every focus
+chain (it is the final ancestor) and *is* the whole chain when nothing is
+focused, so the default bindings are always reachable. App `Shortcuts` widgets
+attach their own `Focus` node mid-chain and intercept first.
+
+New code lives under `app/lib/src/tui/widgets/` as new `part` files of the
+existing `widgets.dart` library — the same organization as `focus_*.dart`.
+
+## `Intent` / `Action` — `actions.dart`
+
+```dart
+/// A marker describing a desired action. Intents are immutable value objects.
+abstract class Intent {
+  const Intent();
+}
+
+/// Performs the work for an [Intent] of type [T].
+abstract class Action<T extends Intent> {
+  /// Whether this action can run for [intent] right now.
+  bool isEnabled(T intent) => true;
+
+  /// Performs the action. The return value is forwarded to the invoker.
+  Object? invoke(T intent);
+}
+```
+
+`Action<T>` is generic with `T extends Intent`. Dart class generics are
+covariant, so an `Action<NextFocusIntent>` is assignable to `Action<Intent>`
+and stores into a `Map<Type, Action<Intent>>`. Invocation looks the action up
+by `intent.runtimeType`, so the value passed to `invoke`/`isEnabled` always
+matches the action's real `T`; the implicit covariance check therefore always
+passes. This is the same mechanism Flutter's `Actions` relies on.
+
+Two concrete marker intents ship here, with **no** default action:
+
+```dart
+/// "Activate the focused thing" — e.g. press a button. Bound to Enter by the
+/// default shortcuts; an app supplies the matching Action.
+class ActivateIntent extends Intent {
+  const ActivateIntent();
+}
+
+/// "Dismiss / cancel" — e.g. close a dialog. Bound to Escape by the default
+/// shortcuts; an app supplies the matching Action.
+class DismissIntent extends Intent {
+  const DismissIntent();
+}
+```
+
+### `Actions` widget
+
+```dart
+class Actions extends StatelessWidget {
+  const Actions({super.key, required this.actions, required this.child});
+  final Map<Type, Action<Intent>> actions;
+  final Widget child;
+
+  /// The nearest [Action] registered for [intent]'s runtime type, walking
+  /// outward through enclosing [Actions]. Null when none is registered. Does
+  /// not register an inherited dependency — safe to call from a key handler.
+  static Action<Intent>? maybeFind(BuildContext context, Intent intent);
+}
+```
+
+`Actions` builds a private `_ActionsMarker` `InheritedWidget`. The element
+layer's `_inheritedElements` map keeps only the *nearest* inherited element per
+type, so chained `Actions` cannot all be seen at once — the marker therefore
+carries a `parent` pointer to the enclosing `_ActionsMarker`, read in `build`
+via `dependOnInheritedWidgetOfExactType<_ActionsMarker>()` (a dependency is
+correct here: if an `Actions` is inserted above, this one must rebuild to
+refresh its `parent`).
+
+```dart
+class _ActionsMarker extends InheritedWidget {
+  const _ActionsMarker({
+    required this.actions,
+    required this.parent,
+    required super.child,
+  });
+  final Map<Type, Action<Intent>> actions;
+  final _ActionsMarker? parent;
+
+  Action<Intent>? find(Type intentType) =>
+      actions[intentType] ?? parent?.find(intentType);
+
+  @override
+  bool updateShouldNotify(_ActionsMarker oldWidget) =>
+      actions != oldWidget.actions || !identical(parent, oldWidget.parent);
+}
+```
+
+`Actions.maybeFind` uses the non-dependency `getInheritedWidgetOfExactType`
+(it is called from a key handler, not a build) then `_ActionsMarker.find`,
+returning the nearest registered `Action`. Enabledness is **not** checked
+during the walk: `maybeFind` returns the nearest match and the caller
+(`ShortcutManager`) checks `isEnabled` — matching Flutter, where a disabled
+nearest action does not transparently defer to a farther one.
+
+## `Shortcuts` / `ShortcutManager` — `shortcuts.dart`
+
+```dart
+/// A key-event-to-intent map. `KeyEvent` has value equality and a
+/// `Set<Modifier>`, so it is a usable map key directly.
+typedef ShortcutMap = Map<KeyEvent, Intent>;
+
+class ShortcutManager {
+  ShortcutManager({
+    this.shortcuts = const {},
+    this.fallbackActions = const {},
+  });
+
+  /// Key bindings this manager owns.
+  ShortcutMap shortcuts;
+
+  /// Actions consulted when no enclosing `Actions` widget supplies one for a
+  /// resolved intent. Empty for app `Shortcuts`; the root manager carries the
+  /// default traversal actions here.
+  Map<Type, Action<Intent>> fallbackActions;
+
+  /// A [FocusOnKeyEventCallback]: used as `rootScope.onKeyEvent` and as the
+  /// `Shortcuts` widget's `Focus.onKeyEvent`.
+  KeyEventResult handleFocusKeyEvent(FocusNode node, KeyEvent event);
+}
+```
+
+`handleFocusKeyEvent`:
+
+1. `intent = shortcuts[event]` — if null, return `KeyEventResult.ignored`.
+2. Resolve the `Action`: from the **focused widget's context**
+   (`node.manager?.primaryFocus.context`), via `Actions.maybeFind`; if that
+   yields nothing, fall back to `fallbackActions[intent.runtimeType]`. The
+   focused context — not the `Shortcuts` widget's own context — is used so an
+   `Actions` widget anywhere on the focused path is honoured, matching Flutter's
+   `Shortcuts` (which dispatches against `primaryFocus.context`). A null context
+   (nothing focused — `rootScope` owns no widget) is tolerated: only
+   `fallbackActions` is consulted.
+3. If no action, or `!action.isEnabled(intent)`, return `ignored` (the key
+   keeps bubbling).
+4. Otherwise `action.invoke(intent)` and return `KeyEventResult.handled`.
+
+### `Shortcuts` widget
+
+```dart
+class Shortcuts extends StatefulWidget {
+  const Shortcuts({
+    super.key,
+    required this.shortcuts,
+    required this.child,
+    this.manager,
+  });
+  final ShortcutMap shortcuts;
+  final ShortcutManager? manager;   // adopt one, else own a default
+  final Widget child;
+}
+```
+
+`Shortcuts` wraps `child` in
+`Focus(skipTraversal: true, canRequestFocus: false,
+onKeyEvent: _manager.handleFocusKeyEvent)`. The `Focus` node attaches into the
+focus chain like any other, so a `Shortcuts` enclosing the focused subtree is
+reached before `rootScope` — giving scoped overrides. An app `Shortcuts` with
+no `manager` owns a `ShortcutManager` with empty `fallbackActions`.
+
+### Default bindings
+
+```dart
+ShortcutMap defaultShortcuts() => {
+  const SpecialKey(code: SpecialKeyCode.tab, modifiers: {}):
+      const NextFocusIntent(),
+  const SpecialKey(code: SpecialKeyCode.tab, modifiers: {Modifier.shift}):
+      const PreviousFocusIntent(),
+  const SpecialKey(code: SpecialKeyCode.up, modifiers: {}):
+      const DirectionalFocusIntent(TraversalDirection.up),
+  const SpecialKey(code: SpecialKeyCode.down, modifiers: {}):
+      const DirectionalFocusIntent(TraversalDirection.down),
+  const SpecialKey(code: SpecialKeyCode.left, modifiers: {}):
+      const DirectionalFocusIntent(TraversalDirection.left),
+  const SpecialKey(code: SpecialKeyCode.right, modifiers: {}):
+      const DirectionalFocusIntent(TraversalDirection.right),
+  const SpecialKey(code: SpecialKeyCode.enter, modifiers: {}):
+      const ActivateIntent(),
+  const SpecialKey(code: SpecialKeyCode.escape, modifiers: {}):
+      const DismissIntent(),
+};
+```
+
+`SpecialKey`'s constructor is `const` and a `const {}` modifier set is a valid
+const value, so the map literal is `const`-key-clean.
+
+## Traversal intents & actions — `focus_traversal.dart` (additions)
+
+The traversal intents and their actions live in `focus_traversal.dart`,
+alongside the policies they drive (mirroring Flutter, which keeps
+`NextFocusIntent`/`NextFocusAction` in `focus_traversal.dart`).
+
+```dart
+class NextFocusIntent extends Intent {
+  const NextFocusIntent();
+}
+class PreviousFocusIntent extends Intent {
+  const PreviousFocusIntent();
+}
+class DirectionalFocusIntent extends Intent {
+  const DirectionalFocusIntent(this.direction);
+  final TraversalDirection direction;
+}
+
+class NextFocusAction extends Action<NextFocusIntent> {
+  NextFocusAction(this.focusManager);
+  final FocusManager focusManager;
+  @override
+  Object? invoke(NextFocusIntent intent) { /* policy.next(...) */ }
+}
+// PreviousFocusAction, DirectionalFocusAction — analogous.
+
+/// The default action map for the root `ShortcutManager.fallbackActions`.
+Map<Type, Action<Intent>> defaultTraversalActions(FocusManager fm);
+```
+
+The traversal actions hold the logic **relocated verbatim** from the deleted
+`FocusManager._handleTraversalKey` / `_directional` / `_policyFor`:
+
+- The active policy is found via `FocusTraversalGroup.maybeOf(focusedNode.context)`,
+  defaulting to `ReadingOrderTraversalPolicy` — `focusedNode` being
+  `focusManager.primaryFocus`. (4.5a's `_policyFor` already read the group from
+  the focused node's context; this is the same call, moved.)
+- `NextFocusAction` → `policy.next(primaryFocus)`; `PreviousFocusAction` →
+  `policy.previous(...)`.
+- `DirectionalFocusAction` → directional traversal in `intent.direction`,
+  always via a `DirectionalFocusTraversalPolicy` (as 4.5a's `_directional`
+  did, even when the ambient policy is reading-order).
+
+`invoke` returns nothing meaningful; the action moving focus is the effect.
+`isEnabled` is the default `true`.
+
+## `FocusManager` / `FocusNode` changes — `focus_manager.dart`
+
+- **Delete** `FocusManager._handleTraversalKey`, `_directional`, `_policyFor`,
+  and the `defaultTraversalPolicy` field. `FocusManager` no longer references
+  `FocusTraversalPolicy`, `TraversalDirection`, or `FocusTraversalGroup`.
+- `handleKeyEvent` now simply walks the chain and returns the chain's result,
+  or `KeyEventResult.ignored` if every node returned `ignored`:
+
+  ```dart
+  KeyEventResult handleKeyEvent(KeyEvent event) {
+    var chain = <FocusNode>[_primaryFocus, ..._primaryFocus.ancestors];
+    for (var node in chain) {
+      var callback = node.onKeyEvent;
+      if (callback == null) continue;
+      var result = callback(node, event);
+      if (result == KeyEventResult.handled ||
+          result == KeyEventResult.skipRemainingHandlers) {
+        return result;
+      }
+    }
+    return KeyEventResult.ignored;
+  }
+  ```
+
+- `FocusNode` gains one additive getter — `ShortcutManager` needs to reach the
+  focused widget's context from the node it is called with:
+
+  ```dart
+  /// The manager this node is attached to, or null if detached.
+  FocusManager? get manager => _manager;
+  ```
+
+## `TuiBinding` / `runApp` integration — `binding.dart`
+
+- `TuiBinding` gains `late final ShortcutManager rootShortcutManager;`.
+- `attachRootWidget` constructs it and wires the default bindings onto the
+  focus-tree root:
+
+  ```dart
+  rootShortcutManager = ShortcutManager(
+    shortcuts: defaultShortcuts(),
+    fallbackActions: defaultTraversalActions(focusManager),
+  );
+  focusManager.rootScope.onKeyEvent = rootShortcutManager.handleFocusKeyEvent;
+  ```
+
+  `rootScope` is the final node in every focus chain — and the entire chain
+  when nothing is focused — so Tab-from-nothing still focuses the first node
+  (`policy.next(rootScope)` has the same effect 4.5a's fallback had).
+- The app widget-tree wrapping (`_FocusMarker(rootScope, …)` around the app) is
+  **unchanged**. The default key behaviour is installed entirely via
+  `rootScope.onKeyEvent` — no `Actions`/`Shortcuts` widget is wrapped around the
+  app. Apps opt into `Shortcuts`/`Actions` widgets themselves.
+- `runApp` is unchanged: it still pumps `terminal.keys` into
+  `FocusManager.handleKeyEvent`.
+- `updateRootWidget` (resize path) is unchanged — `rootScope.onKeyEvent`
+  survives a root-widget reconcile.
+
+## The demo — `app/examples/tui/shortcuts_demo.dart`
+
+A 2×2 grid of focusable panels, leaving `focus_demo.dart` intact:
+
+- Tab/Shift-Tab and arrows traverse the grid — via the auto-installed default
+  shortcuts, with no per-app wiring.
+- Each panel shows a counter. The panel wraps its content in
+  `Actions(actions: {ActivateIntent: _IncrementAction(...)})`; pressing Enter
+  while the panel is focused routes Enter→`ActivateIntent` (default shortcut) →
+  the panel's `_IncrementAction` → counter increments → `setState` → next frame
+  repaints.
+- One panel is additionally wrapped in a local `Shortcuts` mapping a printable
+  key (e.g. `+`) to `ActivateIntent`, demonstrating a scoped override.
+- The whole app is wrapped in `Actions(actions: {DismissIntent: _QuitAction})`;
+  Escape routes Escape→`DismissIntent` → `_QuitAction` → `TerminalApp.of(...)
+  .exit()`. `q` also quits, as in `focus_demo.dart`.
+
+## Files touched
+
+**Create — `app/lib/src/tui/widgets/`:**
+
+- `actions.dart` — `Intent`, `Action`, `ActivateIntent`, `DismissIntent`,
+  `Actions`, `_ActionsMarker`
+- `shortcuts.dart` — `ShortcutMap`, `ShortcutManager`, `Shortcuts`,
+  `defaultShortcuts`
+
+**Create — demo & tests:**
+
+- `app/examples/tui/shortcuts_demo.dart`
+- `app/test/tui/widgets/actions_test.dart` — `Actions` nearest-match lookup,
+  chained fall-through to an enclosing `Actions`, `maybeFind` null when
+  unregistered, inner shadows outer
+- `app/test/tui/widgets/shortcuts_test.dart` — `ShortcutManager` key→intent→
+  action mapping; unknown key → `ignored`; disabled action → `ignored`;
+  `fallbackActions` path when no `Actions` widget; `Shortcuts` widget intercepts
+  a key for its focused subtree; an inner `Shortcuts` shadows an outer; default
+  traversal (Tab-from-nothing focuses first, Tab cycles, arrows directional)
+  routed through `handleKeyEvent` → `rootScope.onKeyEvent`; end-to-end
+  `ActivateIntent` — a focused widget with `Actions({ActivateIntent: …})`,
+  Enter invokes it, the next `drawFrame` reflects the change
+
+**Modify:**
+
+- `app/lib/src/tui/widgets/widgets.dart` — add the `actions.dart` and
+  `shortcuts.dart` `part` directives
+- `app/lib/src/tui/widgets/focus_manager.dart` — delete `_handleTraversalKey`,
+  `_directional`, `_policyFor`, `defaultTraversalPolicy`; simplify
+  `handleKeyEvent`; add `FocusNode.manager`
+- `app/lib/src/tui/widgets/focus_traversal.dart` — add `NextFocusIntent`,
+  `PreviousFocusIntent`, `DirectionalFocusIntent`, their `Action`s, and
+  `defaultTraversalActions`
+- `app/lib/src/tui/widgets/binding.dart` — `TuiBinding.rootShortcutManager`;
+  `attachRootWidget` wires `rootScope.onKeyEvent`
+- `app/lib/src/tui/tui.dart` — export `Intent`, `Action`, `Actions`,
+  `ActivateIntent`, `DismissIntent`, `Shortcuts`, `ShortcutManager`,
+  `ShortcutMap`, `defaultShortcuts`, `NextFocusIntent`, `PreviousFocusIntent`,
+  `DirectionalFocusIntent`, `NextFocusAction`, `PreviousFocusAction`,
+  `DirectionalFocusAction`
+- `app/test/tui/widgets/focus_manager_test.dart`,
+  `app/test/tui/widgets/focus_routing_test.dart` — remove assertions that
+  exercised the deleted `_handleTraversalKey`; re-cover traversal-via-key
+  through the root `ShortcutManager` (or move that coverage to
+  `shortcuts_test.dart`)
+- `app/lib/src/tui/README.md` — note 4.5b done; update the file table and
+  limitations
+- `docs/superpowers/tui-roadmap.md` — add a Stage 4.5b row, link this spec,
+  update the "declarative Actions/Shortcuts layer is deferred" limitation
+
+## Divergences from Flutter
+
+Recorded so the transcription is intentional, not accidental:
+
+- **`Map<KeyEvent, Intent>` is the shortcut map.** No `LogicalKeySet`,
+  `SingleActivator`, or `ShortcutActivator` — the TUI's `KeyEvent` already has
+  value equality and a `Set<Modifier>`.
+- **No `ActionDispatcher`.** `Shortcuts`/`Actions` invoke `Action.invoke`
+  directly. The dispatcher indirection is omitted (YAGNI for a TUI).
+- **No `ContextAction`.** `invoke` never receives a `BuildContext`. Framework
+  actions close over `FocusManager`; app actions capture context in a closure
+  if they need it.
+- **`Action` has no enabled-state listenable and no `consumesKey`.**
+  `isEnabled` is a plain method evaluated at invoke time.
+- **One `ShortcutManager` class, not a `ChangeNotifier`.** It is a plain
+  object; app `Shortcuts` and the auto-installed root defaults share it. The
+  root manager differs only in carrying `fallbackActions`.
+- **Default bindings live on `rootScope.onKeyEvent`, not a wrapping
+  `Shortcuts`/`Actions` widget pair.** There is no `WidgetsApp` in the TUI;
+  attaching the defaults to the focus-tree root keeps them reachable even when
+  nothing is focused (a `Shortcuts` *widget*'s focus node is a child of
+  `rootScope` and would be missed when `primaryFocus == rootScope`).
+- **`Shortcuts` resolves `Actions` from `primaryFocus.context`**, the focused
+  widget's context — matching Flutter's `Shortcuts`, which dispatches against
+  `primaryFocus.context` rather than its own.
+
+## Testing strategy
+
+The whole layer is testable without a tty, as in 4.5a: a `TuiBinding` driven
+against a `CellBuffer` wrapped in a `Painter`, with `KeyEvent`s fed into
+`FocusManager.handleKeyEvent`. Build a tree with `Focus`, `Shortcuts`, and
+`Actions` widgets; call `drawFrame`; assert on `primaryFocus`, on action side
+effects, and on cells read back from the buffer.
+
+Key cases:
+
+- **`Actions`** — `maybeFind` returns the nearest registered action; an
+  unmatched intent type falls through to an enclosing `Actions`; an inner
+  `Actions` shadows an outer for the same type; `maybeFind` is null when no
+  `Actions` registers the type.
+- **`ShortcutManager`** — a bound key resolves its intent and invokes the
+  action, returning `handled`; an unbound key returns `ignored`; a resolved
+  intent whose action `isEnabled` is false returns `ignored`; with no enclosing
+  `Actions`, `fallbackActions` is consulted; a null focused context falls back
+  cleanly.
+- **`Shortcuts` widget** — intercepts a key for its focused subtree; an inner
+  `Shortcuts` shadows an outer; a key it does not bind bubbles past it.
+- **Default traversal migration** — with nothing focused, Tab focuses the first
+  node; Tab/Shift-Tab cycle and wrap; arrows traverse directionally; all routed
+  through `handleKeyEvent` → `rootScope.onKeyEvent`, with no
+  `_handleTraversalKey` present.
+- **End-to-end activation** — a focused widget with
+  `Actions({ActivateIntent: …})`; an Enter `KeyEvent` invokes the action; the
+  next `drawFrame` paints the changed state.
+
+`shortcuts_demo.dart` is covered by manual smoke in a real terminal.
+
+## Success criteria
+
+1. All existing tests still pass; `flutter analyze` is clean.
+2. Every new and updated `app/test/tui/widgets/*_test.dart` suite passes.
+3. `dart tool/prepare_submit.dart` produces no diff.
+4. `FocusManager` no longer contains `_handleTraversalKey` or any traversal
+   logic; `git grep` confirms it.
+5. `shortcuts_demo.dart` runs in a real terminal:
+   - The 2×2 grid renders; Tab/Shift-Tab and arrows traverse it via the default
+     bindings, with the focus highlight following.
+   - Enter increments the focused panel's counter; the `+` override increments
+     its panel; the counters repaint.
+   - Escape and `q` both exit cleanly via `TerminalApp.of(context).exit()`.
+
+## Open questions deferred
+
+- **`FocusableActionDetector`** — depends on the `Action` enabled-state
+  listenable; revisit if a later stage needs hover/enabled-driven rebuilds.
+- **`ActionDispatcher`** — add only if a real need for global action
+  interception appears.
+- **Animation** — `Ticker`/`SchedulerBinding`/`AnimationController`, still
+  deferred beyond the interactivity stage.
+- **`GlobalKey`, repaint boundaries / layer model** — unchanged from earlier
+  stages.

--- a/docs/superpowers/tui-roadmap.md
+++ b/docs/superpowers/tui-roadmap.md
@@ -29,6 +29,7 @@ could use a richer status/dashboard UI.
 | **3. Render tree** | `RenderObject`/`RenderBox`, `BoxConstraints`, `Row`/`Column`/`Padding` | ✅ Done |
 | **4. Widget layer** | `Widget`/`Element`, `StatelessWidget`/`StatefulWidget`, `setState` | ✅ Done |
 | **4.5a Focus** | Focus tree, `FocusManager`, `Focus`/`FocusScope`, traversal, key routing | ✅ Done |
+| **4.5b Shortcuts** | `Actions`/`Intent`/`Action`, `Shortcuts`/`ShortcutManager`, default key bindings | ✅ Done |
 | **5. Integration** | Replace the flutterware CLI startup UX with a real TUI screen | ⬜ Not started |
 
 Each stage is independently useful: after stage 1 you have a working terminal
@@ -51,6 +52,8 @@ framework.
   [plan](plans/2026-05-15-tui-stage4-widget-layer.md)
 - Stage 4.5a — [spec](specs/2026-05-16-tui-stage4.5a-focus-system-design.md) ·
   [plan](plans/2026-05-16-tui-stage4.5a-focus-system.md)
+- Stage 4.5b — [spec](specs/2026-05-17-tui-stage4.5b-actions-shortcuts-design.md) ·
+  [plan](plans/2026-05-17-tui-stage4.5b-actions-shortcuts.md)
 
 ## Key design decisions
 
@@ -110,8 +113,9 @@ These are accepted in earlier stages and should be revisited as later stages lan
   `Cell.width` field is reserved for it.
 - No GlobalKey or animation/tickers — deferred beyond stage 4.
 - A focus system (focus tree, `FocusManager`, `Focus`/`FocusScope`, Tab/arrow
-  traversal, key routing) was added in Stage 4.5a. The declarative
-  `Actions`/`Intents`/`Shortcuts` key-binding layer is deferred to Stage 4.5b.
+  traversal, key routing) was added in Stage 4.5a, and the declarative
+  `Actions`/`Intents`/`Shortcuts` key-binding layer in Stage 4.5b. Traversal
+  and the Enter/Escape bindings are installed by default on `rootScope`.
 - Repaint is whole-tree: with no layer model, `markNeedsPaint` repaints
   everything. Localized repaint is deferred to a later stage.
 - Windows: signal-driven features (resize via SIGWINCH) are Unix-only.


### PR DESCRIPTION
## Summary

Adds the declarative key-binding layer to the TUI framework (`app/lib/src/tui/`) — the second half of the interactivity stage, building on the Stage 4.5a focus system.

- **`actions.dart`** — `Intent`, `Action<T>`, and the `Actions` widget (chained `Type → Action` lookup), plus the standard `ActivateIntent` / `DismissIntent`.
- **`shortcuts.dart`** — `ShortcutMap` (`Map<KeyEvent, Intent>`), `ShortcutManager`, the `Shortcuts` widget, and `defaultShortcuts()`.
- **Traversal intents/actions** added to `focus_traversal.dart` (`NextFocusIntent`/`PreviousFocusIntent`/`DirectionalFocusIntent` + actions).
- **Migrated the 4.5a fallback** — `FocusManager._handleTraversalKey` (and `_directional`/`_policyFor`/`defaultTraversalPolicy`) deleted. The default key bindings (Tab/arrows → traversal, Enter → Activate, Escape → Dismiss) are now installed on `rootScope.onKeyEvent` via a root `ShortcutManager`, wired by `attachRootWidget`. `rootScope` is the last node in every dispatch chain, so traversal still works even when nothing is focused.
- **`shortcuts_demo.dart`** — a 2×2 grid exercising default traversal, per-panel Enter-to-activate counters, a local `Shortcuts` override, and Escape-to-quit.

Design: full transcription of Flutter's Actions/Intents/Shortcuts, trimmed for the TUI (no `ActionDispatcher`, no `ContextAction`, no `ShortcutActivator` — `KeyEvent`'s value equality lets a plain map serve as the shortcut map). See the [design spec](docs/superpowers/specs/2026-05-17-tui-stage4.5b-actions-shortcuts-design.md) and [plan](docs/superpowers/plans/2026-05-17-tui-stage4.5b-actions-shortcuts.md).

Note: a latent bug in `FocusTraversalPolicy._move` was fixed along the way — `next()`/`previous()` from a scope node with a single traversable descendant previously returned `false`; it now focuses that descendant. This is what makes Tab-from-nothing-focused work.

## Test Plan

- [x] `flutter analyze` clean
- [x] `cd app && flutter test` — all 381 tests pass
- [x] `dart tool/prepare_submit.dart` produces no diff
- [x] New suites: `actions_test.dart`, `shortcuts_test.dart`, traversal-action additions to `focus_traversal_test.dart`
- [ ] Manual smoke: `cd app && dart run examples/tui/shortcuts_demo.dart` in a real terminal — Tab/arrows traverse, Enter/`+` increment counters, Esc/`q` quit

🤖 Generated with [Claude Code](https://claude.com/claude-code)