### PR TITLE
Add sub-project 0: the SDK wrap point

### DIFF
--- a/app/bin/wrap.dart
+++ b/app/bin/wrap.dart
@@ -1,0 +1,18 @@
+import 'dart:io';
+
+import 'package:args/command_runner.dart';
+import 'package:flutterware_app/src/wrap/run_command.dart';
+
+Future<void> main(List<String> args) async {
+  final runner = CommandRunner<int>(
+    'wrap',
+    'flutterware SDK wrap point.',
+  )..addCommand(RunCommand());
+  try {
+    final code = await runner.run(args) ?? 0;
+    exit(code);
+  } on UsageException catch (e) {
+    stderr.writeln(e);
+    exit(64);
+  }
+}

--- a/app/bin/wrap.dart
+++ b/app/bin/wrap.dart
@@ -1,13 +1,16 @@
 import 'dart:io';
 
 import 'package:args/command_runner.dart';
+import 'package:flutterware_app/src/wrap/install_command.dart';
 import 'package:flutterware_app/src/wrap/run_command.dart';
 
 Future<void> main(List<String> args) async {
   final runner = CommandRunner<int>(
     'wrap',
     'flutterware SDK wrap point.',
-  )..addCommand(RunCommand());
+  )
+    ..addCommand(RunCommand())
+    ..addCommand(InstallCommand());
   try {
     final code = await runner.run(args) ?? 0;
     exit(code);

--- a/app/lib/src/passthrough/passthrough_command.dart
+++ b/app/lib/src/passthrough/passthrough_command.dart
@@ -60,6 +60,7 @@ Future<int> runUnderPty({
   required List<String> arguments,
   String? workingDirectory,
   bool printSummary = true,
+  IOSink? captureSink,
 }) async {
   // Snapshot parent terminal modes for restoration.
   final originalLineMode = stdin.hasTerminal ? stdin.lineMode : true;
@@ -86,7 +87,10 @@ Future<int> runUnderPty({
       workingDirectory: workingDirectory,
     );
 
-    tee = TeeSink(onBytes: stdout.add);
+    tee = TeeSink(onBytes: (chunk) {
+      stdout.add(chunk);
+      captureSink?.add(chunk);
+    });
 
     // PTY output → tee (stdout + capture).
     final outputDone = Completer<void>();

--- a/app/lib/src/wrap/dart_define.dart
+++ b/app/lib/src/wrap/dart_define.dart
@@ -1,0 +1,14 @@
+/// Returns a copy of [args] with `--dart-define=<key>=<value>` inserted
+/// immediately after the subcommand token (the first non-flag argument,
+/// e.g. `run` in `flutter run`). If there is no non-flag token, the define
+/// is appended at the end.
+List<String> injectDartDefine(
+  List<String> args, {
+  required String key,
+  required String value,
+}) {
+  final define = '--dart-define=$key=$value';
+  final idx = args.indexWhere((a) => !a.startsWith('-'));
+  if (idx == -1) return [...args, define];
+  return [...args.sublist(0, idx + 1), define, ...args.sublist(idx + 1)];
+}

--- a/app/lib/src/wrap/install_command.dart
+++ b/app/lib/src/wrap/install_command.dart
@@ -1,0 +1,40 @@
+import 'dart:io';
+
+import 'package:args/command_runner.dart';
+
+import 'installer.dart';
+
+/// Builds the per-project SDK mirror facade. Sub-project 0 assumes a shared
+/// SDK already exists; this command wraps it.
+class InstallCommand extends Command<int> {
+  @override
+  final name = 'install';
+  @override
+  final description = 'Install the SDK mirror facade for a project.';
+
+  InstallCommand() {
+    argParser
+      ..addOption('sdk', help: 'Path to the existing shared Flutter SDK.')
+      ..addOption('project', help: 'Path to the project root.')
+      ..addOption('wrap-exe',
+          help: 'Path to the compiled wrap executable to bake into shims.');
+  }
+
+  @override
+  Future<int> run() async {
+    final sdk = argResults!['sdk'] as String?;
+    final project = argResults!['project'] as String?;
+    final wrapExe = argResults!['wrap-exe'] as String?;
+    if (sdk == null || project == null || wrapExe == null) {
+      stderr.writeln('[wrap] install requires --sdk, --project, --wrap-exe');
+      return 64;
+    }
+    final mirror = installMirror(
+      sharedSdk: Directory(sdk),
+      projectRoot: Directory(project),
+      wrapExe: wrapExe,
+    );
+    stdout.writeln('Installed SDK mirror at ${mirror.path}');
+    return 0;
+  }
+}

--- a/app/lib/src/wrap/installer.dart
+++ b/app/lib/src/wrap/installer.dart
@@ -1,0 +1,68 @@
+import 'dart:io';
+import 'package:path/path.dart' as p;
+
+import 'shim_template.dart';
+
+/// Builds the per-project SDK mirror facade at `<projectRoot>/flutterware/sdk/`.
+///
+/// Every entry of [sharedSdk] is symlinked into the mirror, except `bin/`,
+/// which is a real directory whose `flutter`/`dart` are generated shims and
+/// whose other entries are symlinks. The mirror is rebuilt from scratch on
+/// every call (idempotent). Returns the mirror directory.
+Directory installMirror({
+  required Directory sharedSdk,
+  required Directory projectRoot,
+  required String wrapExe,
+}) {
+  final mirror = Directory(p.join(projectRoot.path, 'flutterware', 'sdk'));
+  if (mirror.existsSync()) mirror.deleteSync(recursive: true);
+  mirror.createSync(recursive: true);
+
+  final mirrorBin = Directory(p.join(mirror.path, 'bin'))..createSync();
+
+  // Top-level SDK entries (skip `bin`) -> symlinks.
+  for (final entry in sharedSdk.listSync()) {
+    final name = p.basename(entry.path);
+    if (name == 'bin') continue;
+    Link(p.join(mirror.path, name)).createSync(entry.path);
+  }
+
+  // bin/ entries (skip the two wrapped binaries) -> symlinks.
+  final sharedBin = Directory(p.join(sharedSdk.path, 'bin'));
+  for (final entry in sharedBin.listSync()) {
+    final name = p.basename(entry.path);
+    if (name == 'flutter' || name == 'dart') continue;
+    Link(p.join(mirrorBin.path, name)).createSync(entry.path);
+  }
+
+  // The two shims.
+  _writeShim(
+    file: File(p.join(mirrorBin.path, 'flutter')),
+    realBinary: p.join(sharedBin.path, 'flutter'),
+    kind: 'flutter',
+    wrapExe: wrapExe,
+  );
+  _writeShim(
+    file: File(p.join(mirrorBin.path, 'dart')),
+    realBinary: p.join(sharedBin.path, 'dart'),
+    kind: 'dart',
+    wrapExe: wrapExe,
+  );
+
+  return mirror;
+}
+
+void _writeShim({
+  required File file,
+  required String realBinary,
+  required String kind,
+  required String wrapExe,
+}) {
+  file.writeAsStringSync(renderShim(
+    realBinary: realBinary,
+    kind: kind,
+    wrapExe: wrapExe,
+  ));
+  // chmod +x.
+  Process.runSync('chmod', ['+x', file.path]);
+}

--- a/app/lib/src/wrap/project_resolution.dart
+++ b/app/lib/src/wrap/project_resolution.dart
@@ -1,0 +1,48 @@
+import 'dart:io';
+import 'package:path/path.dart' as p;
+
+/// A resolved flutterware project and the worktree the invocation is in.
+class ProjectContext {
+  final Directory projectRoot;
+  final String worktreeName;
+  ProjectContext(this.projectRoot, this.worktreeName);
+}
+
+/// Walks up from [start] looking for a `flutter_version` marker file.
+/// Returns the directory that contains it, or null if none is found.
+Directory? findProjectRoot(Directory start) {
+  var dir = start.absolute;
+  while (true) {
+    if (File(p.join(dir.path, 'flutter_version')).existsSync()) return dir;
+    final parent = dir.parent;
+    if (parent.path == dir.path) return null;
+    dir = parent;
+  }
+}
+
+/// Resolves the worktree name for [projectRoot]. A linked worktree has a
+/// `.git` *file* with a `gitdir:` pointer; the last path segment of that
+/// pointer is the worktree name. A main checkout has a `.git` *directory*.
+String resolveWorktreeName(Directory projectRoot) {
+  final gitPath = p.join(projectRoot.path, '.git');
+  if (FileSystemEntity.isDirectorySync(gitPath)) {
+    return p.basename(projectRoot.path);
+  }
+  final gitFile = File(gitPath);
+  if (gitFile.existsSync()) {
+    final content = gitFile.readAsStringSync().trim();
+    const prefix = 'gitdir:';
+    if (content.startsWith(prefix)) {
+      return p.basename(content.substring(prefix.length).trim());
+    }
+  }
+  return p.basename(projectRoot.path);
+}
+
+/// Resolves the [ProjectContext] for an invocation made from [start],
+/// or null if [start] is not inside a flutterware project.
+ProjectContext? resolveProject(Directory start) {
+  final root = findProjectRoot(start);
+  if (root == null) return null;
+  return ProjectContext(root, resolveWorktreeName(root));
+}

--- a/app/lib/src/wrap/run_command.dart
+++ b/app/lib/src/wrap/run_command.dart
@@ -1,0 +1,84 @@
+import 'dart:io';
+
+import 'package:args/command_runner.dart';
+
+import 'dart_define.dart';
+import 'project_resolution.dart';
+import 'session_sink.dart';
+import 'transport.dart';
+
+/// Heavy-path command for an *interesting* intercepted run.
+///
+/// Invoked by the generated bash shim as:
+///   wrap run --real `<binary>` --kind `<flutter|dart>` -- `<original args...>`
+///
+/// Rewrites argv to inject `--dart-define=FW_MARKER=<token>`, runs the real
+/// binary under the transport, and captures output to a local session sink.
+/// Any failure degrades to a plain run of the real binary.
+class RunCommand extends Command<int> {
+  @override
+  final name = 'run';
+  @override
+  final description = 'Run an intercepted flutter/dart invocation.';
+
+  RunCommand() {
+    argParser
+      ..addOption('real', help: 'Absolute path to the real binary.')
+      ..addOption('kind', help: 'flutter or dart.');
+  }
+
+  @override
+  Future<int> run() async {
+    final real = argResults!['real'] as String?;
+    final original = argResults!.rest;
+    if (real == null || real.isEmpty) {
+      stderr.writeln('[wrap] missing --real');
+      return 64;
+    }
+    try {
+      final ctx = resolveProject(Directory.current);
+      if (ctx == null) return _degrade(real, original);
+
+      final token = newSessionId();
+      final injected =
+          injectDartDefine(original, key: 'FW_MARKER', value: token);
+
+      final flutterwareDir = Directory('${ctx.projectRoot.path}/.flutterware');
+      final sink = SessionSink(flutterwareDir, token);
+      final out = sink.openOutput();
+
+      final code = await runIntercepted(
+        executable: real,
+        arguments: injected,
+        captureSink: out,
+      );
+
+      await out.flush();
+      await out.close();
+      sink.writeMeta({
+        'sessionId': token,
+        'worktree': ctx.worktreeName,
+        'kind': argResults!['kind'],
+        'argvOriginal': original,
+        'argvInjected': injected,
+        'marker': token,
+        'exitCode': code,
+      });
+      return code;
+    } catch (e) {
+      stderr.writeln('[wrap] degraded to plain run: $e');
+      return _degrade(real, original);
+    }
+  }
+
+  /// Plain spawn of the real binary with the original argv — the guiding
+  /// principle: the user's command always runs.
+  Future<int> _degrade(String real, List<String> original) async {
+    final proc = await Process.start(
+      real,
+      original,
+      mode: ProcessStartMode.inheritStdio,
+    );
+    return proc.exitCode;
+  }
+}

--- a/app/lib/src/wrap/run_command.dart
+++ b/app/lib/src/wrap/run_command.dart
@@ -32,9 +32,12 @@ class RunCommand extends Command<int> {
     final real = argResults!['real'] as String?;
     final original = argResults!.rest;
     if (real == null || real.isEmpty) {
+      // Without a binary path there is nothing to run or degrade to.
       stderr.writeln('[wrap] missing --real');
       return 64;
     }
+
+    IOSink? out;
     try {
       final ctx = resolveProject(Directory.current);
       if (ctx == null) return _degrade(real, original);
@@ -45,7 +48,7 @@ class RunCommand extends Command<int> {
 
       final flutterwareDir = Directory('${ctx.projectRoot.path}/.flutterware');
       final sink = SessionSink(flutterwareDir, token);
-      final out = sink.openOutput();
+      out = sink.openOutput();
 
       final code = await runIntercepted(
         executable: real,
@@ -53,32 +56,52 @@ class RunCommand extends Command<int> {
         captureSink: out,
       );
 
-      await out.flush();
-      await out.close();
-      sink.writeMeta({
-        'sessionId': token,
-        'worktree': ctx.worktreeName,
-        'kind': argResults!['kind'],
-        'argvOriginal': original,
-        'argvInjected': injected,
-        'marker': token,
-        'exitCode': code,
-      });
+      // Post-run finalisation must never trigger a degrade — the run
+      // already happened. Log and swallow any failure, still return code.
+      try {
+        await out.flush();
+        await out.close();
+        out = null;
+        sink.writeMeta({
+          'sessionId': token,
+          'worktree': ctx.worktreeName,
+          'kind': argResults!['kind'] ?? 'unknown',
+          'argvOriginal': original,
+          'argvInjected': injected,
+          'marker': token,
+          'exitCode': code,
+        });
+      } catch (e) {
+        stderr.writeln('[wrap] failed to finalise session: $e');
+      }
       return code;
     } catch (e) {
       stderr.writeln('[wrap] degraded to plain run: $e');
+      // Close a leaked sink from a failed setup/run before degrading.
+      if (out != null) {
+        try {
+          await out.close();
+        } catch (_) {}
+      }
       return _degrade(real, original);
     }
   }
 
   /// Plain spawn of the real binary with the original argv — the guiding
-  /// principle: the user's command always runs.
+  /// principle: the user's command always runs. If even this fails (the
+  /// binary is genuinely not runnable) there is nothing to salvage; report
+  /// and exit non-zero rather than crashing with a stack trace.
   Future<int> _degrade(String real, List<String> original) async {
-    final proc = await Process.start(
-      real,
-      original,
-      mode: ProcessStartMode.inheritStdio,
-    );
-    return proc.exitCode;
+    try {
+      final proc = await Process.start(
+        real,
+        original,
+        mode: ProcessStartMode.inheritStdio,
+      );
+      return proc.exitCode;
+    } catch (e) {
+      stderr.writeln('[wrap] degrade failed: $e');
+      return 1;
+    }
   }
 }

--- a/app/lib/src/wrap/session_sink.dart
+++ b/app/lib/src/wrap/session_sink.dart
@@ -1,0 +1,30 @@
+import 'dart:convert';
+import 'dart:io';
+import 'package:path/path.dart' as p;
+
+/// A filesystem-safe, reasonably unique id for one intercepted session.
+String newSessionId() {
+  final ts = DateTime.now().toIso8601String().replaceAll(RegExp(r'[:.]'), '-');
+  return '$ts-$pid';
+}
+
+/// The local, provisional observation sink for one interesting run.
+/// Lives at `<flutterwareDir>/sessions/<sessionId>/`. Sub-project 1
+/// replaces this with the daemon + SQLite DB.
+class SessionSink {
+  final Directory dir;
+
+  SessionSink(Directory flutterwareDir, String sessionId)
+      : dir = Directory(p.join(flutterwareDir.path, 'sessions', sessionId)) {
+    dir.createSync(recursive: true);
+  }
+
+  /// Opens the captured-output file for streaming writes.
+  IOSink openOutput() => File(p.join(dir.path, 'output.log')).openWrite();
+
+  /// Writes the session metadata as pretty-printed JSON.
+  void writeMeta(Map<String, Object?> meta) {
+    File(p.join(dir.path, 'meta.json'))
+        .writeAsStringSync(const JsonEncoder.withIndent('  ').convert(meta));
+  }
+}

--- a/app/lib/src/wrap/shim_template.dart
+++ b/app/lib/src/wrap/shim_template.dart
@@ -1,0 +1,63 @@
+/// The bash shim installed as `<mirror>/bin/flutter` and `<mirror>/bin/dart`.
+/// `@REAL@`, `@KIND@`, `@WRAP_EXE@` are replaced at install time.
+///
+/// Fast path is pure bash: marker walk-up, classification, one audit-log
+/// line. Only *interesting* runs hand off to the compiled wrap executable.
+const _shimTemplate = r'''#!/usr/bin/env bash
+# flutterware wrap shim — generated; do not edit.
+set -u
+REAL="@REAL@"
+KIND="@KIND@"
+WRAP_EXE="@WRAP_EXE@"
+
+# 1. Walk up for the flutter_version marker.
+root=""
+d="$PWD"
+while :; do
+  if [ -f "$d/flutter_version" ]; then root="$d"; break; fi
+  [ "$d" = "/" ] && break
+  d="$(dirname "$d")"
+done
+[ -z "$root" ] && exec "$REAL" "$@"
+
+# 2. First non-flag argument (the subcommand).
+sub=""
+for a in "$@"; do
+  case "$a" in
+    -*) ;;
+    *) sub="$a"; break ;;
+  esac
+done
+
+# 3. Classify (probe default — replaced by config.dart in sub-project 3).
+cls="noise"
+if [ "$KIND" = "flutter" ]; then
+  case "$sub" in
+    run|test) cls="interesting" ;;
+  esac
+fi
+
+# 4. Audit log — one line per invocation, every kind.
+fwdir="$root/.flutterware"
+mkdir -p "$fwdir" 2>/dev/null || true
+printf '%s\t%s\t%s\t%s\t%s %s\n' \
+  "$(date +%Y-%m-%dT%H:%M:%S)" "$PWD" "$KIND" "$cls" "$KIND" "$*" \
+  >>"$fwdir/wrap-audit.log" 2>/dev/null || true
+
+# 5. Dispatch. Interesting -> the wrap exe; anything else / missing exe -> real.
+if [ "$cls" = "interesting" ] && [ -x "$WRAP_EXE" ]; then
+  exec "$WRAP_EXE" run --real "$REAL" --kind "$KIND" -- "$@"
+fi
+exec "$REAL" "$@"
+''';
+
+/// Renders the shim with the given absolute paths baked in.
+String renderShim({
+  required String realBinary,
+  required String kind,
+  required String wrapExe,
+}) =>
+    _shimTemplate
+        .replaceAll('@REAL@', realBinary)
+        .replaceAll('@KIND@', kind)
+        .replaceAll('@WRAP_EXE@', wrapExe);

--- a/app/lib/src/wrap/transport.dart
+++ b/app/lib/src/wrap/transport.dart
@@ -65,6 +65,9 @@ Future<int> _runPiped({
       captureSink.add(chunk);
     },
     onDone: outDone.complete,
+    onError: (Object e, StackTrace st) {
+      if (!outDone.isCompleted) outDone.completeError(e, st);
+    },
   );
   proc.stderr.listen(
     (chunk) {
@@ -72,11 +75,17 @@ Future<int> _runPiped({
       captureSink.add(chunk);
     },
     onDone: errDone.complete,
+    onError: (Object e, StackTrace st) {
+      if (!errDone.isCompleted) errDone.completeError(e, st);
+    },
   );
 
-  final code = await proc.exitCode;
-  await outDone.future;
-  await errDone.future;
-  await stdinSub?.cancel();
-  return code;
+  try {
+    final code = await proc.exitCode;
+    await outDone.future;
+    await errDone.future;
+    return code;
+  } finally {
+    await stdinSub?.cancel();
+  }
 }

--- a/app/lib/src/wrap/transport.dart
+++ b/app/lib/src/wrap/transport.dart
@@ -1,0 +1,82 @@
+import 'dart:async';
+import 'dart:io';
+
+import '../passthrough/passthrough_command.dart';
+
+/// Runs [executable] with [arguments], streaming I/O to the parent and
+/// teeing all output into [captureSink].
+///
+/// Uses a PTY when the parent stdin is a terminal (an interactive CLI run),
+/// and plain pipes otherwise (an IDE / `--machine` run, whose stdin/stdout
+/// carry the daemon JSON-RPC protocol). Neither mode parses the stream.
+Future<int> runIntercepted({
+  required String executable,
+  required List<String> arguments,
+  required IOSink captureSink,
+  String? workingDirectory,
+}) async {
+  if (stdin.hasTerminal) {
+    return runUnderPty(
+      executable: executable,
+      arguments: arguments,
+      workingDirectory: workingDirectory,
+      printSummary: false,
+      captureSink: captureSink,
+    );
+  }
+  return _runPiped(
+    executable: executable,
+    arguments: arguments,
+    workingDirectory: workingDirectory,
+    captureSink: captureSink,
+  );
+}
+
+Future<int> _runPiped({
+  required String executable,
+  required List<String> arguments,
+  required IOSink captureSink,
+  String? workingDirectory,
+}) async {
+  final proc = await Process.start(
+    executable,
+    arguments,
+    workingDirectory: workingDirectory,
+  );
+
+  StreamSubscription<List<int>>? stdinSub;
+  try {
+    stdinSub = stdin.listen(
+      proc.stdin.add,
+      onDone: () => proc.stdin.close().catchError((_) {}),
+      onError: (_) {},
+    );
+  } catch (_) {
+    // stdin may not be listenable in all environments (e.g. flutter test);
+    // proceed without forwarding stdin.
+    unawaited(proc.stdin.close().catchError((_) {}));
+  }
+
+  final outDone = Completer<void>();
+  final errDone = Completer<void>();
+  proc.stdout.listen(
+    (chunk) {
+      stdout.add(chunk);
+      captureSink.add(chunk);
+    },
+    onDone: outDone.complete,
+  );
+  proc.stderr.listen(
+    (chunk) {
+      stderr.add(chunk);
+      captureSink.add(chunk);
+    },
+    onDone: errDone.complete,
+  );
+
+  final code = await proc.exitCode;
+  await outDone.future;
+  await errDone.future;
+  await stdinSub?.cancel();
+  return code;
+}

--- a/app/test/wrap/dart_define_test.dart
+++ b/app/test/wrap/dart_define_test.dart
@@ -1,0 +1,29 @@
+import 'package:flutterware_app/src/wrap/dart_define.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('inserts the define immediately after the subcommand token', () {
+    final out = injectDartDefine(
+      ['--no-color', 'run', '--machine', 'lib/main.dart'],
+      key: 'FW_MARKER',
+      value: 'tok123',
+    );
+    expect(out, [
+      '--no-color',
+      'run',
+      '--dart-define=FW_MARKER=tok123',
+      '--machine',
+      'lib/main.dart',
+    ]);
+  });
+
+  test('appends the define when there is no non-flag token', () {
+    final out = injectDartDefine(['--version'], key: 'FW_MARKER', value: 't');
+    expect(out, ['--version', '--dart-define=FW_MARKER=t']);
+  });
+
+  test('handles a bare subcommand with no flags', () {
+    final out = injectDartDefine(['test'], key: 'K', value: 'v');
+    expect(out, ['test', '--dart-define=K=v']);
+  });
+}

--- a/app/test/wrap/installer_test.dart
+++ b/app/test/wrap/installer_test.dart
@@ -1,0 +1,58 @@
+import 'dart:io';
+import 'package:flutterware_app/src/wrap/installer.dart';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+void main() {
+  late Directory tmp;
+  late Directory sdk;
+  late Directory project;
+
+  setUp(() {
+    tmp = Directory.systemTemp.createTempSync('wrap_inst');
+    // A fake "shared SDK".
+    sdk = Directory(p.join(tmp.path, 'sharedsdk'))..createSync();
+    Directory(p.join(sdk.path, 'bin'))..createSync();
+    Directory(p.join(sdk.path, 'bin', 'cache')).createSync();
+    File(p.join(sdk.path, 'bin', 'flutter')).writeAsStringSync('#real\n');
+    File(p.join(sdk.path, 'bin', 'dart')).writeAsStringSync('#real\n');
+    File(p.join(sdk.path, 'bin', 'internal')).writeAsStringSync('x\n');
+    File(p.join(sdk.path, 'pubspec.yaml')).writeAsStringSync('name: x\n');
+    project = Directory(p.join(tmp.path, 'project'))..createSync();
+  });
+  tearDown(() => tmp.deleteSync(recursive: true));
+
+  test('installMirror builds a facade: real bin/, symlinked entries, shims',
+      () {
+    final mirror = installMirror(
+      sharedSdk: sdk,
+      projectRoot: project,
+      wrapExe: '/cache/wrap',
+    );
+    expect(mirror.path, p.join(project.path, 'flutterware', 'sdk'));
+
+    // Top-level non-bin entries are symlinks to the shared SDK.
+    expect(FileSystemEntity.isLinkSync(p.join(mirror.path, 'pubspec.yaml')),
+        isTrue);
+    // bin/ is a real directory.
+    expect(
+        FileSystemEntity.isDirectorySync(p.join(mirror.path, 'bin')), isTrue);
+    expect(FileSystemEntity.isLinkSync(p.join(mirror.path, 'bin')), isFalse);
+    // bin/cache and bin/internal are symlinks.
+    expect(FileSystemEntity.isLinkSync(p.join(mirror.path, 'bin', 'cache')),
+        isTrue);
+    // bin/flutter and bin/dart are real shim files, not symlinks.
+    final flutterShim = File(p.join(mirror.path, 'bin', 'flutter'));
+    expect(FileSystemEntity.isLinkSync(flutterShim.path), isFalse);
+    expect(flutterShim.readAsStringSync(), contains('KIND="flutter"'));
+    expect(File(p.join(mirror.path, 'bin', 'dart')).readAsStringSync(),
+        contains('KIND="dart"'));
+  });
+
+  test('installMirror is idempotent — re-running rebuilds cleanly', () {
+    installMirror(sharedSdk: sdk, projectRoot: project, wrapExe: '/c/wrap');
+    final mirror =
+        installMirror(sharedSdk: sdk, projectRoot: project, wrapExe: '/c/wrap');
+    expect(File(p.join(mirror.path, 'bin', 'flutter')).existsSync(), isTrue);
+  });
+}

--- a/app/test/wrap/installer_test.dart
+++ b/app/test/wrap/installer_test.dart
@@ -12,7 +12,7 @@ void main() {
     tmp = Directory.systemTemp.createTempSync('wrap_inst');
     // A fake "shared SDK".
     sdk = Directory(p.join(tmp.path, 'sharedsdk'))..createSync();
-    Directory(p.join(sdk.path, 'bin'))..createSync();
+    Directory(p.join(sdk.path, 'bin')).createSync();
     Directory(p.join(sdk.path, 'bin', 'cache')).createSync();
     File(p.join(sdk.path, 'bin', 'flutter')).writeAsStringSync('#real\n');
     File(p.join(sdk.path, 'bin', 'dart')).writeAsStringSync('#real\n');

--- a/app/test/wrap/project_resolution_test.dart
+++ b/app/test/wrap/project_resolution_test.dart
@@ -1,0 +1,38 @@
+import 'dart:io';
+import 'package:flutterware_app/src/wrap/project_resolution.dart';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+void main() {
+  late Directory tmp;
+  setUp(() => tmp = Directory.systemTemp.createTempSync('wrap_proj'));
+  tearDown(() => tmp.deleteSync(recursive: true));
+
+  test('findProjectRoot walks up to the flutter_version marker', () {
+    File(p.join(tmp.path, 'flutter_version')).writeAsStringSync('3.44.0\n');
+    final nested = Directory(p.join(tmp.path, 'a', 'b'))
+      ..createSync(recursive: true);
+    final root = findProjectRoot(nested);
+    expect(root?.resolveSymbolicLinksSync(),
+        equals(tmp.resolveSymbolicLinksSync()));
+  });
+
+  test('findProjectRoot returns null when there is no marker', () {
+    final nested = Directory(p.join(tmp.path, 'a'))..createSync();
+    expect(findProjectRoot(nested), isNull);
+  });
+
+  test('resolveWorktreeName reads the gitdir pointer from a .git file', () {
+    File(p.join(tmp.path, 'flutter_version')).writeAsStringSync('3.44.0\n');
+    File(p.join(tmp.path, '.git'))
+        .writeAsStringSync('gitdir: /repo/.git/worktrees/feature-x\n');
+    expect(resolveWorktreeName(tmp), equals('feature-x'));
+  });
+
+  test('resolveWorktreeName falls back to the dir name for a main checkout',
+      () {
+    File(p.join(tmp.path, 'flutter_version')).writeAsStringSync('3.44.0\n');
+    Directory(p.join(tmp.path, '.git')).createSync();
+    expect(resolveWorktreeName(tmp), equals(p.basename(tmp.path)));
+  });
+}

--- a/app/test/wrap/project_resolution_test.dart
+++ b/app/test/wrap/project_resolution_test.dart
@@ -35,4 +35,22 @@ void main() {
     Directory(p.join(tmp.path, '.git')).createSync();
     expect(resolveWorktreeName(tmp), equals(p.basename(tmp.path)));
   });
+
+  test('resolveProject returns a ProjectContext for a nested directory', () {
+    File(p.join(tmp.path, 'flutter_version')).writeAsStringSync('3.44.0\n');
+    Directory(p.join(tmp.path, '.git')).createSync();
+    final nested = Directory(p.join(tmp.path, 'sub'))..createSync();
+    final ctx = resolveProject(nested);
+    expect(ctx, isNotNull);
+    expect(ctx!.projectRoot.resolveSymbolicLinksSync(),
+        equals(tmp.resolveSymbolicLinksSync()));
+    expect(ctx.worktreeName, equals(p.basename(tmp.path)));
+  });
+
+  test(
+      'resolveProject returns null when start is not inside a flutterware project',
+      () {
+    final isolated = Directory(p.join(tmp.path, 'no_marker'))..createSync();
+    expect(resolveProject(isolated), isNull);
+  });
 }

--- a/app/test/wrap/run_command_test.dart
+++ b/app/test/wrap/run_command_test.dart
@@ -84,4 +84,27 @@ void main() {
     expect(result.exitCode, 0);
     expect(result.stdout.toString(), contains('still-runs'));
   }, timeout: const Timeout(Duration(minutes: 2)));
+
+  test('degrade with an unrunnable real binary exits non-zero, no crash',
+      () async {
+    final outside = Directory.systemTemp.createTempSync('wrap_badbin');
+    addTearDown(() => outside.deleteSync(recursive: true));
+    final result = await Process.run(
+      dart,
+      [
+        'run',
+        wrapScript,
+        'run',
+        '--real',
+        '/no/such/binary_xyz',
+        '--kind',
+        'flutter',
+        '--',
+        'run',
+      ],
+      workingDirectory: outside.path,
+    );
+    expect(result.exitCode, isNot(0));
+    expect(result.exitCode, isNot(255));
+  }, timeout: const Timeout(Duration(minutes: 2)));
 }

--- a/app/test/wrap/run_command_test.dart
+++ b/app/test/wrap/run_command_test.dart
@@ -1,0 +1,87 @@
+import 'dart:io';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+/// Locate the `dart` executable (see passthrough_command_test for why).
+String _resolveDart() {
+  if (Platform.resolvedExecutable.endsWith('/dart')) {
+    return Platform.resolvedExecutable;
+  }
+  final r = Process.runSync('/usr/bin/which', ['dart']);
+  if (r.exitCode == 0 && (r.stdout as String).trim().isNotEmpty) {
+    return (r.stdout as String).trim();
+  }
+  throw StateError('Could not locate dart');
+}
+
+void main() {
+  final dart = _resolveDart();
+  // Use absolute path so `dart run` finds the script regardless of the
+  // workingDirectory we set on the test process.
+  final wrapScript = p.join(Directory.current.path, 'bin', 'wrap.dart');
+  late Directory project;
+
+  setUp(() {
+    project = Directory.systemTemp.createTempSync('wrap_run');
+    File(p.join(project.path, 'flutter_version')).writeAsStringSync('3.44.0\n');
+    Directory(p.join(project.path, '.git')).createSync();
+  });
+  tearDown(() => project.deleteSync(recursive: true));
+
+  test('interesting run is captured into a session dir with meta', () async {
+    final result = await Process.run(
+      dart,
+      [
+        'run',
+        wrapScript,
+        'run',
+        '--real',
+        '/bin/echo',
+        '--kind',
+        'flutter',
+        '--',
+        'run',
+        'captured-payload',
+      ],
+      workingDirectory: project.path,
+    );
+    expect(result.exitCode, 0);
+    final sessions = Directory(
+      p.join(project.path, '.flutterware', 'sessions'),
+    );
+    expect(sessions.existsSync(), isTrue);
+    final dirs = sessions.listSync().whereType<Directory>().toList();
+    expect(dirs, hasLength(1));
+    final out = File(p.join(dirs.single.path, 'output.log')).readAsStringSync();
+    expect(out, contains('captured-payload'));
+    expect(out, contains('--dart-define=FW_MARKER='));
+    expect(
+      File(p.join(dirs.single.path, 'meta.json')).existsSync(),
+      isTrue,
+    );
+  }, timeout: const Timeout(Duration(minutes: 2)));
+
+  test('degrades to a plain run when not inside a flutterware project',
+      () async {
+    final outside = Directory.systemTemp.createTempSync('wrap_outside');
+    addTearDown(() => outside.deleteSync(recursive: true));
+    final result = await Process.run(
+      dart,
+      [
+        'run',
+        wrapScript,
+        'run',
+        '--real',
+        '/bin/echo',
+        '--kind',
+        'flutter',
+        '--',
+        'run',
+        'still-runs',
+      ],
+      workingDirectory: outside.path,
+    );
+    expect(result.exitCode, 0);
+    expect(result.stdout.toString(), contains('still-runs'));
+  }, timeout: const Timeout(Duration(minutes: 2)));
+}

--- a/app/test/wrap/session_sink_test.dart
+++ b/app/test/wrap/session_sink_test.dart
@@ -27,7 +27,8 @@ void main() {
 
     final dir = p.join(tmp.path, 'sessions', 'sess-1');
     expect(File(p.join(dir, 'output.log')).readAsStringSync(), 'hello');
-    final meta = jsonDecode(File(p.join(dir, 'meta.json')).readAsStringSync());
+    final meta = jsonDecode(File(p.join(dir, 'meta.json')).readAsStringSync())
+        as Map<String, Object?>;
     expect(meta['exitCode'], 0);
     expect(meta['worktree'], 'main');
   });

--- a/app/test/wrap/session_sink_test.dart
+++ b/app/test/wrap/session_sink_test.dart
@@ -1,0 +1,34 @@
+import 'dart:convert';
+import 'dart:io';
+import 'package:flutterware_app/src/wrap/session_sink.dart';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+void main() {
+  late Directory tmp;
+  setUp(() => tmp = Directory.systemTemp.createTempSync('wrap_sink'));
+  tearDown(() => tmp.deleteSync(recursive: true));
+
+  test('newSessionId yields a non-empty filesystem-safe id', () {
+    final id = newSessionId();
+    expect(id, isNotEmpty);
+    expect(id, isNot(contains('/')));
+    expect(id, isNot(contains(':')));
+  });
+
+  test('SessionSink creates a per-session dir and writes output + meta',
+      () async {
+    final sink = SessionSink(tmp, 'sess-1');
+    final out = sink.openOutput();
+    out.add('hello'.codeUnits);
+    await out.flush();
+    await out.close();
+    sink.writeMeta({'exitCode': 0, 'worktree': 'main'});
+
+    final dir = p.join(tmp.path, 'sessions', 'sess-1');
+    expect(File(p.join(dir, 'output.log')).readAsStringSync(), 'hello');
+    final meta = jsonDecode(File(p.join(dir, 'meta.json')).readAsStringSync());
+    expect(meta['exitCode'], 0);
+    expect(meta['worktree'], 'main');
+  });
+}

--- a/app/test/wrap/shim_integration_test.dart
+++ b/app/test/wrap/shim_integration_test.dart
@@ -1,0 +1,82 @@
+import 'dart:io';
+import 'package:flutterware_app/src/wrap/shim_template.dart';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+void main() {
+  late Directory tmp;
+  late File shim;
+  late File realMarker;
+  late File wrapMarker;
+
+  setUp(() {
+    tmp = Directory.systemTemp.createTempSync('wrap_shim');
+    // A "real binary" double that records it was called and echoes argv.
+    realMarker = File(p.join(tmp.path, 'real.called'));
+    final fakeReal = File(p.join(tmp.path, 'fake_real'))
+      ..writeAsStringSync('#!/usr/bin/env bash\necho "real:'
+          r'$*'
+          '" >>"${realMarker.path}"\n');
+    Process.runSync('chmod', ['+x', fakeReal.path]);
+    // A "wrap exe" double — note it must accept the `run ... -- ...` argv.
+    wrapMarker = File(p.join(tmp.path, 'wrap.called'));
+    final fakeWrap = File(p.join(tmp.path, 'fake_wrap'))
+      ..writeAsStringSync('#!/usr/bin/env bash\necho "wrap:'
+          r'$*'
+          '" >>"${wrapMarker.path}"\n');
+    Process.runSync('chmod', ['+x', fakeWrap.path]);
+
+    shim = File(p.join(tmp.path, 'flutter'))
+      ..writeAsStringSync(renderShim(
+        realBinary: fakeReal.path,
+        kind: 'flutter',
+        wrapExe: fakeWrap.path,
+      ));
+    Process.runSync('chmod', ['+x', shim.path]);
+  });
+  tearDown(() => tmp.deleteSync(recursive: true));
+
+  ProcessResult invoke(List<String> args, {required Directory cwd}) =>
+      Process.runSync(shim.path, args, workingDirectory: cwd.path);
+
+  test('no marker -> straight to the real binary, no audit log', () {
+    final cwd = Directory(p.join(tmp.path, 'plain'))..createSync();
+    invoke(['run'], cwd: cwd);
+    expect(realMarker.existsSync(), isTrue);
+    expect(wrapMarker.existsSync(), isFalse);
+  });
+
+  test('interesting run (flutter run) is dispatched to the wrap exe', () {
+    final proj = Directory(p.join(tmp.path, 'proj'))..createSync();
+    File(p.join(proj.path, 'flutter_version')).writeAsStringSync('3.44.0\n');
+    invoke(['--no-color', 'run', '--machine'], cwd: proj);
+    expect(wrapMarker.existsSync(), isTrue);
+    expect(wrapMarker.readAsStringSync(), contains('run --real'));
+    final audit = File(p.join(proj.path, '.flutterware', 'wrap-audit.log'));
+    expect(audit.readAsStringSync(), contains('interesting'));
+  });
+
+  test('noise (flutter pub get) goes to the real binary, audited as noise', () {
+    final proj = Directory(p.join(tmp.path, 'proj2'))..createSync();
+    File(p.join(proj.path, 'flutter_version')).writeAsStringSync('3.44.0\n');
+    invoke(['pub', 'get'], cwd: proj);
+    expect(realMarker.existsSync(), isTrue);
+    expect(wrapMarker.existsSync(), isFalse);
+    final audit = File(p.join(proj.path, '.flutterware', 'wrap-audit.log'));
+    expect(audit.readAsStringSync(), contains('noise'));
+  });
+
+  test('interesting run degrades to real when the wrap exe is missing', () {
+    final proj = Directory(p.join(tmp.path, 'proj3'))..createSync();
+    File(p.join(proj.path, 'flutter_version')).writeAsStringSync('3.44.0\n');
+    // Re-render the shim pointing at a non-existent wrap exe.
+    shim.writeAsStringSync(renderShim(
+      realBinary: File(p.join(tmp.path, 'fake_real')).path,
+      kind: 'flutter',
+      wrapExe: '/no/such/wrap_exe',
+    ));
+    Process.runSync('chmod', ['+x', shim.path]);
+    invoke(['run'], cwd: proj);
+    expect(realMarker.existsSync(), isTrue);
+  });
+}

--- a/app/test/wrap/shim_template_test.dart
+++ b/app/test/wrap/shim_template_test.dart
@@ -1,0 +1,20 @@
+import 'package:flutterware_app/src/wrap/shim_template.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('renderShim bakes in the real binary, kind, and wrap exe', () {
+    final shim = renderShim(
+      realBinary: '/sdk/bin/flutter',
+      kind: 'flutter',
+      wrapExe: '/cache/wrap',
+    );
+    expect(shim, startsWith('#!/usr/bin/env bash'));
+    expect(shim, contains('REAL="/sdk/bin/flutter"'));
+    expect(shim, contains('KIND="flutter"'));
+    expect(shim, contains('WRAP_EXE="/cache/wrap"'));
+    // The marker walk-up and classification must be present.
+    expect(shim, contains('flutter_version'));
+    expect(shim, contains('run|test'));
+    expect(shim, contains('wrap-audit.log'));
+  });
+}

--- a/app/test/wrap/transport_test.dart
+++ b/app/test/wrap/transport_test.dart
@@ -1,0 +1,37 @@
+import 'dart:io';
+import 'package:flutterware_app/src/wrap/transport.dart';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+void main() {
+  late Directory tmp;
+  setUp(() => tmp = Directory.systemTemp.createTempSync('wrap_tx'));
+  tearDown(() => tmp.deleteSync(recursive: true));
+
+  test('runIntercepted captures child output and returns its exit code',
+      () async {
+    final file = File(p.join(tmp.path, 'cap.log'));
+    final sink = file.openWrite();
+    final code = await runIntercepted(
+      executable: '/bin/echo',
+      arguments: const ['hello-wrap-transport'],
+      captureSink: sink,
+    );
+    await sink.flush();
+    await sink.close();
+    expect(code, 0);
+    expect(file.readAsStringSync(), contains('hello-wrap-transport'));
+  }, timeout: const Timeout(Duration(minutes: 1)));
+
+  test('runIntercepted propagates a non-zero exit code', () async {
+    final sink = File(p.join(tmp.path, 'c2.log')).openWrite();
+    final code = await runIntercepted(
+      executable: '/bin/bash',
+      arguments: const ['-c', 'exit 7'],
+      captureSink: sink,
+    );
+    await sink.flush();
+    await sink.close();
+    expect(code, 7);
+  }, timeout: const Timeout(Duration(minutes: 1)));
+}

--- a/app/test/wrap/transport_test.dart
+++ b/app/test/wrap/transport_test.dart
@@ -34,4 +34,18 @@ void main() {
     await sink.close();
     expect(code, 7);
   }, timeout: const Timeout(Duration(minutes: 1)));
+
+  test('runIntercepted captures stderr into the sink', () async {
+    final file = File(p.join(tmp.path, 'cap-stderr.log'));
+    final sink = file.openWrite();
+    final code = await runIntercepted(
+      executable: '/bin/bash',
+      arguments: const ['-c', 'echo to-stderr 1>&2'],
+      captureSink: sink,
+    );
+    await sink.flush();
+    await sink.close();
+    expect(code, 0);
+    expect(file.readAsStringSync(), contains('to-stderr'));
+  }, timeout: const Timeout(Duration(minutes: 1)));
 }

--- a/docs/superpowers/plans/2026-05-15-subproject-0-sdk-wrap-point.md
+++ b/docs/superpowers/plans/2026-05-15-subproject-0-sdk-wrap-point.md
@@ -1,0 +1,1359 @@
+# Sub-project 0 — SDK Wrap Point Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wrap the `flutter`/`dart` scripts an IDE invokes so every run is intercepted, classified, observed, and can have a `--dart-define` injected — degrading to plain passthrough on any failure.
+
+**Architecture:** A per-project SDK *mirror facade* (`<project>/flutterware/sdk/`) whose `bin/flutter`/`bin/dart` are bash shims and whose other entries symlink the pristine SDK. The shims do a cheap pure-bash fast path (marker walk-up, classify, audit-log); *interesting* runs hand off to a compiled Dart `flutterware wrap run` command that rewrites argv to inject a `--dart-define`, runs the real binary under a PTY (interactive) or pipe (`--machine`/IDE) transport, and captures output to a local sink.
+
+**Tech Stack:** Dart (the `flutterware_app` package), `package:args` CommandRunner, bash, the phase-1 `passthrough` PTY (`app/lib/src/passthrough/`).
+
+**Spec:** `docs/superpowers/specs/2026-05-15-subproject-0-sdk-wrap-point-design.md`
+**Finding:** `docs/superpowers/specs/2026-05-15-subproject-0-ide-launch-finding.md`
+
+---
+
+## File Structure
+
+Created under the `flutterware_app` package (`app/`):
+
+- `app/lib/src/wrap/dart_define.dart` — argv rewrite to inject a `--dart-define`.
+- `app/lib/src/wrap/project_resolution.dart` — project root + worktree identity.
+- `app/lib/src/wrap/session_sink.dart` — local observation sink.
+- `app/lib/src/wrap/transport.dart` — PTY vs pipe passthrough.
+- `app/lib/src/wrap/run_command.dart` — the `run` command (heavy-path orchestration).
+- `app/lib/src/wrap/shim_template.dart` — the bash shim as a string + renderer.
+- `app/lib/src/wrap/installer.dart` — builds the mirror facade.
+- `app/lib/src/wrap/install_command.dart` — the `install` command.
+- `app/bin/wrap.dart` — standalone CLI entry (`CommandRunner` with `run` + `install`).
+- `app/test/wrap/*_test.dart` — one test file per unit.
+- `examples/example/lib/main.dart` — modified: the probe widget.
+
+Modified:
+
+- `app/lib/src/passthrough/passthrough_command.dart` — `runUnderPty` gains an optional `captureSink`.
+
+---
+
+## Task 0: Setup
+
+**Files:** none.
+
+- [ ] **Step 1: Resolve workspace dependencies**
+
+Run: `dart tool/pub_get_all_projects.dart`
+Expected: completes without error (the pre-commit format hook needs resolved deps).
+
+- [ ] **Step 2: Confirm the wrap test directory**
+
+Run: `mkdir -p app/test/wrap && ls app/test/wrap`
+Expected: empty directory exists.
+
+---
+
+## Task 1: dart-define injection
+
+**Files:**
+- Create: `app/lib/src/wrap/dart_define.dart`
+- Test: `app/test/wrap/dart_define_test.dart`
+
+- [ ] **Step 1: Write the failing test**
+
+```dart
+import 'package:flutterware_app/src/wrap/dart_define.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('inserts the define immediately after the subcommand token', () {
+    final out = injectDartDefine(
+      ['--no-color', 'run', '--machine', 'lib/main.dart'],
+      key: 'FW_MARKER',
+      value: 'tok123',
+    );
+    expect(out, [
+      '--no-color',
+      'run',
+      '--dart-define=FW_MARKER=tok123',
+      '--machine',
+      'lib/main.dart',
+    ]);
+  });
+
+  test('appends the define when there is no non-flag token', () {
+    final out = injectDartDefine(['--version'], key: 'FW_MARKER', value: 't');
+    expect(out, ['--version', '--dart-define=FW_MARKER=t']);
+  });
+
+  test('handles a bare subcommand with no flags', () {
+    final out = injectDartDefine(['test'], key: 'K', value: 'v');
+    expect(out, ['test', '--dart-define=K=v']);
+  });
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd app && flutter test test/wrap/dart_define_test.dart`
+Expected: FAIL — `dart_define.dart` / `injectDartDefine` does not exist.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```dart
+/// Returns a copy of [args] with `--dart-define=<key>=<value>` inserted
+/// immediately after the subcommand token (the first non-flag argument,
+/// e.g. `run` in `flutter run`). If there is no non-flag token, the define
+/// is appended at the end.
+List<String> injectDartDefine(
+  List<String> args, {
+  required String key,
+  required String value,
+}) {
+  final define = '--dart-define=$key=$value';
+  final idx = args.indexWhere((a) => !a.startsWith('-'));
+  if (idx == -1) return [...args, define];
+  return [...args.sublist(0, idx + 1), define, ...args.sublist(idx + 1)];
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd app && flutter test test/wrap/dart_define_test.dart`
+Expected: PASS — 3 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/lib/src/wrap/dart_define.dart app/test/wrap/dart_define_test.dart
+git commit -m "Add dart-define argv injection for the SDK wrap point"
+```
+
+---
+
+## Task 2: Project & worktree resolution
+
+**Files:**
+- Create: `app/lib/src/wrap/project_resolution.dart`
+- Test: `app/test/wrap/project_resolution_test.dart`
+
+- [ ] **Step 1: Write the failing test**
+
+```dart
+import 'dart:io';
+import 'package:flutterware_app/src/wrap/project_resolution.dart';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+void main() {
+  late Directory tmp;
+  setUp(() => tmp = Directory.systemTemp.createTempSync('wrap_proj'));
+  tearDown(() => tmp.deleteSync(recursive: true));
+
+  test('findProjectRoot walks up to the flutter_version marker', () {
+    File(p.join(tmp.path, 'flutter_version')).writeAsStringSync('3.44.0\n');
+    final nested = Directory(p.join(tmp.path, 'a', 'b'))
+      ..createSync(recursive: true);
+    final root = findProjectRoot(nested);
+    expect(root?.resolveSymbolicLinksSync(),
+        equals(tmp.resolveSymbolicLinksSync()));
+  });
+
+  test('findProjectRoot returns null when there is no marker', () {
+    final nested = Directory(p.join(tmp.path, 'a'))..createSync();
+    expect(findProjectRoot(nested), isNull);
+  });
+
+  test('resolveWorktreeName reads the gitdir pointer from a .git file', () {
+    File(p.join(tmp.path, 'flutter_version')).writeAsStringSync('3.44.0\n');
+    File(p.join(tmp.path, '.git')).writeAsStringSync(
+        'gitdir: /repo/.git/worktrees/feature-x\n');
+    expect(resolveWorktreeName(tmp), equals('feature-x'));
+  });
+
+  test('resolveWorktreeName falls back to the dir name for a main checkout',
+      () {
+    File(p.join(tmp.path, 'flutter_version')).writeAsStringSync('3.44.0\n');
+    Directory(p.join(tmp.path, '.git')).createSync();
+    expect(resolveWorktreeName(tmp), equals(p.basename(tmp.path)));
+  });
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd app && flutter test test/wrap/project_resolution_test.dart`
+Expected: FAIL — `project_resolution.dart` does not exist.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```dart
+import 'dart:io';
+import 'package:path/path.dart' as p;
+
+/// A resolved flutterware project and the worktree the invocation is in.
+class ProjectContext {
+  final Directory projectRoot;
+  final String worktreeName;
+  ProjectContext(this.projectRoot, this.worktreeName);
+}
+
+/// Walks up from [start] looking for a `flutter_version` marker file.
+/// Returns the directory that contains it, or null if none is found.
+Directory? findProjectRoot(Directory start) {
+  var dir = start.absolute;
+  while (true) {
+    if (File(p.join(dir.path, 'flutter_version')).existsSync()) return dir;
+    final parent = dir.parent;
+    if (parent.path == dir.path) return null;
+    dir = parent;
+  }
+}
+
+/// Resolves the worktree name for [projectRoot]. A linked worktree has a
+/// `.git` *file* with a `gitdir:` pointer; the last path segment of that
+/// pointer is the worktree name. A main checkout has a `.git` *directory*.
+String resolveWorktreeName(Directory projectRoot) {
+  final gitPath = p.join(projectRoot.path, '.git');
+  if (FileSystemEntity.isDirectorySync(gitPath)) {
+    return p.basename(projectRoot.path);
+  }
+  final gitFile = File(gitPath);
+  if (gitFile.existsSync()) {
+    final content = gitFile.readAsStringSync().trim();
+    const prefix = 'gitdir:';
+    if (content.startsWith(prefix)) {
+      return p.basename(content.substring(prefix.length).trim());
+    }
+  }
+  return p.basename(projectRoot.path);
+}
+
+/// Resolves the [ProjectContext] for an invocation made from [start],
+/// or null if [start] is not inside a flutterware project.
+ProjectContext? resolveProject(Directory start) {
+  final root = findProjectRoot(start);
+  if (root == null) return null;
+  return ProjectContext(root, resolveWorktreeName(root));
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd app && flutter test test/wrap/project_resolution_test.dart`
+Expected: PASS — 4 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/lib/src/wrap/project_resolution.dart app/test/wrap/project_resolution_test.dart
+git commit -m "Add project root and worktree resolution for the SDK wrap point"
+```
+
+---
+
+## Task 3: Session sink
+
+**Files:**
+- Create: `app/lib/src/wrap/session_sink.dart`
+- Test: `app/test/wrap/session_sink_test.dart`
+
+- [ ] **Step 1: Write the failing test**
+
+```dart
+import 'dart:convert';
+import 'dart:io';
+import 'package:flutterware_app/src/wrap/session_sink.dart';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+void main() {
+  late Directory tmp;
+  setUp(() => tmp = Directory.systemTemp.createTempSync('wrap_sink'));
+  tearDown(() => tmp.deleteSync(recursive: true));
+
+  test('newSessionId yields a non-empty filesystem-safe id', () {
+    final id = newSessionId();
+    expect(id, isNotEmpty);
+    expect(id, isNot(contains('/')));
+    expect(id, isNot(contains(':')));
+  });
+
+  test('SessionSink creates a per-session dir and writes output + meta',
+      () async {
+    final sink = SessionSink(tmp, 'sess-1');
+    final out = sink.openOutput();
+    out.add('hello'.codeUnits);
+    await out.flush();
+    await out.close();
+    sink.writeMeta({'exitCode': 0, 'worktree': 'main'});
+
+    final dir = p.join(tmp.path, 'sessions', 'sess-1');
+    expect(File(p.join(dir, 'output.log')).readAsStringSync(), 'hello');
+    final meta = jsonDecode(File(p.join(dir, 'meta.json')).readAsStringSync());
+    expect(meta['exitCode'], 0);
+    expect(meta['worktree'], 'main');
+  });
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd app && flutter test test/wrap/session_sink_test.dart`
+Expected: FAIL — `session_sink.dart` does not exist.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```dart
+import 'dart:convert';
+import 'dart:io';
+import 'package:path/path.dart' as p;
+
+/// A filesystem-safe, reasonably unique id for one intercepted session.
+String newSessionId() {
+  final ts = DateTime.now()
+      .toIso8601String()
+      .replaceAll(RegExp(r'[:.]'), '-');
+  return '$ts-$pid';
+}
+
+/// The local, provisional observation sink for one interesting run.
+/// Lives at `<flutterwareDir>/sessions/<sessionId>/`. Sub-project 1
+/// replaces this with the daemon + SQLite DB.
+class SessionSink {
+  final Directory dir;
+
+  SessionSink(Directory flutterwareDir, String sessionId)
+      : dir = Directory(
+            p.join(flutterwareDir.path, 'sessions', sessionId)) {
+    dir.createSync(recursive: true);
+  }
+
+  /// Opens the captured-output file for streaming writes.
+  IOSink openOutput() => File(p.join(dir.path, 'output.log')).openWrite();
+
+  /// Writes the session metadata as pretty-printed JSON.
+  void writeMeta(Map<String, Object?> meta) {
+    File(p.join(dir.path, 'meta.json'))
+        .writeAsStringSync(const JsonEncoder.withIndent('  ').convert(meta));
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd app && flutter test test/wrap/session_sink_test.dart`
+Expected: PASS — 2 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/lib/src/wrap/session_sink.dart app/test/wrap/session_sink_test.dart
+git commit -m "Add local session sink for the SDK wrap point"
+```
+
+---
+
+## Task 4: Transport (PTY + pipe passthrough)
+
+**Files:**
+- Modify: `app/lib/src/passthrough/passthrough_command.dart` (`runUnderPty` gains `captureSink`)
+- Create: `app/lib/src/wrap/transport.dart`
+- Test: `app/test/wrap/transport_test.dart`
+
+- [ ] **Step 1: Add a capture sink to `runUnderPty`**
+
+In `app/lib/src/passthrough/passthrough_command.dart`, add a parameter to
+`runUnderPty` and fan PTY output into it. Change the signature:
+
+```dart
+Future<int> runUnderPty({
+  required String executable,
+  required List<String> arguments,
+  String? workingDirectory,
+  bool printSummary = true,
+  IOSink? captureSink,
+}) async {
+```
+
+and change the `TeeSink` construction from `TeeSink(onBytes: stdout.add)` to:
+
+```dart
+    tee = TeeSink(onBytes: (chunk) {
+      stdout.add(chunk);
+      captureSink?.add(chunk);
+    });
+```
+
+- [ ] **Step 2: Write the failing test**
+
+```dart
+import 'dart:io';
+import 'package:flutterware_app/src/wrap/transport.dart';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+void main() {
+  late Directory tmp;
+  setUp(() => tmp = Directory.systemTemp.createTempSync('wrap_tx'));
+  tearDown(() => tmp.deleteSync(recursive: true));
+
+  test('runIntercepted captures child output and returns its exit code',
+      () async {
+    final file = File(p.join(tmp.path, 'cap.log'));
+    final sink = file.openWrite();
+    final code = await runIntercepted(
+      executable: '/bin/echo',
+      arguments: const ['hello-wrap-transport'],
+      captureSink: sink,
+    );
+    await sink.flush();
+    await sink.close();
+    expect(code, 0);
+    expect(file.readAsStringSync(), contains('hello-wrap-transport'));
+  }, timeout: const Timeout(Duration(minutes: 1)));
+
+  test('runIntercepted propagates a non-zero exit code', () async {
+    final sink = File(p.join(tmp.path, 'c2.log')).openWrite();
+    final code = await runIntercepted(
+      executable: '/bin/bash',
+      arguments: const ['-c', 'exit 7'],
+      captureSink: sink,
+    );
+    await sink.flush();
+    await sink.close();
+    expect(code, 7);
+  }, timeout: const Timeout(Duration(minutes: 1)));
+}
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `cd app && flutter test test/wrap/transport_test.dart`
+Expected: FAIL — `transport.dart` does not exist.
+
+- [ ] **Step 4: Write minimal implementation**
+
+```dart
+import 'dart:async';
+import 'dart:io';
+
+import '../passthrough/passthrough_command.dart';
+
+/// Runs [executable] with [arguments], streaming I/O to the parent and
+/// teeing all output into [captureSink].
+///
+/// Uses a PTY when the parent stdin is a terminal (an interactive CLI run),
+/// and plain pipes otherwise (an IDE / `--machine` run, whose stdin/stdout
+/// carry the daemon JSON-RPC protocol). Neither mode parses the stream.
+Future<int> runIntercepted({
+  required String executable,
+  required List<String> arguments,
+  required IOSink captureSink,
+  String? workingDirectory,
+}) async {
+  if (stdin.hasTerminal) {
+    return runUnderPty(
+      executable: executable,
+      arguments: arguments,
+      workingDirectory: workingDirectory,
+      printSummary: false,
+      captureSink: captureSink,
+    );
+  }
+  return _runPiped(
+    executable: executable,
+    arguments: arguments,
+    workingDirectory: workingDirectory,
+    captureSink: captureSink,
+  );
+}
+
+Future<int> _runPiped({
+  required String executable,
+  required List<String> arguments,
+  required IOSink captureSink,
+  String? workingDirectory,
+}) async {
+  final proc = await Process.start(
+    executable,
+    arguments,
+    workingDirectory: workingDirectory,
+  );
+
+  final stdinSub = stdin.listen(
+    proc.stdin.add,
+    onDone: () => proc.stdin.close().catchError((_) {}),
+    onError: (_) {},
+  );
+
+  final outDone = Completer<void>();
+  final errDone = Completer<void>();
+  proc.stdout.listen(
+    (chunk) {
+      stdout.add(chunk);
+      captureSink.add(chunk);
+    },
+    onDone: outDone.complete,
+  );
+  proc.stderr.listen(
+    (chunk) {
+      stderr.add(chunk);
+      captureSink.add(chunk);
+    },
+    onDone: errDone.complete,
+  );
+
+  final code = await proc.exitCode;
+  await outDone.future;
+  await errDone.future;
+  await stdinSub.cancel();
+  return code;
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd app && flutter test test/wrap/transport_test.dart test/passthrough/passthrough_command_test.dart`
+Expected: PASS — transport tests pass and the existing passthrough tests still pass (the `captureSink` change is backward compatible).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/lib/src/wrap/transport.dart app/lib/src/passthrough/passthrough_command.dart app/test/wrap/transport_test.dart
+git commit -m "Add PTY/pipe transport for intercepted runs"
+```
+
+---
+
+## Task 5: The `run` command + CLI entry
+
+**Files:**
+- Create: `app/lib/src/wrap/run_command.dart`
+- Create: `app/bin/wrap.dart`
+- Test: `app/test/wrap/run_command_test.dart`
+
+- [ ] **Step 1: Write the failing test**
+
+```dart
+import 'dart:io';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+/// Locate the `dart` executable (see passthrough_command_test for why).
+String _resolveDart() {
+  if (Platform.resolvedExecutable.endsWith('/dart')) {
+    return Platform.resolvedExecutable;
+  }
+  final r = Process.runSync('/usr/bin/which', ['dart']);
+  if (r.exitCode == 0 && (r.stdout as String).trim().isNotEmpty) {
+    return (r.stdout as String).trim();
+  }
+  throw StateError('Could not locate dart');
+}
+
+void main() {
+  final dart = _resolveDart();
+  late Directory project;
+
+  setUp(() {
+    project = Directory.systemTemp.createTempSync('wrap_run');
+    File(p.join(project.path, 'flutter_version')).writeAsStringSync('3.44.0\n');
+    Directory(p.join(project.path, '.git')).createSync();
+  });
+  tearDown(() => project.deleteSync(recursive: true));
+
+  test('interesting run is captured into a session dir with meta', () async {
+    final result = await Process.run(
+      dart,
+      [
+        'run', 'bin/wrap.dart', 'run',
+        '--real', '/bin/echo', '--kind', 'flutter',
+        '--', 'run', 'captured-payload',
+      ],
+      workingDirectory: project.path,
+    );
+    expect(result.exitCode, 0);
+    final sessions = Directory(p.join(project.path, '.flutterware', 'sessions'));
+    expect(sessions.existsSync(), isTrue);
+    final dirs = sessions.listSync().whereType<Directory>().toList();
+    expect(dirs, hasLength(1));
+    final out = File(p.join(dirs.single.path, 'output.log')).readAsStringSync();
+    expect(out, contains('captured-payload'));
+    expect(out, contains('--dart-define=FW_MARKER='));
+    expect(File(p.join(dirs.single.path, 'meta.json')).existsSync(), isTrue);
+  }, timeout: const Timeout(Duration(minutes: 2)));
+
+  test('degrades to a plain run when not inside a flutterware project',
+      () async {
+    final outside = Directory.systemTemp.createTempSync('wrap_outside');
+    addTearDown(() => outside.deleteSync(recursive: true));
+    final result = await Process.run(
+      dart,
+      [
+        'run', 'bin/wrap.dart', 'run',
+        '--real', '/bin/echo', '--kind', 'flutter',
+        '--', 'run', 'still-runs',
+      ],
+      workingDirectory: outside.path,
+    );
+    expect(result.exitCode, 0);
+    expect(result.stdout.toString(), contains('still-runs'));
+  }, timeout: const Timeout(Duration(minutes: 2)));
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd app && flutter test test/wrap/run_command_test.dart`
+Expected: FAIL — `bin/wrap.dart` does not exist.
+
+- [ ] **Step 3: Write the `run` command**
+
+Create `app/lib/src/wrap/run_command.dart`:
+
+```dart
+import 'dart:io';
+
+import 'package:args/command_runner.dart';
+
+import 'dart_define.dart';
+import 'project_resolution.dart';
+import 'session_sink.dart';
+import 'transport.dart';
+
+/// Heavy-path command for an *interesting* intercepted run.
+///
+/// Invoked by the generated bash shim as:
+///   wrap run --real <binary> --kind <flutter|dart> -- <original args...>
+///
+/// Rewrites argv to inject `--dart-define=FW_MARKER=<token>`, runs the real
+/// binary under the transport, and captures output to a local session sink.
+/// Any failure degrades to a plain run of the real binary.
+class RunCommand extends Command<int> {
+  @override
+  final name = 'run';
+  @override
+  final description = 'Run an intercepted flutter/dart invocation.';
+
+  RunCommand() {
+    argParser
+      ..addOption('real', help: 'Absolute path to the real binary.')
+      ..addOption('kind', help: 'flutter or dart.');
+  }
+
+  @override
+  Future<int> run() async {
+    final real = argResults!['real'] as String?;
+    final original = argResults!.rest;
+    if (real == null || real.isEmpty) {
+      stderr.writeln('[wrap] missing --real');
+      return 64;
+    }
+    try {
+      final ctx = resolveProject(Directory.current);
+      if (ctx == null) return _degrade(real, original);
+
+      final token = newSessionId();
+      final injected =
+          injectDartDefine(original, key: 'FW_MARKER', value: token);
+
+      final flutterwareDir =
+          Directory('${ctx.projectRoot.path}/.flutterware');
+      final sink = SessionSink(flutterwareDir, token);
+      final out = sink.openOutput();
+
+      final code = await runIntercepted(
+        executable: real,
+        arguments: injected,
+        captureSink: out,
+      );
+
+      await out.flush();
+      await out.close();
+      sink.writeMeta({
+        'sessionId': token,
+        'worktree': ctx.worktreeName,
+        'kind': argResults!['kind'],
+        'argvOriginal': original,
+        'argvInjected': injected,
+        'marker': token,
+        'exitCode': code,
+      });
+      return code;
+    } catch (e) {
+      stderr.writeln('[wrap] degraded to plain run: $e');
+      return _degrade(real, original);
+    }
+  }
+
+  /// Plain spawn of the real binary with the original argv — the guiding
+  /// principle: the user's command always runs.
+  Future<int> _degrade(String real, List<String> original) async {
+    final proc = await Process.start(
+      real,
+      original,
+      mode: ProcessStartMode.inheritStdio,
+    );
+    return proc.exitCode;
+  }
+}
+```
+
+- [ ] **Step 4: Write the CLI entry**
+
+Create `app/bin/wrap.dart`:
+
+```dart
+import 'dart:io';
+
+import 'package:args/command_runner.dart';
+import 'package:flutterware_app/src/wrap/run_command.dart';
+
+Future<void> main(List<String> args) async {
+  final runner = CommandRunner<int>(
+    'wrap',
+    'flutterware SDK wrap point.',
+  )..addCommand(RunCommand());
+  try {
+    final code = await runner.run(args) ?? 0;
+    exit(code);
+  } on UsageException catch (e) {
+    stderr.writeln(e);
+    exit(64);
+  }
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd app && flutter test test/wrap/run_command_test.dart`
+Expected: PASS — 2 tests. The first writes a session dir whose `output.log`
+contains both the payload and the injected `--dart-define=FW_MARKER=` (because
+the fake real binary is `/bin/echo`, which echoes its rewritten argv).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/lib/src/wrap/run_command.dart app/bin/wrap.dart app/test/wrap/run_command_test.dart
+git commit -m "Add the wrap run command and CLI entry"
+```
+
+---
+
+## Task 6: Shim template + renderer
+
+**Files:**
+- Create: `app/lib/src/wrap/shim_template.dart`
+- Test: `app/test/wrap/shim_template_test.dart`
+
+- [ ] **Step 1: Write the failing test**
+
+```dart
+import 'package:flutterware_app/src/wrap/shim_template.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('renderShim bakes in the real binary, kind, and wrap exe', () {
+    final shim = renderShim(
+      realBinary: '/sdk/bin/flutter',
+      kind: 'flutter',
+      wrapExe: '/cache/wrap',
+    );
+    expect(shim, startsWith('#!/usr/bin/env bash'));
+    expect(shim, contains('REAL="/sdk/bin/flutter"'));
+    expect(shim, contains('KIND="flutter"'));
+    expect(shim, contains('WRAP_EXE="/cache/wrap"'));
+    // The marker walk-up and classification must be present.
+    expect(shim, contains('flutter_version'));
+    expect(shim, contains('run|test'));
+    expect(shim, contains('wrap-audit.log'));
+  });
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd app && flutter test test/wrap/shim_template_test.dart`
+Expected: FAIL — `shim_template.dart` does not exist.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```dart
+/// The bash shim installed as `<mirror>/bin/flutter` and `<mirror>/bin/dart`.
+/// `@REAL@`, `@KIND@`, `@WRAP_EXE@` are replaced at install time.
+///
+/// Fast path is pure bash: marker walk-up, classification, one audit-log
+/// line. Only *interesting* runs hand off to the compiled wrap executable.
+const _shimTemplate = r'''#!/usr/bin/env bash
+# flutterware wrap shim — generated; do not edit.
+set -u
+REAL="@REAL@"
+KIND="@KIND@"
+WRAP_EXE="@WRAP_EXE@"
+
+# 1. Walk up for the flutter_version marker.
+root=""
+d="$PWD"
+while :; do
+  if [ -f "$d/flutter_version" ]; then root="$d"; break; fi
+  [ "$d" = "/" ] && break
+  d="$(dirname "$d")"
+done
+[ -z "$root" ] && exec "$REAL" "$@"
+
+# 2. First non-flag argument (the subcommand).
+sub=""
+for a in "$@"; do
+  case "$a" in
+    -*) ;;
+    *) sub="$a"; break ;;
+  esac
+done
+
+# 3. Classify (probe default — replaced by config.dart in sub-project 3).
+cls="noise"
+if [ "$KIND" = "flutter" ]; then
+  case "$sub" in
+    run|test) cls="interesting" ;;
+  esac
+fi
+
+# 4. Audit log — one line per invocation, every kind.
+fwdir="$root/.flutterware"
+mkdir -p "$fwdir" 2>/dev/null || true
+printf '%s\t%s\t%s\t%s\t%s %s\n' \
+  "$(date +%Y-%m-%dT%H:%M:%S)" "$PWD" "$KIND" "$cls" "$KIND" "$*" \
+  >>"$fwdir/wrap-audit.log" 2>/dev/null || true
+
+# 5. Dispatch. Interesting -> the wrap exe; anything else / missing exe -> real.
+if [ "$cls" = "interesting" ] && [ -x "$WRAP_EXE" ]; then
+  exec "$WRAP_EXE" run --real "$REAL" --kind "$KIND" -- "$@"
+fi
+exec "$REAL" "$@"
+''';
+
+/// Renders the shim with the given absolute paths baked in.
+String renderShim({
+  required String realBinary,
+  required String kind,
+  required String wrapExe,
+}) =>
+    _shimTemplate
+        .replaceAll('@REAL@', realBinary)
+        .replaceAll('@KIND@', kind)
+        .replaceAll('@WRAP_EXE@', wrapExe);
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd app && flutter test test/wrap/shim_template_test.dart`
+Expected: PASS — 1 test.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/lib/src/wrap/shim_template.dart app/test/wrap/shim_template_test.dart
+git commit -m "Add the bash wrap shim template and renderer"
+```
+
+---
+
+## Task 7: Installer + `install` command
+
+**Files:**
+- Create: `app/lib/src/wrap/installer.dart`
+- Create: `app/lib/src/wrap/install_command.dart`
+- Modify: `app/bin/wrap.dart` (register `InstallCommand`)
+- Test: `app/test/wrap/installer_test.dart`
+
+- [ ] **Step 1: Write the failing test**
+
+```dart
+import 'dart:io';
+import 'package:flutterware_app/src/wrap/installer.dart';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+void main() {
+  late Directory tmp;
+  late Directory sdk;
+  late Directory project;
+
+  setUp(() {
+    tmp = Directory.systemTemp.createTempSync('wrap_inst');
+    // A fake "shared SDK".
+    sdk = Directory(p.join(tmp.path, 'sharedsdk'))..createSync();
+    Directory(p.join(sdk.path, 'bin'))..createSync();
+    Directory(p.join(sdk.path, 'bin', 'cache')).createSync();
+    File(p.join(sdk.path, 'bin', 'flutter')).writeAsStringSync('#real\n');
+    File(p.join(sdk.path, 'bin', 'dart')).writeAsStringSync('#real\n');
+    File(p.join(sdk.path, 'bin', 'internal')).writeAsStringSync('x\n');
+    File(p.join(sdk.path, 'pubspec.yaml')).writeAsStringSync('name: x\n');
+    project = Directory(p.join(tmp.path, 'project'))..createSync();
+  });
+  tearDown(() => tmp.deleteSync(recursive: true));
+
+  test('installMirror builds a facade: real bin/, symlinked entries, shims',
+      () {
+    final mirror = installMirror(
+      sharedSdk: sdk,
+      projectRoot: project,
+      wrapExe: '/cache/wrap',
+    );
+    expect(mirror.path, p.join(project.path, 'flutterware', 'sdk'));
+
+    // Top-level non-bin entries are symlinks to the shared SDK.
+    expect(FileSystemEntity.isLinkSync(p.join(mirror.path, 'pubspec.yaml')),
+        isTrue);
+    // bin/ is a real directory.
+    expect(FileSystemEntity.isDirectorySync(p.join(mirror.path, 'bin')),
+        isTrue);
+    expect(FileSystemEntity.isLinkSync(p.join(mirror.path, 'bin')), isFalse);
+    // bin/cache and bin/internal are symlinks.
+    expect(FileSystemEntity.isLinkSync(p.join(mirror.path, 'bin', 'cache')),
+        isTrue);
+    // bin/flutter and bin/dart are real shim files, not symlinks.
+    final flutterShim = File(p.join(mirror.path, 'bin', 'flutter'));
+    expect(FileSystemEntity.isLinkSync(flutterShim.path), isFalse);
+    expect(flutterShim.readAsStringSync(), contains('KIND="flutter"'));
+    expect(File(p.join(mirror.path, 'bin', 'dart')).readAsStringSync(),
+        contains('KIND="dart"'));
+  });
+
+  test('installMirror is idempotent — re-running rebuilds cleanly', () {
+    installMirror(sharedSdk: sdk, projectRoot: project, wrapExe: '/c/wrap');
+    final mirror = installMirror(
+        sharedSdk: sdk, projectRoot: project, wrapExe: '/c/wrap');
+    expect(File(p.join(mirror.path, 'bin', 'flutter')).existsSync(), isTrue);
+  });
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd app && flutter test test/wrap/installer_test.dart`
+Expected: FAIL — `installer.dart` does not exist.
+
+- [ ] **Step 3: Write the installer**
+
+Create `app/lib/src/wrap/installer.dart`:
+
+```dart
+import 'dart:io';
+import 'package:path/path.dart' as p;
+
+import 'shim_template.dart';
+
+/// Builds the per-project SDK mirror facade at `<projectRoot>/flutterware/sdk/`.
+///
+/// Every entry of [sharedSdk] is symlinked into the mirror, except `bin/`,
+/// which is a real directory whose `flutter`/`dart` are generated shims and
+/// whose other entries are symlinks. The mirror is rebuilt from scratch on
+/// every call (idempotent). Returns the mirror directory.
+Directory installMirror({
+  required Directory sharedSdk,
+  required Directory projectRoot,
+  required String wrapExe,
+}) {
+  final mirror =
+      Directory(p.join(projectRoot.path, 'flutterware', 'sdk'));
+  if (mirror.existsSync()) mirror.deleteSync(recursive: true);
+  mirror.createSync(recursive: true);
+
+  final mirrorBin = Directory(p.join(mirror.path, 'bin'))..createSync();
+
+  // Top-level SDK entries (skip `bin`) -> symlinks.
+  for (final entry in sharedSdk.listSync()) {
+    final name = p.basename(entry.path);
+    if (name == 'bin') continue;
+    Link(p.join(mirror.path, name)).createSync(entry.path);
+  }
+
+  // bin/ entries (skip the two wrapped binaries) -> symlinks.
+  final sharedBin = Directory(p.join(sharedSdk.path, 'bin'));
+  for (final entry in sharedBin.listSync()) {
+    final name = p.basename(entry.path);
+    if (name == 'flutter' || name == 'dart') continue;
+    Link(p.join(mirrorBin.path, name)).createSync(entry.path);
+  }
+
+  // The two shims.
+  _writeShim(
+    file: File(p.join(mirrorBin.path, 'flutter')),
+    realBinary: p.join(sharedBin.path, 'flutter'),
+    kind: 'flutter',
+    wrapExe: wrapExe,
+  );
+  _writeShim(
+    file: File(p.join(mirrorBin.path, 'dart')),
+    realBinary: p.join(sharedBin.path, 'dart'),
+    kind: 'dart',
+    wrapExe: wrapExe,
+  );
+
+  return mirror;
+}
+
+void _writeShim({
+  required File file,
+  required String realBinary,
+  required String kind,
+  required String wrapExe,
+}) {
+  file.writeAsStringSync(renderShim(
+    realBinary: realBinary,
+    kind: kind,
+    wrapExe: wrapExe,
+  ));
+  // chmod +x.
+  Process.runSync('chmod', ['+x', file.path]);
+}
+```
+
+- [ ] **Step 4: Run the installer test to verify it passes**
+
+Run: `cd app && flutter test test/wrap/installer_test.dart`
+Expected: PASS — 2 tests.
+
+- [ ] **Step 5: Write the `install` command**
+
+Create `app/lib/src/wrap/install_command.dart`:
+
+```dart
+import 'dart:io';
+
+import 'package:args/command_runner.dart';
+
+import 'installer.dart';
+
+/// Builds the per-project SDK mirror facade. Sub-project 0 assumes a shared
+/// SDK already exists; this command wraps it.
+class InstallCommand extends Command<int> {
+  @override
+  final name = 'install';
+  @override
+  final description = 'Install the SDK mirror facade for a project.';
+
+  InstallCommand() {
+    argParser
+      ..addOption('sdk', help: 'Path to the existing shared Flutter SDK.')
+      ..addOption('project', help: 'Path to the project root.')
+      ..addOption('wrap-exe',
+          help: 'Path to the compiled wrap executable to bake into shims.');
+  }
+
+  @override
+  Future<int> run() async {
+    final sdk = argResults!['sdk'] as String?;
+    final project = argResults!['project'] as String?;
+    final wrapExe = argResults!['wrap-exe'] as String?;
+    if (sdk == null || project == null || wrapExe == null) {
+      stderr.writeln('[wrap] install requires --sdk, --project, --wrap-exe');
+      return 64;
+    }
+    final mirror = installMirror(
+      sharedSdk: Directory(sdk),
+      projectRoot: Directory(project),
+      wrapExe: wrapExe,
+    );
+    stdout.writeln('Installed SDK mirror at ${mirror.path}');
+    return 0;
+  }
+}
+```
+
+- [ ] **Step 6: Register the command**
+
+In `app/bin/wrap.dart`, add the import and register the command. The file
+becomes:
+
+```dart
+import 'dart:io';
+
+import 'package:args/command_runner.dart';
+import 'package:flutterware_app/src/wrap/install_command.dart';
+import 'package:flutterware_app/src/wrap/run_command.dart';
+
+Future<void> main(List<String> args) async {
+  final runner = CommandRunner<int>(
+    'wrap',
+    'flutterware SDK wrap point.',
+  )
+    ..addCommand(RunCommand())
+    ..addCommand(InstallCommand());
+  try {
+    final code = await runner.run(args) ?? 0;
+    exit(code);
+  } on UsageException catch (e) {
+    stderr.writeln(e);
+    exit(64);
+  }
+}
+```
+
+- [ ] **Step 7: Run all wrap tests to verify they pass**
+
+Run: `cd app && flutter test test/wrap/`
+Expected: PASS — all wrap unit tests.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add app/lib/src/wrap/installer.dart app/lib/src/wrap/install_command.dart app/bin/wrap.dart app/test/wrap/installer_test.dart
+git commit -m "Add the SDK mirror installer and install command"
+```
+
+---
+
+## Task 8: End-to-end shim integration test
+
+Tests the *bash* layer — marker walk-up, classification, audit log, dispatch,
+degradation — using test doubles for the real binary and the wrap exe.
+
+**Files:**
+- Test: `app/test/wrap/shim_integration_test.dart`
+
+- [ ] **Step 1: Write the test**
+
+```dart
+import 'dart:io';
+import 'package:flutterware_app/src/wrap/shim_template.dart';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+void main() {
+  late Directory tmp;
+  late File shim;
+  late File realMarker;
+  late File wrapMarker;
+
+  setUp(() {
+    tmp = Directory.systemTemp.createTempSync('wrap_shim');
+    // A "real binary" double that records it was called and echoes argv.
+    realMarker = File(p.join(tmp.path, 'real.called'));
+    final fakeReal = File(p.join(tmp.path, 'fake_real'))
+      ..writeAsStringSync(
+          '#!/usr/bin/env bash\necho "real:$*" >>"${realMarker.path}"\n');
+    Process.runSync('chmod', ['+x', fakeReal.path]);
+    // A "wrap exe" double — note it must accept the `run ... -- ...` argv.
+    wrapMarker = File(p.join(tmp.path, 'wrap.called'));
+    final fakeWrap = File(p.join(tmp.path, 'fake_wrap'))
+      ..writeAsStringSync(
+          '#!/usr/bin/env bash\necho "wrap:$*" >>"${wrapMarker.path}"\n');
+    Process.runSync('chmod', ['+x', fakeWrap.path]);
+
+    shim = File(p.join(tmp.path, 'flutter'))
+      ..writeAsStringSync(renderShim(
+        realBinary: fakeReal.path,
+        kind: 'flutter',
+        wrapExe: fakeWrap.path,
+      ));
+    Process.runSync('chmod', ['+x', shim.path]);
+  });
+  tearDown(() => tmp.deleteSync(recursive: true));
+
+  ProcessResult invoke(List<String> args, {required Directory cwd}) =>
+      Process.runSync(shim.path, args, workingDirectory: cwd.path);
+
+  test('no marker -> straight to the real binary, no audit log', () {
+    final cwd = Directory(p.join(tmp.path, 'plain'))..createSync();
+    invoke(['run'], cwd: cwd);
+    expect(realMarker.existsSync(), isTrue);
+    expect(wrapMarker.existsSync(), isFalse);
+  });
+
+  test('interesting run (flutter run) is dispatched to the wrap exe', () {
+    final proj = Directory(p.join(tmp.path, 'proj'))..createSync();
+    File(p.join(proj.path, 'flutter_version')).writeAsStringSync('3.44.0\n');
+    invoke(['--no-color', 'run', '--machine'], cwd: proj);
+    expect(wrapMarker.existsSync(), isTrue);
+    expect(wrapMarker.readAsStringSync(), contains('run --real'));
+    final audit =
+        File(p.join(proj.path, '.flutterware', 'wrap-audit.log'));
+    expect(audit.readAsStringSync(), contains('interesting'));
+  });
+
+  test('noise (flutter pub get) goes to the real binary, audited as noise', () {
+    final proj = Directory(p.join(tmp.path, 'proj2'))..createSync();
+    File(p.join(proj.path, 'flutter_version')).writeAsStringSync('3.44.0\n');
+    invoke(['pub', 'get'], cwd: proj);
+    expect(realMarker.existsSync(), isTrue);
+    expect(wrapMarker.existsSync(), isFalse);
+    final audit =
+        File(p.join(proj.path, '.flutterware', 'wrap-audit.log'));
+    expect(audit.readAsStringSync(), contains('noise'));
+  });
+
+  test('interesting run degrades to real when the wrap exe is missing', () {
+    final proj = Directory(p.join(tmp.path, 'proj3'))..createSync();
+    File(p.join(proj.path, 'flutter_version')).writeAsStringSync('3.44.0\n');
+    // Re-render the shim pointing at a non-existent wrap exe.
+    shim.writeAsStringSync(renderShim(
+      realBinary: File(p.join(tmp.path, 'fake_real')).path,
+      kind: 'flutter',
+      wrapExe: '/no/such/wrap_exe',
+    ));
+    Process.runSync('chmod', ['+x', shim.path]);
+    invoke(['run'], cwd: proj);
+    expect(realMarker.existsSync(), isTrue);
+  });
+}
+```
+
+- [ ] **Step 2: Run the test to verify it passes**
+
+Run: `cd app && flutter test test/wrap/shim_integration_test.dart`
+Expected: PASS — 4 tests. (The shim template from Task 6 already implements
+this behaviour; this task adds the coverage that locks it in.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/test/wrap/shim_integration_test.dart
+git commit -m "Add end-to-end integration test for the wrap shim"
+```
+
+---
+
+## Task 9: The probe app
+
+**Files:**
+- Modify: `examples/example/lib/main.dart`
+
+- [ ] **Step 1: Add the probe widget**
+
+In `examples/example/lib/main.dart`, add a top-level constant after the imports:
+
+```dart
+const _fwMarker = String.fromEnvironment('FW_MARKER', defaultValue: '<none>');
+```
+
+Then, inside `_MyHomePageState.build`, add a `Text` as the first child of the
+`ListView` (before `Text('Language: ...')`):
+
+```dart
+          Text('FW_MARKER: $_fwMarker',
+              key: const Key('fw-marker'),
+              style: const TextStyle(fontWeight: FontWeight.bold)),
+```
+
+- [ ] **Step 2: Verify the example still analyzes**
+
+Run: `cd examples/example && flutter analyze`
+Expected: No new analysis errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add examples/example/lib/main.dart
+git commit -m "Add FW_MARKER probe widget to the example app"
+```
+
+---
+
+## Task 10: Manual smoke test
+
+**Files:**
+- Create: `docs/superpowers/specs/2026-05-15-subproject-0-manual-smoke.md`
+
+- [ ] **Step 1: Write the smoke-test doc**
+
+Create `docs/superpowers/specs/2026-05-15-subproject-0-manual-smoke.md` with
+this content:
+
+````markdown
+# Sub-project 0 — Manual Smoke Test
+
+Validates the SDK wrap point against a real IDE. Run after the automated
+plan tasks pass.
+
+## Setup
+
+1. Compile the wrap executable:
+   ```sh
+   cd app && dart compile exe bin/wrap.dart -o build/wrap
+   ```
+2. Mark the example project: write its Flutter version into a marker file:
+   ```sh
+   flutter --version | head -1   # note the version
+   echo "<version>" > examples/example/flutter_version
+   ```
+3. Install the mirror facade:
+   ```sh
+   cd app && dart run bin/wrap.dart install \
+     --sdk "$(dirname "$(dirname "$(which flutter)")")" \
+     --project ../examples/example \
+     --wrap-exe "$(pwd)/build/wrap"
+   ```
+   This creates `examples/example/flutterware/sdk/`.
+
+## Checks
+
+### A. CLI interception
+- `cd examples/example/.. ` then run `flutterware/sdk/bin/flutter run -d macos`
+  from `examples/example`.
+- Expect: a `examples/example/.flutterware/sessions/<id>/` directory with
+  `output.log` and `meta.json`; `meta.json` shows the injected marker.
+- Expect: `examples/example/.flutterware/wrap-audit.log` has an `interesting`
+  line for the run.
+
+### B. IDE interception (IntelliJ)
+- Point IntelliJ's Flutter SDK at `examples/example/flutterware/sdk`
+  (a non-hidden path — IntelliJ accepts it).
+- Do **not** set `FW_MARKER` in the run configuration (the wrap injects it).
+- Run the example app from IntelliJ. Hot reload once. Stop.
+- Expect: the running app shows `FW_MARKER: <session id>` (not `<none>`) —
+  confirming the injected `--dart-define` reached `String.fromEnvironment`.
+- Expect: a new `interesting` session in the audit log and a session dir.
+- Expect: hot reload, stop, and the debugger still work.
+
+### C. IDE interception (VS Code) — same as B with the Dart-Code extension.
+
+### D. Noise latency
+- Watch the audit log while the IDE is open; confirm `dart`/`flutter`
+  noise invocations are classified `noise` and the IDE is not visibly slowed.
+
+### E. Degradation
+- Temporarily rename `app/build/wrap`; run `flutter run` through the mirror;
+  confirm the real command still runs (degraded to plain exec).
+
+## Result
+
+Record pass/fail per check. A negative result (the wrap breaks an IDE
+workflow, or noise is misclassified) is a valid finding that escalates to the
+parent architecture.
+````
+
+- [ ] **Step 2: Run the full automated suite once more**
+
+Run: `cd app && flutter test test/wrap/ test/passthrough/`
+Expected: PASS — all wrap and passthrough tests.
+
+- [ ] **Step 3: Run the workspace formatter**
+
+Run: `dart tool/prepare_submit.dart`
+Expected: completes; if it reformats files, include them in the commit.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/superpowers/specs/2026-05-15-subproject-0-manual-smoke.md
+git commit -m "Add manual smoke test for the SDK wrap point"
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** mirror facade (Task 7), non-hidden mirror path
+  `flutterware/sdk/` (Task 7 `installMirror`), bash fast-path shims with
+  marker walk-up + classification + audit log (Tasks 6, 8), `flutterware wrap`
+  heavy path (Task 5), dart-define argv injection (Task 1), PTY/pipe transport
+  (Task 4), project/worktree resolution (Task 2), session sink under
+  `.flutterware/` (Task 3), graceful degradation (Tasks 5, 8), probe app
+  (Task 9), installer (Task 7), test plan automated + manual (Tasks 1-8, 10).
+  All spec sections map to tasks.
+- **Placeholder scan:** no TBD/TODO; every code step has complete code.
+- **Type consistency:** `injectDartDefine`, `resolveProject`/`ProjectContext`,
+  `SessionSink`/`newSessionId`, `runIntercepted`, `RunCommand`, `renderShim`,
+  `installMirror`, `InstallCommand` — names used identically across tasks.
+  `runUnderPty`'s new `captureSink` parameter is used consistently in Task 4.

--- a/docs/superpowers/specs/2026-05-15-subproject-0-ide-launch-finding.md
+++ b/docs/superpowers/specs/2026-05-15-subproject-0-ide-launch-finding.md
@@ -1,0 +1,97 @@
+# Sub-project 0 — IDE Launch Finding (Phase A spike)
+
+**Date:** 2026-05-15
+**Status:** Empirical finding. Produced by the Phase A diagnostic spike described
+in `2026-05-15-subproject-0-sdk-wrap-point.md`. This resolves the open risk that
+threatened the parent architecture.
+
+## What was done
+
+A throwaway diagnostic wrapper was placed around a real Flutter SDK:
+
+- A full SDK *mirror* at `~/flutterware-spike/sdk/` — every SDK entry symlinked
+  to the pristine SDK (`/Users/xavier/flutter`) except `bin/flutter` and
+  `bin/dart`, which are shim scripts.
+- The shims call `spike-wrap.sh`, which logs the full argv, the process
+  environment, and a tee of stdin/stdout, then runs the real binary.
+
+IntelliJ's Flutter SDK path was pointed at the mirror. A `--dart-define` was
+added to the run configuration (`--dart-define=FW_MARKER=spike123`). The example
+app (`examples/example`) was launched from IntelliJ, hot-reloaded once, stopped.
+
+## What IntelliJ actually did
+
+IntelliJ accepted the mirror SDK without complaint. It ran `flutter --no-color
+--version` three times to validate the SDK, then launched the run as a single
+direct invocation:
+
+```
+flutter --no-color run --machine --track-widget-creation --device-id=macos \
+  --start-paused --dart-define=FW_MARKER=spike123 \
+  --dart-define=flutter.inspector.structuredErrors=true \
+  --devtools-server-address=http://127.0.0.1:9101 lib/main.dart
+```
+
+The run process had piped (non-TTY) stdin and stdout. Over those pipes IntelliJ
+drove the session with daemon-protocol JSON-RPC — e.g.
+`app.callServiceExtension` calls for the inspector. Hot reload spawned **no new
+process**; it flowed over the existing run process's pipe.
+
+## Findings
+
+1. **IntelliJ launches runs as a direct `flutter run --machine`** — not via a
+   separate, long-lived `flutter daemon` process. The feared branch (an IDE
+   daemon that receives launch parameters over JSON-RPC *after* start) did not
+   occur.
+
+2. **`--dart-define` values are passed in plain argv at launch.** Both the
+   user's define (`FW_MARKER=spike123`) and IntelliJ's own
+   (`flutter.inspector.structuredErrors=true`) appear as ordinary `argv`
+   entries. Injecting an additional `--dart-define` therefore requires only an
+   **argv rewrite** — no protocol-aware proxy, no JSON-RPC splicing.
+
+3. **`--machine` is a control channel, not a config channel.** It makes
+   `flutter run` speak the daemon JSON-RPC protocol over its own stdin/stdout so
+   the IDE can drive hot reload, service extensions, and stop. That traffic
+   carries *no* dart-defines — defines are fixed at launch in argv. The wrap can
+   tee this traffic verbatim; it never needs to parse it.
+
+4. **IDE runs use pipes, not a PTY.** The heavy path for an IDE/`--machine` run
+   is a plain bidirectional pipe passthrough. The phase-1 `runUnderPty` is only
+   needed for an interactive CLI `flutter run` in a real terminal.
+
+5. **The mirror facade is accepted by IntelliJ** when placed at a non-hidden
+   path. IntelliJ rejects SDK paths containing a hidden (dot-prefixed) directory
+   component — confirmed from prior experience and accounted for in the mirror
+   location decision below.
+
+6. **dart-define is not an environment variable.** It was confirmed absent from
+   the process environment. A compiled Flutter app on a device cannot receive
+   host environment variables; `--dart-define` (read via
+   `String.fromEnvironment`) is the only host→app launch-config channel. The
+   parent architecture's "inject an env var (the channel address)" framing is
+   wrong for mobile targets and must become "inject a `--dart-define`".
+
+## Caveats
+
+- One IntelliJ version, macOS host, desktop (`macos`) device. Behaviour could
+  differ on older IntelliJ, other platforms, or other device types.
+- IntelliJ may still spawn a `flutter daemon` for device discovery; none was
+  observed in the capture window. Such a daemon launches no app, so it is
+  harmless noise even if present.
+- The marker reaching the *running app* via `String.fromEnvironment` was not
+  verified here (the probe app is a Phase B deliverable). It is verifiable in
+  principle: the define is present in the real `flutter run` argv, which is the
+  ordinary, supported way dart-defines reach an app.
+
+## Decisions this resolves
+
+- **No daemon JSON-RPC proxy.** All three launch paths (CLI `flutter run`,
+  VS Code `flutter run --machine`, IntelliJ `flutter run --machine`) carry
+  dart-defines in argv. The heavy path is: argv rewrite + transport passthrough.
+- **Two transport modes for the heavy path:** PTY passthrough for an interactive
+  terminal run; plain pipe passthrough for a `--machine` run. Both are dumb tees
+  — neither parses the stream.
+- **Mirror location is non-hidden.** The SDK mirror lives at a non-hidden,
+  IDE-referenced path (`<project>/flutterware/sdk/`). The audit log and session
+  sink — not referenced by any IDE config — stay under `<project>/.flutterware/`.

--- a/docs/superpowers/specs/2026-05-15-subproject-0-manual-smoke.md
+++ b/docs/superpowers/specs/2026-05-15-subproject-0-manual-smoke.md
@@ -1,0 +1,60 @@
+# Sub-project 0 — Manual Smoke Test
+
+Validates the SDK wrap point against a real IDE. Run after the automated
+plan tasks pass.
+
+## Setup
+
+1. Compile the wrap executable:
+   ```sh
+   cd app && dart compile exe bin/wrap.dart -o build/wrap
+   ```
+2. Mark the example project: write its Flutter version into a marker file:
+   ```sh
+   flutter --version | head -1   # note the version
+   echo "<version>" > examples/example/flutter_version
+   ```
+3. Install the mirror facade:
+   ```sh
+   cd app && dart run bin/wrap.dart install \
+     --sdk "$(dirname "$(dirname "$(which flutter)")")" \
+     --project ../examples/example \
+     --wrap-exe "$(pwd)/build/wrap"
+   ```
+   This creates `examples/example/flutterware/sdk/`.
+
+## Checks
+
+### A. CLI interception
+- `cd examples/example/.. ` then run `flutterware/sdk/bin/flutter run -d macos`
+  from `examples/example`.
+- Expect: a `examples/example/.flutterware/sessions/<id>/` directory with
+  `output.log` and `meta.json`; `meta.json` shows the injected marker.
+- Expect: `examples/example/.flutterware/wrap-audit.log` has an `interesting`
+  line for the run.
+
+### B. IDE interception (IntelliJ)
+- Point IntelliJ's Flutter SDK at `examples/example/flutterware/sdk`
+  (a non-hidden path — IntelliJ accepts it).
+- Do **not** set `FW_MARKER` in the run configuration (the wrap injects it).
+- Run the example app from IntelliJ. Hot reload once. Stop.
+- Expect: the running app shows `FW_MARKER: <session id>` (not `<none>`) —
+  confirming the injected `--dart-define` reached `String.fromEnvironment`.
+- Expect: a new `interesting` session in the audit log and a session dir.
+- Expect: hot reload, stop, and the debugger still work.
+
+### C. IDE interception (VS Code) — same as B with the Dart-Code extension.
+
+### D. Noise latency
+- Watch the audit log while the IDE is open; confirm `dart`/`flutter`
+  noise invocations are classified `noise` and the IDE is not visibly slowed.
+
+### E. Degradation
+- Temporarily rename `app/build/wrap`; run `flutter run` through the mirror;
+  confirm the real command still runs (degraded to plain exec).
+
+## Result
+
+Record pass/fail per check. A negative result (the wrap breaks an IDE
+workflow, or noise is misclassified) is a valid finding that escalates to the
+parent architecture.

--- a/docs/superpowers/specs/2026-05-15-subproject-0-sdk-wrap-point-design.md
+++ b/docs/superpowers/specs/2026-05-15-subproject-0-sdk-wrap-point-design.md
@@ -1,0 +1,219 @@
+# Sub-project 0 — The SDK Wrap Point (Implementation Spec)
+
+**Date:** 2026-05-15
+**Status:** Implementation spec. Ready for an implementation plan.
+**Parent:** `2026-05-15-wrapper-tool-architecture.md` — read it for vocabulary
+(Mechanisms A/B, three-layer distribution, sub-project decomposition).
+**Brief:** `2026-05-15-subproject-0-sdk-wrap-point.md` — the scoping brief.
+**Phase A finding:** `2026-05-15-subproject-0-ide-launch-finding.md` — the
+empirical result that shaped this spec.
+
+## Purpose
+
+Wrap the `flutter`/`dart` scripts an IDE invokes so that every run — CLI, AI, or
+IDE — is intercepted, classified, observed, and can have a `--dart-define`
+injected, degrading to plain passthrough on any failure. This is the riskiest
+piece of the architecture; building it for real and pointing an IDE at it is how
+the architecture is de-risked.
+
+The Phase A spike already de-risked the central unknown (see the finding doc):
+IntelliJ launches runs as a direct `flutter run --machine` with `--dart-define`
+values in plain argv. No daemon JSON-RPC proxy is needed; injection is an argv
+rewrite. This spec is written on that result.
+
+## Two open decisions — resolved
+
+1. **Wrapped-script placement: per-project mirror facade.** The project's SDK
+   path is a real directory whose `bin/flutter` and `bin/dart` are wrapper
+   scripts and whose every other entry symlinks into the pristine shared SDK.
+   The shared SDK stays byte-identical to a clean checkout. The wrapper `exec`s
+   the *real* binary, which computes `FLUTTER_ROOT` from its own physical path —
+   so builds run entirely against the pristine SDK; the mirror is a pure
+   interception facade.
+
+2. **Noise classification: a hard-coded probe default.** A pure-bash `case` on
+   the first non-flag argument. `flutter run` / `flutter test` → *interesting*;
+   everything else, and all `dart`, → *noise*. This is deliberately disposable —
+   sub-project 3's `config.dart` replaces it. Every invocation is recorded as
+   one line in an audit log, which doubles as the discovery instrument for
+   refining classification later.
+
+## What it delivers
+
+A wrapped `flutter`/`dart` such that, on every invocation:
+
+1. **Marker resolution** — walk up from `$PWD` for the `flutter_version` marker.
+   Not found → `exec` the real binary immediately, fully transparent.
+2. **Classification** — pure-bash `case` on the first non-flag arg.
+3. **Noise** → append one audit-log line, `exec` the real binary.
+4. **Interesting** → hand off to the compiled `flutterware wrap` executable,
+   which resolves worktree identity, injects `--dart-define=FW_MARKER=<token>`
+   by argv rewrite, runs the real binary under a transport passthrough, captures
+   output to a local session sink, and exits with the child's code.
+5. **Always degrades** — any failure (missing marker, missing/failing wrap
+   executable, error inside the wrap) ends in a plain `exec` of the real binary.
+
+Plus: an installer that builds the mirror around an existing SDK, a probe app
+that proves the injected define reaches the running app, and the audit log /
+session sink for inspecting what was intercepted.
+
+## Components
+
+### 1. The mirror facade
+
+Location: `<project>/flutterware/sdk/` — **non-hidden** (IntelliJ rejects SDK
+paths with a hidden path component; the finding confirms this). The audit log
+and session sink live separately under `<project>/.flutterware/` (hidden, not
+referenced by any IDE config).
+
+Layout: a real directory mirroring the SDK. Every top-level SDK entry and every
+`bin/` entry is a symlink into the pristine shared SDK, except `bin/flutter` and
+`bin/dart`, which are the generated wrapper scripts. (Sub-project 0 builds the
+*full* mirror — symlink everything — rather than hunting the minimal symlink
+set; minimization is a later optimisation.)
+
+The IDE is pointed at `<project>/flutterware/sdk` as its **Flutter SDK**;
+IntelliJ then derives the Dart SDK as `<mirror>/bin/cache/dart-sdk` itself,
+through the `bin/cache` symlink. The IDE must not be pointed at the cache
+directly, or the wrap is bypassed.
+
+### 2. The installer
+
+A `flutterware wrap-install` command (or equivalent), given an existing shared
+SDK path and a project root: creates `<project>/flutterware/sdk/`, symlinks all
+SDK entries, and writes the two wrapper scripts with absolute paths baked in
+(real binary path, compiled `flutterware wrap` executable path). Idempotent —
+re-running rebuilds cleanly.
+
+Sub-project 0 assumes the shared SDK already exists at a known path; the
+walker/bootstrapper/SDK-download is tracked separately.
+
+### 3. The bash wrapper scripts (the cheap fast path)
+
+Generated per project by the installer. Both `flutter` and `dart` shims share
+the same logic, parameterised by the wrapped binary's name:
+
+1. Walk up from `$PWD` for `flutter_version`. Not found → `exec` the real
+   binary. (This is the bulk-transparency case and the cheapest path.)
+2. Find the first non-flag argument (skip leading `--*` global flags such as
+   `--no-color`, `--verbose`).
+3. Classify: `flutter` + (`run` | `test`) → interesting; all else → noise.
+4. Append one tab-separated audit-log line — timestamp, cwd, kind,
+   classification, full argv — to `<project>/.flutterware/wrap-audit.log`.
+   Cheap `printf >>`; concurrent short appends are atomic on POSIX.
+5. Noise → `exec` the real binary.
+6. Interesting → `exec` the compiled `flutterware wrap` executable, passing the
+   real binary path, kind, project root, and the original argv. If that
+   executable is missing or not executable → `exec` the real binary.
+
+Classification and the noise path are pure bash, so the high-frequency `dart`
+invocations an IDE makes pay only a marker walk-up and one log append.
+
+### 4. The `flutterware wrap` command (the heavy path)
+
+A new standalone CLI entry `app/bin/wrap.dart` (mirroring `app/bin/passthrough.dart`)
+with logic under `app/lib/src/wrap/`, compiled to an executable via
+`dart compile exe`. Invoked by the bash shim only for *interesting* runs.
+
+Internal units, each independently testable:
+
+- **Project / worktree resolution** — project root is the `flutter_version`
+  directory; worktree identity is resolved from the worktree's `.git` *file*
+  (`gitdir:` pointer) when present, else the project root itself.
+- **dart-define injection** — rewrite the argv to insert
+  `--dart-define=FW_MARKER=<token>` immediately after the `run`/`test`
+  subcommand token. The `<token>` is a value the wrap chooses and records, so
+  the probe app can confirm the round-trip.
+- **Transport passthrough** — run the real binary and stream its I/O:
+  - `stdin` is *not* a terminal (an IDE / `--machine` run) → plain bidirectional
+    **pipe** passthrough (tee both directions to the sink).
+  - `stdin` *is* a terminal (an interactive CLI run) → **PTY** passthrough,
+    reusing `runUnderPty` from phase 1.
+  Neither mode parses the stream; both are dumb tees. The child's exit code is
+  propagated.
+- **Session sink** — writes a `<project>/.flutterware/sessions/<id>/` directory
+  with captured output and a `meta.json` (timestamp, worktree, argv before and
+  after rewrite, injected token, exit code).
+- **Graceful degradation** — any error before/while spawning the child falls
+  back to a plain spawn of the real binary with the original argv; the wrap
+  never prevents the real command from running.
+
+### 5. The probe app
+
+`examples/example` gains a trivial widget that reads
+`String.fromEnvironment('FW_MARKER')` and displays it. Success is that token
+appearing **in the running app** — for CLI, AI, VS Code, and IntelliJ launches —
+not merely present in a host process.
+
+## Observation sink format
+
+Under `<project>/.flutterware/` (hidden; sub-project 1 replaces all of this with
+the daemon + SQLite DB):
+
+- `wrap-audit.log` — one tab-separated line per invocation (every kind, every
+  classification). The discovery instrument: `grep` it after living with an IDE
+  to refine classification.
+- `sessions/<id>/` — per interesting run: captured output stream(s) and
+  `meta.json`.
+
+## Graceful degradation — every layer
+
+- No `flutter_version` marker → plain `exec` (not a flutterware project).
+- Classification or audit-log write fails → still `exec` the real binary.
+- `flutterware wrap` executable missing / not executable → bash `exec`s the real
+  binary.
+- Any error inside `flutterware wrap` → plain spawn of the real binary with the
+  original, un-rewritten argv.
+- The real command always runs and the wrap exits with the child's code.
+
+## File layout
+
+```
+app/bin/wrap.dart                         # new standalone CLI entry
+app/lib/src/wrap/
+  wrap_command.dart                       # arg parsing + orchestration
+  project_resolution.dart                 # project root + worktree identity
+  dart_define.dart                        # argv rewrite
+  transport.dart                          # PTY vs pipe passthrough
+  session_sink.dart                       # local observation sink
+app/lib/src/passthrough/                  # reused as-is (PTY transport)
+docs/superpowers/specs/                    # this spec + the finding doc
+```
+
+The installer command is added to the existing CLI command set.
+
+## Testing & success criteria
+
+**Automated** (`app/test/`):
+- Classification: representative `flutter`/`dart` argvs → correct
+  interesting/noise verdict, including leading global flags.
+- dart-define injection: argv rewrite inserts the define in the right position
+  and is idempotent against the input shapes seen in the finding.
+- Project/worktree resolution: marker walk-up; `.git`-file worktree case.
+- Degradation: errored wrap still spawns the real binary with original argv.
+
+**Manual** (recorded in a smoke-test doc, like the phase-1 passthrough smoke):
+- `flutter run` from IntelliJ and from VS Code appears in `wrap-audit.log` as an
+  intercepted interesting session, output captured, and `FW_MARKER` confirmed
+  *inside the running app*.
+- The IDE's own workflows still work end-to-end through the wrap — hot reload,
+  stop, debugger, analysis server.
+- Noise `dart`/`flutter` invocations are classified as noise and add negligible
+  latency.
+- Killing the wrapper, or any wrap-step failure, still runs the real command.
+
+A clear negative result — the wrap breaks an IDE workflow, or noise cannot be
+classified cheaply — is also a successful outcome: it forces a change to the
+parent architecture before more is built on it.
+
+## Out of scope (later sub-projects)
+
+- The daemon, the SQLite DB, `policy.query` — sub-project 1. Here there is no
+  daemon; the wrap always takes the standalone path and writes the local sink.
+- `config.dart` / per-worktree config processes / user-configurable
+  classification — sub-project 3.
+- The Mechanism-B back-channel — sub-project 2.
+- The walker + bootstrapper + SDK download — tracked separately; sub-project 0
+  assumes a shared SDK exists at a known path.
+- Auto-writing the IDE's `.idea/` SDK configuration — sub-project 0 validates
+  the facade with the IDE configured by hand.

--- a/docs/superpowers/specs/2026-05-15-subproject-0-sdk-wrap-point.md
+++ b/docs/superpowers/specs/2026-05-15-subproject-0-sdk-wrap-point.md
@@ -1,0 +1,135 @@
+# Sub-project 0 — The SDK Wrap Point
+
+**Date:** 2026-05-15
+**Status:** Scoping brief. Hand-off for a fresh implementation session — *not*
+a finished spec. The implementation session should brainstorm the "Open
+decisions" below before writing code, then produce a plan.
+**Parent:** `2026-05-15-wrapper-tool-architecture.md` (read it first — this brief
+assumes its vocabulary: Mechanisms A/B, the three-layer distribution model, the
+sub-project decomposition).
+
+## Purpose
+
+Sub-project 0 is the **first** sub-project for two reasons: everything else
+depends on it, and it is the **riskiest assumption** in the whole architecture.
+
+The architecture promises to observe `flutter run` / Dart processes started
+*any way* — by an AI, a human terminal, or an IDE. That promise rests entirely
+on one hack: **wrapping the `flutter` and `dart` scripts the IDE itself
+invokes.** The daemon, DB, and channel layers are conventional engineering and
+will work. The SDK-script wrap is a hack against Flutter's SDK layout and IDE
+behavior — if it is fragile, the architecture must change. Sub-project 0 exists
+to find out, by building the real wrap point and pointing a real IDE at it.
+
+It is built **for real** (the wrapped scripts are permanent infrastructure, not
+throwaway), but kept deliberately minimal — its only genuinely exploratory part
+is the noise-classification rule.
+
+## What it delivers
+
+A wrapped `flutter` / `dart` such that, on every invocation:
+
+1. **Project + worktree resolution** — walk up to the `flutter_version` marker
+   for the project root; resolve worktree identity (a worktree's `.git` is a
+   *file* pointing at the common dir). Not a flutterware project → exec the real
+   binary immediately, fully transparent.
+2. **Classification** — decide *interesting* (a run worth observing, e.g.
+   `flutter run`, `flutter test`) vs *noise* (`dart pub get`, the IDE analysis
+   server, `flutter --version`, …).
+3. **Noise** → exec the real binary directly, negligible overhead.
+4. **Interesting** → run the real binary under the existing `passthrough` PTY
+   (reuse `runUnderPty` from phase 1), capture its output, **inject a marker env
+   var** into the child (proving the injection path), and append a record to a
+   **local log/capture sink**.
+5. **Always** — the real command runs and exits with the child's code; any
+   failure in the wrap degrades to plain exec (the guiding principle).
+
+Plus: a minimal installer step that places the wrapped scripts around an SDK,
+and a way to inspect what was intercepted (the local log).
+
+## In scope / out of scope
+
+**In scope**
+- The wrapped `flutter`/`dart` and the wrap logic.
+- Project-root + worktree-identity resolution.
+- A minimal, hard-coded noise-classification rule.
+- Env-var injection into interesting children.
+- A **local** observation sink (a log file + captured output) — enough to prove
+  interception.
+- Reuse of the phase-1 `passthrough` PTY for interesting runs.
+
+**Out of scope** (later sub-projects)
+- The daemon, the SQLite DB, `policy.query` — sub-project 1. In sub-project 0
+  there is no daemon, so the wrap *always* takes the degraded/standalone path
+  and writes to the local sink. Sub-project 1 swaps that sink for the daemon.
+- `config.dart` / per-worktree config processes / real policy — sub-project 3.
+  Classification here is hard-coded, not user-configurable.
+- The Mechanism-B back-channel — sub-project 2.
+- The full walker + bootstrapper + SDK download. Sub-project 0 may **assume an
+  SDK already exists** at a known path and focus on wrapping it; building the
+  distribution layers is tracked separately.
+
+## Intended shape (subject to the open decisions)
+
+The wrapped script keeps a **cheap fast path**: classification and the noise
+case should be pure bash (a `case` on the first argument), so the common,
+high-frequency `dart` invocations pay almost nothing. Only *interesting* runs
+hand off to the heavier machinery (the compiled `passthrough` executable with
+the real binary as its child). This matters because wrapping `dart` taxes every
+`dart` call an IDE makes — build scripts, the analysis server, etc.
+
+## Open decisions — brainstorm these first
+
+The implementation session must resolve these before coding. They are genuine
+design choices, not placeholders.
+
+1. **Wrapped-script placement.** Two candidates, from the parent doc:
+   - *Shared SDK cache* — wrap `<cache>/bin/flutter`/`dart` in place. Simple
+     (one install per version) but modifies a git-tracked SDK file and affects
+     every project on that version.
+   - *Per-project mirror dir* — the project's SDK path is a real directory whose
+     `bin/flutter`/`dart` are wrappers and whose other entries symlink into the
+     pristine shared cache. Keeps the cache git-clean, scopes the wrap to
+     opted-in projects, and is naturally per-worktree.
+
+   The parent doc leans **per-project mirror**. Validate: how many symlinks does
+   a believable SDK mirror need, and does IntelliJ's Dart/Flutter plugin accept
+   it (it resolves `<sdk>/bin/cache/dart-sdk`).
+
+2. **Noise classification — the central research question.** A static
+   subcommand allow/deny list is the obvious starting point (`flutter run`,
+   `flutter test` interesting; everything else noise). Living with a real IDE
+   for an hour is how you find out whether that is enough or whether it
+   misfires. *This is the finding sub-project 0 exists to produce.*
+
+3. **Locating the real binary.** Depends on (1): a renamed `flutter.real` in the
+   shared-cache approach, or the cache path directly in the mirror approach.
+
+4. **The local observation sink format** — where the log/captured output lives
+   (e.g. under `.flutterware/`) and its shape. Keep it trivial; sub-project 1
+   replaces it with the DB.
+
+## Success criteria
+
+The de-risking is successful when:
+
+- A `flutter run` launched **from IntelliJ** (and ideally VS Code) appears in
+  the local log as an intercepted *interesting* session, with its output
+  captured and a marker env var confirmed injected into the child.
+- The IDE's own workflows still work end-to-end through the wrap — hot reload,
+  stop, the debugger, the analysis server.
+- The IDE's many *noise* `dart`/`flutter` invocations are classified as noise
+  and add negligible latency.
+- Killing the wrapper (or any wrap-step failure) still lets the real command run
+  (degrades to plain exec).
+
+A clear *negative* result — "the hijack breaks the IDE" or "noise is
+unclassifiable cheaply" — is also a successful outcome of sub-project 0: it
+would force a change to the parent architecture before more is built on it.
+
+## Relationship to later sub-projects
+
+Sub-project 0's local sink and standalone (no-daemon) path are intentionally
+provisional. Sub-project 1 introduces the per-project daemon + DB and the wrap
+point starts reporting to it via `policy.query` / DB writes; the local sink
+becomes the fallback used only when the daemon is unreachable.

--- a/docs/superpowers/specs/2026-05-15-wrapper-tool-architecture.md
+++ b/docs/superpowers/specs/2026-05-15-wrapper-tool-architecture.md
@@ -1,85 +1,284 @@
 # Command-Wrapper Tool — Architecture Exploration
 
-**Date:** 2026-05-15
-**Status:** Exploration / direction-setting. **Not a committed spec.** No implementation
-beyond phase 1 (the `passthrough` command) exists.
+**Date:** 2026-05-15 (revised same day)
+**Status:** Exploration / direction-setting. **Not a committed spec.** Only phase 1
+(the `passthrough` PTY command) exists in code.
 
-This document captures a design discussion about the larger tool that the
-`passthrough` PTY command is the first building block of. It records the shape
-we agreed on and the open questions, so a future session can pick it up without
-re-deriving everything.
+This document captures an ongoing design discussion about the larger tool that
+the `passthrough` PTY command is the first building block of. It records the
+shape we agreed on, the decomposition into sub-projects, and the open questions,
+so a future session can pick it up without re-deriving everything.
+
+> **Revision note (2026-05-15):** an earlier version of this doc framed the
+> whole product as a wrapper CLI you invoke explicitly. That framing missed two
+> things: (1) the product is really *two* mechanisms that compose, and (2) the
+> daemon bundled two responsibilities that split on the per-project /
+> per-worktree line. Both are corrected below.
+>
+> **Revision note 2 (2026-05-15):** the distribution/install model is now worked
+> out — a three-layer split (frozen walker → tiny bootstrapper → host-built big
+> CLI) and a plain-text `flutter_version` marker. See "Distribution & install
+> model" below; it replaces the earlier "fw foundation" section.
 
 ## The goal
 
-A wrapper CLI that AI agents (and humans) invoke in many git worktrees of the
-same project. Every command run through the wrapper funnels to one central,
-per-project place so its progress and results are observable in a GUI — each
-open worktree shown as a tab.
+A per-project tool that AI agents (and humans) use across many git worktrees of
+the same project. Every interesting process — `flutter run`, a long-running
+Dart server, a test run — funnels to one central, **per-project** place so its
+progress and results are observable in a GUI: each open worktree shown as a tab.
 
-`passthrough` (phase 1, done) is the bottom layer: it runs a child process under
-a real PTY, tees its output, forwards stdin/signals/resize, and exposes the
-captured stream. Everything below builds on top of it.
+Crucially, this must observe runs started **any way**: by an AI agent, by a
+human in a terminal, or by an IDE (IntelliJ / VS Code). The tool cannot assume
+everything launches through an explicit wrapper command.
+
+## Two mechanisms (the key reframe)
+
+The product is two distinct mechanisms that **compose**. Earlier framing treated
+the launch-wrapper as the foundation; in fact it is the *bootstrap* for the
+back-channel.
+
+**Mechanism A — wrap the launch (the *outside* of a process).**
+Intercept *how* a process starts: observe its argv/output, inject env vars and
+`--dart-define`s. This is where launch-time policy lives.
+
+**Mechanism B — the app connects back (the *inside* of a process).**
+A library embedded in the running app/server (today: `Devbar`, `lib/devbar.dart`)
+opens a channel to the GUI for rich features — DB introspection, screenshots,
+hot-reload, HTTP-log streaming, SQL-query streaming.
+
+**How they compose:** A intercepts the launch *and injects an env var* (the
+channel address) into the child. B reads that env var and phones home. A is not
+a secondary convenience — it is how B learns where to connect.
+
+| Feature | Needs |
+|---|---|
+| Worktree list & tabs | neither — GUI shell |
+| Discover running `flutter run` / servers | A (the wrap point) |
+| Rich app features (Devbar, DB, screenshots, hot-reload) | A injects + B connects |
+| Server features (HTTP logs, SQL queries, open pages) | A injects + B connects |
+| Inject `--dart-define` (e.g. server host/port per worktree) | A |
+| `config.dart` shortcuts (`fw env up` → `cd … && …`) | A |
+
+## Wrapping the SDK, not a prefix
+
+The naive form of Mechanism A is a `fw <command>` prefix the user types. That
+cannot catch IDE-launched runs — an IDE invokes `flutter` directly.
+
+The fix: **wrap the `flutter` and `dart` scripts that the IDE actually
+invokes** — the ones inside the project's SDK location. Because `fw` owns the
+SDK install and the path the IDE is pointed at, wrapping `flutter`/`dart` there
+means **every** invocation — CLI, AI, or IDE — passes through the wrap point.
+That is what makes "observe runs started any way" achievable. The exact
+placement of the wrapped scripts (shared SDK cache vs. per-project mirror dir)
+is a sub-project 0 decision; see that section.
+
+The sibling `rimbaud` project (`bin/fw` + `tool/fw`) is a working prototype of
+the SDK-management half and a useful reference, but its structure is *not* the
+model — see the distribution model below.
+
+## Distribution & install model
+
+The hard constraint: the very first run on a fresh machine has **no `dart` and
+no `flutter`**. Whatever runs first must be bash or a precompiled binary. Only
+*after* an SDK exists can Dart code (`pub get`, `dart compile`, `flutter build`)
+run. That constraint produces a **three-layer split** — the dividing line is
+"does this need a full SDK to exist yet?"
+
+| Layer | Job | Form | Distributed how |
+|---|---|---|---|
+| **Walker** | walk up from `$PWD`, find the project, dispatch | frozen bash (~30 lines) | once, global (on `PATH`) |
+| **Bootstrapper** | install the pinned Flutter SDK — *nothing else* | tiny precompiled binary (`dart compile exe`) | GitHub releases, machine-global, version-*floating* |
+| **Big CLI** | daemon, DB, wrapping, GUI — all real logic | built **lazily on the host** | from the pinned `flutterware` pub package |
+
+**Why three.** A single distributed binary cannot carry the big CLI: the GUI is
+a Flutter desktop app (`flutter build`, never `dart compile exe`) and the
+daemon/DB layers may need native deps. So the big CLI is **built on the host**
+once the SDK exists — the model `bin/flutterware.dart` already uses today
+(`pub get` + `dart compile exe` + `flutter build` into a per-version cache,
+reused on later runs). It is never shipped as a binary; its versioning is
+ordinary pub resolution. Only the *bootstrapper* must be a clean precompiled
+binary, and installing an SDK has trivial dependencies (HTTP/`git`, archive
+extraction) — safe for `dart compile exe` indefinitely.
+
+**The walker** is the only thing installed globally and the only thing "frozen".
+It is safe to freeze precisely because it carries **no logic** — pure dispatch,
+no external contract beyond "a `flutter_version` file exists up the tree". It is
+a single global file, so if it ever does need to change the big CLI can simply
+overwrite it (the escape hatch fvm never had). A `curl … | sh` installer (always
+fetched fresh, never frozen) seeds the walker + the first bootstrapper.
+
+### The marker — `flutter_version`
+
+The walker keys on a **plain-text `flutter_version` file** at the repo root
+(just the version string). Not `.fvmrc` (an fvm convention — would collide), not
+the `flutterware` pubspec dependency (would force the frozen walker to
+understand pub, and `pubspec.lock` does not exist on a fresh checkout).
+
+This makes opt-in **two-level**, deliberately:
+
+- `flutter_version` present → `fw` manages the Flutter SDK. Useful on its own —
+  `fw` is a viable fvm replacement even for projects that never touch the GUI.
+- `flutter_version` **+** a `flutterware` pubspec dependency → `fw` *also*
+  delivers the big CLI, daemon, wrapping, and GUI. The pubspec dependency pins
+  the big-CLI version and delivers the Mechanism-B runtime libs (`devbar`).
+
+An optional committed config file (tentatively `tool/flutterware.dart`) carries
+user policy; see `config.dart` below.
+
+### Bootstrapper pinning — there is none (by design)
+
+The bootstrapper **cannot** be pinned per-project, and does not need to be.
+
+*Cannot:* it runs at cold-start, before any `dart` exists. The only pin readable
+that early is the plain-text `flutter_version`. The `flutterware` version lives
+in `pubspec.lock`, which does not exist until `pub get` runs — which needs the
+SDK the bootstrapper has not installed yet. So the bootstrapper executes before
+the project's flutterware version is even knowable.
+
+*Does not need to:* the bootstrapper is a **fungible installer**, not part of
+the build. Its only job is "fetch the exact Flutter SDK named in
+`flutter_version`" — `git clone` of a tag, which works regardless of bootstrapper
+age. Whichever bootstrapper does the fetch, the result is the same SDK. CI
+reproducibility comes entirely from the two real pins: `flutter_version` and the
+`flutterware` pub dependency.
+
+So there are exactly **two per-project pins** (`flutter_version`, the
+`flutterware` pub dep). The bootstrapper is machine-global and version-floating
+(seeded by the installer, updated deliberately, not silently per-run).
+
+**The one frozen contract: the IDE-facing SDK path.** What *could* bite CI is
+not the bootstrapper's install *mechanism* (which may evolve freely — same
+output) but its output *layout*. Within that layout, only the SDK path the IDE
+is pointed at is a hard external contract — committed IDE configs (`.idea/`)
+depend on it. That single path must be chosen once and treated as permanent,
+like a public API. The *internal* cache structure may still evolve: the pinned
+big CLI runs after the bootstrapper and can detect and migrate an older
+internal layout. CI is further insulated because it caches the Flutter SDK
+directory anyway, so the bootstrapper is not re-fetched or re-run per build.
+
+**Optional escape hatch.** A project that wants hard determinism against
+bootstrapper drift may commit an optional plain-text `flutterware_version` file
+at the repo root; the walker reads it at cold-start (it already reads
+`flutter_version`) and fetches that exact bootstrapper version. Deliberately
+*optional* — making it mandatory would recreate fvm's real pain (a third version
+knob to manage and skew), which the 99% case should not pay.
+
+### Cold-start trace
+
+1. **One-time per machine:** `curl … | sh` puts the walker on `PATH` and seeds
+   the latest bootstrapper into `~/.flutterware/`.
+2. `fw …` in a project → walker walks up, finds `flutter_version`, dispatches.
+3. **Bootstrapper** runs (native binary, needs nothing): installs the Flutter
+   SDK named in `flutter_version`.
+4. `dart`/`flutter` now exist → `pub get` resolves the `flutterware` package at
+   the pinned version into the pub cache.
+5. **Big CLI** is built lazily on the host into a per-version cache (reused on
+   later runs), then runs the requested command / daemon / GUI.
+
+### Evolution resistance
+
+CI reproducibility rests on the **two per-project pins** (`flutter_version`,
+the `flutterware` pub dep) — not on the bootstrapper, which is a fungible
+installer (see "Bootstrapper pinning" above). The big CLI is host-built at its
+pinned pub version, so an old project keeps building its old, known-good CLI and
+is never forced to upgrade.
+
+The bootstrapper stays backward compatible for *installing* old Flutter versions
+because that is just `git clone` of an old tag — durable for any tag. Its
+install *mechanism* may evolve freely (a floating "latest" is fine). Its output
+*layout* may also evolve, with one exception frozen forever: the IDE-facing SDK
+path. The walker's contract (`find flutter_version` → dispatch) is the other
+forever-stable surface, and it is regenerable.
+
+Two honest limits, neither solvable by architecture:
+- If we ever *must* move the IDE-facing SDK path, that is a breaking change — a
+  deliberate, rare major-version migration, not something a pin file makes
+  painless (it would only trade the migration for permanent multi-layout
+  support).
+- If Flutter *upstream* removes old download artifacts, nothing saves you — but
+  cloning a git tag from `github.com/flutter/flutter` is about as durable as
+  anything gets.
 
 ## Architecture
 
 ```
-┌────────────────────────────────────────────────────────────┐
-│  flutterware daemon  (one per project)                       │
-│                                                               │
-│  ┌──────────────────┐    ┌────────────────────────┐          │
-│  │ config compiler  │ ←  │ <project>/flutterware/ │ watch    │
-│  │ (dart compile,   │    │   config.dart           │          │
-│  │  on invalidation)│    └────────────────────────┘          │
-│  └────────┬─────────┘                                         │
-│           ▼                                                   │
-│  ┌──────────────────┐  separate process — crash-isolated;     │
-│  │ user-config      │  killed + replaced on recompile         │
-│  │ process          │                                         │
-│  └────────┬─────────┘                                         │
-│           ▲ JSON-RPC over socket                              │
-│  ┌────────┴─────────┐    ┌────────────────────────┐          │
-│  │ RPC server       │ ←  │ wrapper CLIs query     │          │
-│  │ (unix socket)    │    │ "spawning X — policy?" │          │
-│  └──────────────────┘    └────────────────────────┘          │
-│                                                               │
-│  ┌──────────────────┐                                         │
-│  │ DB writer        │ → <project>/.flutterware/flutterware.db  │
-│  └──────────────────┘                                         │
-└────────────────────────────────────────────────────────────┘
-        ▲                    ▲                      │
-        │ query              │ inner-app channel    │ sqlite_async.watch()
-┌───────┴────────┐  ┌────────┴────────┐    ┌────────▼────────────┐
-│ wrapper CLI    │  │ inner app       │    │ GUI                 │
-│ (per worktree) │  │ (e.g. flutter   │    │ (attaches any time, │
-│  └─ passthrough│  │  run) connects  │    │  one tab/worktree)  │
-│     + PTY      │  │  via env var    │    │                     │
-└────────────────┘  └─────────────────┘    └─────────────────────┘
+┌──────────────────────────────────────────────────────────────┐
+│  flutterware daemon  (one per PROJECT)                         │
+│                                                                 │
+│  ┌────────────────────────────────────────────┐               │
+│  │ per-WORKTREE config-process pool            │  each worktree │
+│  │  ┌──────────┐ ┌──────────┐ ┌──────────┐    │  has its own   │
+│  │  │ wt-A cfg │ │ wt-B cfg │ │ wt-C cfg │    │  config.dart;  │
+│  │  │ process  │ │ process  │ │ process  │    │  compiled +    │
+│  │  └──────────┘ └──────────┘ └──────────┘    │  run per wt,   │
+│  │     ▲ JSON-RPC: policy.query per worktree  │  crash-isolated│
+│  └─────┼──────────────────────────────────────┘               │
+│  ┌─────┴────────────┐   ┌────────────────────────────┐        │
+│  │ RPC server       │ ← │ wrapper invocations query  │        │
+│  │ (unix socket)    │   │ "spawning X in wt-B —       │        │
+│  └──────────────────┘   │  policy?"                   │        │
+│                          └────────────────────────────┘        │
+│  ┌──────────────────┐                                          │
+│  │ DB writer        │ → <project>/.flutterware/flutterware.db   │
+│  └──────────────────┘   (single DB — the funnel)                │
+└──────────────────────────────────────────────────────────────┘
+        ▲                  ▲                    │
+        │ query            │ inner-app channel  │ sqlite_async.watch()
+┌───────┴────────┐ ┌───────┴────────┐  ┌────────▼────────────┐
+│ wrapped        │ │ inner app /    │  │ GUI                 │
+│ flutter/dart   │ │ server connects│  │ (attaches any time, │
+│ (any worktree, │ │ back via env   │  │  one tab/worktree)  │
+│  any launcher) │ │ var (Mech. B)  │  │                     │
+└────────────────┘ └────────────────┘  └─────────────────────┘
 ```
+
+### Per-project vs per-worktree — the split
+
+The word "daemon" earlier bundled two responsibilities that belong on different
+sides of the per-project / per-worktree line:
+
+- **Per-project:** the DB, the funnel, the RPC server, the GUI-facing hub. This
+  *must* be per-project — a single DB with a `worktree` column is the entire
+  reason the GUI can show all worktrees with one `watch()` + `WHERE`. N
+  per-worktree databases would force the GUI to discover and merge them.
+- **Per-worktree:** `config.dart` compilation + execution. Each worktree is a
+  separate checkout with its own `flutterware/config.dart`; they diverge. One
+  config process cannot serve them all.
+
+**Resolution:** the daemon stays **per-project** and manages a **pool of
+per-worktree config processes** — one compiled `config.dart` per active
+worktree. A `policy.query` from a worktree's wrapper routes to *that worktree's*
+config process. The doc's original diagram already drew the config process as a
+separate, crash-isolated, recompile-replaced process; the only change is
+quantity (one per worktree instead of one).
+
+Daemon identity is per-project, not per-user (different projects may use
+different flutterware versions). The deeper complication — different *worktrees*
+of the same project pinning different flutterware versions — is deliberately
+deferred; per-worktree config processes partly absorb it, but the daemon binary
+itself stays single-version.
 
 ### Components
 
-**Wrapper CLI** — thin, per-invocation. Flow:
-1. Find project root (walk up to nearest `flutterware/` marker).
+**Wrapper (the wrapped `flutter`/`dart`)** — thin, per-invocation. Flow:
+1. Resolve project root and **worktree identity** (a worktree's `.git` is a file
+   pointing at the common dir).
 2. Find or auto-spawn the project daemon.
-3. RPC `policy.query`: "about to run `<cmd> <args>` in `<cwd>` — apply policy."
-4. Apply the returned rewrites (argv, env, GUI metadata, channel routing).
+3. RPC `policy.query`: "about to run `<cmd> <args>` in worktree `<wt>` — policy?"
+4. Apply returned rewrites (argv, env, GUI metadata, channel routing).
 5. Spawn the child under `passthrough` (PTY), stream observations to the DB
    through the daemon.
 6. If the daemon is down or policy fails → fall back to plain passthrough.
 
-**Per-project daemon** — long-lived, one per project. Owns:
-- Compilation of `<project>/flutterware/config.dart` (recompile on file
-  invalidation; not Dart hot reload — judged too heavy / low value).
-- The user-config process (run separately for crash isolation; replaced on
-  recompile).
-- A Unix-socket JSON-RPC server that wrapper CLIs query.
-- The DB writer.
+**Per-project daemon** — long-lived, one per project. Owns: the per-worktree
+config-process pool (compile-on-invalidation, crash isolation, recompile =
+kill+replace), the Unix-socket JSON-RPC server, the DB writer.
 
-Daemon identity is **per-project**, not per-user: different projects may use
-different flutterware versions. (A worktree technically can override the
-flutterware package version; that complication is deliberately ignored for now.)
+**Per-worktree config process** — runs that worktree's compiled `config.dart`,
+crash-isolated, serves `policy.query` for invocations in that worktree.
 
-**`config.dart`** — user-written policy code. Proposed API:
+**Config file** (optional, tentatively `tool/flutterware.dart`) — user-written
+policy code. Proposed API:
 
 ```dart
 import 'package:flutterware/config.dart';
@@ -93,9 +292,9 @@ void main() => Flutterware.configure((fw) {
     ctx.channels.enable(['http.logs', 'ui.buttons']);
   });
 
-  fw.command('dart test', (ctx) {
-    ctx.gui.tabLabel = 'tests';
-  });
+  // config-defined shortcut: `fw env up` from anywhere in the repo
+  fw.shortcut('env up', (ctx) => ctx.run('dart tool/local_env up',
+      cwd: 'packages/server'));
 
   // async reactions to runtime events (off the spawn critical path)
   fw.on<ChannelMessage>('http.logs', (msg) {
@@ -108,56 +307,69 @@ void main() => Flutterware.configure((fw) {
   recognized commands without running code).
 - The handler is **imperative** and `FutureOr<void>` — sync for the fast path,
   `await` allowed when needed.
-- Inside the handler: synchronous spawn-time config (`ctx.args`, `ctx.env`,
-  `ctx.gui`) is on the wrapper's critical path; `fw.on` event reactions are not.
-- A purely-declarative `fw.rules([...])` form could coexist later (e.g. for a
-  GUI-editable rules table) — not designed yet.
+- Synchronous spawn-time config (`ctx.args`, `ctx.env`, `ctx.gui`) is on the
+  wrapper's critical path; `fw.on` event reactions are not.
 
 **Communication channel** — per-invocation Unix socket. The wrapper owns the
 socket; its address is injected into the child via an environment variable so
-the inner app can connect back. Wire format: JSON frames with an envelope
-`{session, channel, payload}`. `channel` is a sub-protocol name
+the inner app (Mechanism B) can connect back. Wire format: JSON frames with an
+envelope `{session, channel, payload}`. `channel` is a sub-protocol name
 (`pty.stdout`, `http.logs`, `ui.buttons`, …); new features = new channel name,
-no protocol version bump. The config process never touches the DB or PTY
-directly — it only *requests* actions through the daemon.
+no protocol version bump.
 
 **SQLite as the bus** — the daemon writes everything (PTY output, channel
 messages, session metadata) to `<project>/.flutterware/flutterware.db`. The GUI
-reads via `sqlite_async`'s `watch()` streams and subscribes selectively with
-SQL `WHERE` clauses. No separate daemon↔GUI protocol. Cross-process change
-detection is ~100–200 ms (polling `pragma data_version`) — acceptable because
-the user's own terminal already shows real-time output; the GUI is a secondary
-observer.
+reads via `sqlite_async`'s `watch()` and subscribes selectively with SQL `WHERE`
+clauses. No separate daemon↔GUI protocol. Cross-process change detection is
+~100–200 ms (polling `pragma data_version`) — acceptable because the user's own
+terminal already shows real-time output; the GUI is a secondary observer.
 
-Active-session discovery and orphan cleanup (wrapper killed `-9`) are handled
-with a heartbeat column the wrapper bumps periodically, plus a staleness sweep.
+Active-session discovery and orphan cleanup (wrapper killed `-9`) use a
+heartbeat column the wrapper bumps periodically, plus a staleness sweep.
 
-## Config-process ↔ daemon protocol
+## Decomposition into sub-projects
 
-JSON frames over a socket, same envelope style as the rest:
+The product is too large for one spec. Four sub-projects, each its own
+spec → plan → implementation cycle, ordered by dependency:
 
-| Direction | Message | Purpose |
-|---|---|---|
-| daemon → config | `policy.query {invocation}` | "about to spawn X — policy?" |
-| config → daemon | `policy.result {args, env, gui, channels}` | the decision |
-| config → daemon | `event.subscribe {channel}` | config wants runtime events |
-| daemon → config | `event.deliver {channel, payload}` | forwards a runtime event |
-| config → daemon | `action.notify` / `action.dbWrite` / … | side effects requested |
-| config → daemon | `ready` / `error {message, stack}` | startup + failures |
-
-The config process receives concurrent `policy.query` requests (multiple
-worktrees spawning at once); each gets its own `ctx`.
+| # | Sub-project | Delivers | Depends on |
+|---|---|---|---|
+| 0 | **The SDK wrap point** | Every `flutter`/`dart` invocation intercepted (CLI/AI/IDE); can observe output + inject env; worktree identity resolved | — |
+| 1 | Central place + GUI shell | Per-project daemon + single DB, worktree tabs, lists running sessions | 0 |
+| 2 | The back-channel | `Devbar` reads injected env, connects back; one rich feature end-to-end | 0, 1 |
+| 3 | `config.dart` | Per-worktree config-process pool; `--dart-define` injection; shortcuts | 1 |
 
 ## Decisions locked
 
-- **Unix socket** for the channel (per invocation).
-- **GUI is lazy** — the CLI does everything; the GUI catches up later when opened.
-- **JSON** wire format for now, with named sub-protocol channels.
-- **Multiple simultaneous invocations** across worktrees — funnel to one
+- **Two mechanisms** — A (wrap the launch) bootstraps B (app connects back).
+- **Wrap point is the SDK's `flutter`/`dart` scripts**, not a typed prefix — so
+  IDE-launched runs are caught.
+- **Three-layer distribution** — frozen bash *walker* (global) → tiny
+  precompiled *bootstrapper* (install-SDK only, from releases) → *big CLI*
+  (daemon/DB/wrapping/GUI) built lazily on the host from the pinned pub package.
+- **Marker is a plain-text `flutter_version` file** at the repo root — not
+  `.fvmrc`, not the pubspec dependency.
+- **Two-level opt-in** — `flutter_version` → SDK management; + `flutterware`
+  pub dependency → big CLI / daemon / GUI.
+- **Two per-project pins only** — `flutter_version` and the `flutterware` pub
+  dep. The bootstrapper is **machine-global and version-floating**, not pinned
+  (it runs before any pin but `flutter_version` is readable); it is a fungible
+  installer, so it does not affect reproducibility.
+- **One frozen contract: the IDE-facing SDK path.** Install mechanism and
+  internal cache layout may evolve; the path the IDE points at may not.
+- **Optional `flutterware_version` escape hatch** — a project may pin the
+  bootstrapper version; deliberately optional, not the default.
+- **Big CLI is never distributed as a binary** — host-built; ordinary pub
+  versioning. Old projects keep building their pinned CLI and are never forced
+  to upgrade.
+- **Per-project daemon + DB** (the funnel); **per-worktree config processes**.
+- **Unix socket** for the per-invocation channel.
+- **GUI is lazy** — the CLI/wrapper does everything; the GUI catches up later.
+- **JSON** wire format, named sub-protocol channels.
+- **Multiple simultaneous invocations** across worktrees funnel to one
   per-project DB.
-- **Per-project daemon** (not per-user, not per-worktree).
-- **Compile-on-invalidation** for `config.dart` (not Dart hot reload).
-- **`config.dart` handler is `FutureOr<void>`** — async allowed.
+- **Compile-on-invalidation** for the config file (not Dart hot reload).
+- **Config handler is `FutureOr<void>`** — async allowed.
 - **Per-command tunable timeout** with a conservative global default.
 
 ## Guiding principle — always degrades to plain passthrough
@@ -167,37 +379,35 @@ Every layer can fail and the user's command still runs:
 - **Policy-query timeout** — wrapper waits ≤ the command's budget for
   `policy.result`; on timeout, spawn unmodified and log it.
 - **Atomic policy application** — if the handler times out mid-`await`, discard
-  the *entire* decision. Never apply a partial `ctx` (partial policy is silent
-  corruption).
-- **Compile failure** — daemon keeps the last-good compiled config; surfaces the
-  error in the GUI; if there is no good version, all commands fall through.
+  the *entire* decision. Never apply a partial `ctx`.
+- **Compile failure** — daemon keeps the last-good compiled config per worktree;
+  surfaces the error in the GUI; if there is no good version, commands fall
+  through.
 - **Config crash** — daemon restarts the process; repeated crashes trip a
-  circuit-breaker → config disabled, plain passthrough, error shown.
-- **Daemon unreachable** — wrapper auto-spawns it; if that fails too → plain
+  circuit-breaker → that worktree's config disabled, plain passthrough.
+- **Daemon unreachable** — wrapper auto-spawns it; if that fails → plain
   passthrough.
 
 ## Open questions
 
-- How the GUI process starts in the per-project model (manual `flutterware gui`
-  from inside the project, auto-spawn on first wrapper invocation, or a
-  standalone always-running app with a project picker). Leaning toward manual.
+- **Noise classification (sub-project 0's central question):** wrapping `dart`
+  catches the IDE's analysis server, `dart pub get`, and internal tooling — far
+  more than interesting runs. How does the wrap cheaply tell a session worth
+  observing from the dozens of noise invocations, without breaking the IDE?
+- How the GUI process starts (manual `fw gui`, auto-spawn, or standalone app
+  with a project picker). Leaning toward manual.
 - Whether a purely-declarative `fw.rules([...])` subset is worth adding for
   GUI-editable rules.
 - DB schema for sessions, PTY chunks, and channel messages.
 - Daemon auto-start mechanics (double-fork / `setsid`) and the well-known socket
   path convention.
+- Worktrees pinning different flutterware versions (deferred).
 
-## Suggested next step (separate session)
+## Next step
 
-Build the **smallest end-to-end loop** to de-risk the daemon lifecycle and the
-DB-as-bus before the `config.dart` machinery goes in:
-
-> A trivial daemon + wrapper that recognizes one hard-coded command and writes
-> its PTY output to a per-project SQLite DB — no config compilation, no channels,
-> no policy. Prove: daemon auto-start, project-root discovery, the wrapper →
-> daemon → DB write path, and a minimal GUI/CLI reader using `sqlite_async`
-> `watch()`.
-
-Once that loop is solid, layer in (in order): `config.dart` compilation +
-`policy.query`, then the per-invocation channel and sub-protocols, then richer
-GUI.
+Brainstorm and spec **sub-project 0 — the SDK wrap point**. It is the
+foundation everything else depends on, and it is the riskiest assumption (a hack
+against Flutter's SDK layout and IDE behavior). It sits on the distribution
+model above: the walker + bootstrapper get the SDK in place; sub-project 0 adds
+the wrapped `flutter`/`dart` and proves an IDE-launched `flutter run` is
+intercepted and classified without breaking the IDE.

--- a/examples/example/lib/main.dart
+++ b/examples/example/lib/main.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 
+const _fwMarker = String.fromEnvironment('FW_MARKER', defaultValue: '<none>');
+
 void main() {
   runApp(const MyApp());
 }
@@ -65,6 +67,9 @@ class _MyHomePageState extends State<MyHomePage> {
       body: ListView(
         padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 20),
         children: [
+          Text('FW_MARKER: $_fwMarker',
+              key: const Key('fw-marker'),
+              style: const TextStyle(fontWeight: FontWeight.bold)),
           Text('Language: ${Localizations.localeOf(context).languageCode}'),
           Text(MaterialLocalizations.of(context).alertDialogLabel),
           Text(MaterialLocalizations.of(context).invalidTimeLabel),


### PR DESCRIPTION
## Summary

First sub-project of the command-wrapper tool — the riskiest piece. Wraps the `flutter`/`dart` scripts an IDE invokes so every run (CLI, AI, or IDE) is intercepted, classified, observed, and can have a `--dart-define` injected, degrading to plain passthrough on any failure.

- **De-risking spike result** (`docs/.../subproject-0-ide-launch-finding.md`): IntelliJ launches runs as a direct `flutter run --machine` with `--dart-define` values in plain argv — so injection is a simple argv rewrite. The feared "daemon JSON-RPC proxy" branch was eliminated before any code was written.
- **What's delivered:** a per-project SDK *mirror facade* (`<project>/flutterware/sdk/`, symlinks the pristine SDK + two bash shims), a pure-bash fast path (marker walk-up → classify → audit log → dispatch), the `flutterware wrap run`/`install` CLI (argv-rewrite `--dart-define` injection, PTY/pipe transport reusing phase-1 passthrough, local session sink), and an `FW_MARKER` probe widget in the example app.
- **Entirely dormant when merged:** nothing in the existing codebase invokes it; the shims only exist after an explicit `wrap install`, and the shim only intercepts when a `flutter_version` marker is present (none is committed). The only modified production files are an optional, backward-compatible `captureSink` param on `runUnderPty` and a 5-line probe widget in `examples/example`.
- Includes the implementation spec, plan, and a manual smoke-test checklist. Out of scope (later sub-projects): the daemon + DB + GUI, the back-channel, `config.dart`, and the walker/bootstrapper/SDK-download.

## Test plan

- [x] 44 automated tests pass (`cd app && flutter test test/wrap/ test/passthrough/`) — dart-define injection, project/worktree resolution, session sink, transport, the `wrap run` command + degrade paths, and an end-to-end test driving the rendered bash shim.
- [x] Analyzer clean on all new/changed files; `dart tool/prepare_submit.dart` produces no diff.
- [ ] Manual smoke test against a real IDE — see `docs/superpowers/specs/2026-05-15-subproject-0-manual-smoke.md` (compile the wrap exe, install the mirror, point IntelliJ at it, confirm `flutter run` is intercepted and `FW_MARKER` reaches the running app).

🤖 Generated with [Claude Code](https://claude.com/claude-code)