### PR TITLE
Copy a preview, and compile the catalog into a page

### DIFF
--- a/app/lib/src/catalog/catalog_view.dart
+++ b/app/lib/src/catalog/catalog_view.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'dart:math' as math;
 
 import 'package:device_frame/device_frame.dart';
+import 'package:file_selector/file_selector.dart';
 import 'package:flutterware/ui_catalog.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -11,6 +12,7 @@ import '../address/address_scope.dart';
 import '../embedder/embedded_engine.dart';
 import '../embedder/protocol.dart';
 import '../ui/design/design.dart';
+import '../utils/image_clipboard.dart';
 import 'catalog_params.dart';
 import 'catalog_devices.dart';
 import 'catalog_entry.dart';
@@ -215,9 +217,35 @@ class _CatalogViewState extends State<CatalogView> {
       bindings: {
         const SingleActivator(LogicalKeyboardKey.keyR, meta: true): _reload,
         const SingleActivator(LogicalKeyboardKey.keyR, control: true): _reload,
+        // Shifted, because plain ⌘C belongs to whatever text has the selection.
+        const SingleActivator(LogicalKeyboardKey.keyC, meta: true, shift: true):
+            _copyPreview,
+        const SingleActivator(
+          LogicalKeyboardKey.keyC,
+          control: true,
+          shift: true,
+        ): _copyPreview,
       },
       child: _buildBody(context),
     );
+  }
+
+  /// The same thing the top bar's copy button does — see [_capturePreview] for
+  /// why the two share their capture rather than each having one.
+  void _copyPreview() {
+    if (!ImageClipboard.isSupported) return;
+    unawaited(() async {
+      try {
+        var png = await _capturePreview(context, _session);
+        if (png != null) await ImageClipboard.setPng(png);
+      } catch (e) {
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text('Could not copy the preview: $e')),
+          );
+        }
+      }
+    }());
   }
 
   void _reload() {
@@ -1194,6 +1222,7 @@ class _TopBar extends StatelessWidget {
               ),
             ),
           ),
+          _CaptureButtons(session: session),
           if (device != null)
             IconButton(
               icon: Icon(
@@ -1209,6 +1238,176 @@ class _TopBar extends StatelessWidget {
             ),
         ],
       ),
+    );
+  }
+}
+
+/// The live guest's next frame, cropped to whatever node is selected.
+///
+/// Shared by the top bar's buttons and the panel's ⌘⇧C. A shortcut that copied
+/// the whole frame while the button beside it copied the selected node would be
+/// two behaviours wearing one name.
+///
+/// Null when there is no guest to ask — the panel is compiling, or the last
+/// build failed — which is a refusal rather than an error: there is nothing on
+/// screen to be a picture of.
+Future<Uint8List?> _capturePreview(
+  BuildContext context,
+  CatalogSession session,
+) async {
+  var engine = session.engine;
+  if (engine == null || engine.phase != EmbeddedEnginePhase.running) {
+    return null;
+  }
+  // Only when the tree still describes what is on screen: a rect from a read
+  // taken before the last switch would crop this frame to a box measured in
+  // another one.
+  var id = AddressScope.params(context)['node'];
+  var node = id == null ? null : session.treeForSelection?.nodeAt(id);
+  return engine.capturePng(
+    crop: node?.layout,
+    // A crop arrives in the guest's logical coordinates; its pixels are in the
+    // device's.
+    pixelRatio: _deviceOf(context, session)?.pixelRatio ?? 1,
+  );
+}
+
+/// The node the Elements tab has selected, when its tree still describes what
+/// is on screen.
+InspectNode? _croppedNode(BuildContext context, CatalogSession session) {
+  var id = AddressScope.params(context)['node'];
+  return id == null ? null : session.treeForSelection?.nodeAt(id);
+}
+
+/// Copy the preview to the clipboard, or save it to a file.
+///
+/// These photograph the **live** guest, which is why they are here rather than
+/// being the `screenshot` action with a button on it. What they capture is the
+/// demo as you left it — the dropdown you opened, the tab you switched to, the
+/// row you scrolled to — and no fresh render performs your clicks. `fw` cannot
+/// offer the same thing and deliberately refuses to pretend otherwise: an
+/// attached session gives it a VM service and no frames. The panel is the only
+/// place that holds the socket the picture comes over.
+///
+/// With a node selected in the Elements tab they capture that node's box
+/// instead of the whole frame — cropped out of the real composited frame, so it
+/// is the widget among its surroundings rather than the different picture that
+/// re-rendering it alone would produce.
+class _CaptureButtons extends StatefulWidget {
+  const _CaptureButtons({required this.session});
+
+  final CatalogSession session;
+
+  @override
+  State<_CaptureButtons> createState() => _CaptureButtonsState();
+}
+
+class _CaptureButtonsState extends State<_CaptureButtons> {
+  /// Set while a capture is in flight, so a second click cannot start one on
+  /// top of it — the two would write the same scratch path.
+  var _busy = false;
+
+  /// Flips the copy icon to a tick for a moment. A 36px bar has no room for a
+  /// message, and a button that looks identical before and after is a button
+  /// you press twice.
+  Timer? _copied;
+
+  @override
+  void dispose() {
+    _copied?.cancel();
+    super.dispose();
+  }
+
+  Future<Uint8List?> _capture() async {
+    setState(() => _busy = true);
+    try {
+      return await _capturePreview(context, widget.session);
+    } catch (e) {
+      if (mounted) _complain('$e');
+      return null;
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  Future<void> _copy() async {
+    var png = await _capture();
+    if (png == null || !mounted) return;
+    try {
+      await ImageClipboard.setPng(png);
+      if (!mounted) return;
+      _copied?.cancel();
+      setState(() {});
+      _copied = Timer(const Duration(milliseconds: 1400), () {
+        if (mounted) setState(() {});
+      });
+    } catch (e) {
+      if (mounted) _complain('$e');
+    }
+  }
+
+  Future<void> _save() async {
+    var png = await _capture();
+    if (png == null || !mounted) return;
+    var location = await getSaveLocation(
+      suggestedName: _suggestedName(),
+      acceptedTypeGroups: const [
+        XTypeGroup(label: 'PNG image', extensions: ['png']),
+      ],
+    );
+    if (location == null) return;
+    try {
+      await File(location.path).writeAsBytes(png);
+    } catch (e) {
+      if (mounted) _complain('$e');
+    }
+  }
+
+  /// Named after what it is a picture *of*, so a directory of these is still
+  /// readable a week later. Matches what the `screenshot` action derives.
+  String _suggestedName() {
+    var entry = widget.session.selected ?? widget.session.active;
+    var base = entry == null
+        ? 'catalog'
+        : entry.id.replaceAll(RegExp(r'[^A-Za-z0-9]+'), '-');
+    var node = AddressScope.params(context)['node'];
+    return '$base${node == null ? '' : '-node-${node.replaceAll('/', '-')}'}.png';
+  }
+
+  /// Failures only. A capture that worked says so by changing the icon; one
+  /// that did not has a reason, and a reason needs words.
+  void _complain(String message) => ScaffoldMessenger.of(context).showSnackBar(
+    SnackBar(content: Text('Could not capture the preview: $message')),
+  );
+
+  @override
+  Widget build(BuildContext context) {
+    var running = widget.session.engine?.phase == EmbeddedEnginePhase.running;
+    var enabled = running && !_busy;
+    var cropped = _croppedNode(context, widget.session) != null;
+    var what = cropped ? 'the selected node' : 'the preview';
+    var justCopied = _copied?.isActive ?? false;
+
+    return Row(
+      spacing: FwSpacing.xs,
+      children: [
+        IconButton(
+          icon: Icon(justCopied ? Icons.check : Icons.content_copy, size: 15),
+          padding: EdgeInsets.zero,
+          constraints: const BoxConstraints.tightFor(width: 24, height: 24),
+          tooltip: ImageClipboard.isSupported
+              ? 'Copy $what (⌘⇧C)'
+              : 'Copying an image is not implemented on this platform',
+          onPressed: enabled && ImageClipboard.isSupported ? _copy : null,
+        ),
+        IconButton(
+          icon: const Icon(Icons.save_alt, size: 15),
+          padding: EdgeInsets.zero,
+          constraints: const BoxConstraints.tightFor(width: 24, height: 24),
+          tooltip: 'Save $what as PNG',
+          onPressed: enabled ? _save : null,
+        ),
+      ],
     );
   }
 }

--- a/app/lib/src/catalog/catalog_wrapper.dart
+++ b/app/lib/src/catalog/catalog_wrapper.dart
@@ -1,0 +1,123 @@
+import 'dart:io';
+
+import 'package:analyzer/dart/analysis/utilities.dart';
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:path/path.dart' as p;
+
+import 'catalog_entry.dart';
+
+/// Writes the one file that stands between a demo and whoever renders it: the
+/// annotation evaluated as Dart, and the demo's builder, reachable by name.
+///
+/// Shared by the guest's entrypoint and by the web build, and it has to be
+/// shared rather than merely similar. What is encoded here is the demo's own
+/// *scope* — which imports were in it, what a relative URI resolves against,
+/// why the file is imported twice — and a second copy of those rules would go
+/// out of date silently: the symptom is a demo that renders in the panel and
+/// not on the page, or the reverse.
+class CatalogWrapperWriter {
+  CatalogWrapperWriter({required this.outputDir, required this.projectRoot});
+
+  /// Where the wrapper is written. Relative URIs inside it resolve from here.
+  final String outputDir;
+
+  /// Resolves each entry's [CatalogEntry.path].
+  final String projectRoot;
+
+  /// The source of `entry_<index>.dart` for [entry].
+  String source(CatalogEntry entry, int index) {
+    var demo = p.join(projectRoot, entry.path);
+    // The demo's own imports, and only the demo's. A shell used to contribute
+    // its imports too, because the generated call named an axis's enum by type
+    // and that type is in scope where the shell is written rather than where
+    // the demo is. Axes are declared inside the shell now, so nothing the shell
+    // knows about has to be nameable from here — which is what removes the one
+    // case where two files' import sets were merged and could collide.
+    var carried = carriedImports(demo);
+    return '''
+// GENERATED — do not edit.
+// Imports carried from the demo file: the annotation is written in *its* scope,
+// so anything the annotation names has to resolve here too.
+${carried.join('\n')}
+// Unconditional: the getters below are typed, and a demo file is not obliged
+// to import widgets itself.
+import 'package:flutter/widgets.dart';
+import 'package:flutterware/ui_catalog.dart';
+
+// The demo file twice, and both are load-bearing. Prefixed, because fwBuilder
+// has to name the entry unambiguously. Unprefixed, because the annotation may
+// name something the demo file *declares* rather than imports — a wrapper
+// written beside the demo it wraps is the ordinary case — and a file does not
+// import itself, so nothing else would put that in scope.
+//
+// Together these reproduce the demo's own scope, which is the one the
+// annotation was written in. The gap that remains is privacy: a `_kName` in the
+// annotation is visible where it was written and not here.
+import '${relative(demo)}';
+import '${relative(demo)}' as fw$index;
+
+// The annotation, evaluated as Dart rather than interpreted statically.
+// `transform()` returns a plain Preview and drops id/figma/formFactor, so the
+// annotation itself is kept alongside it.
+//
+// Getters, not consts. A const holding a function tear-off — every `wrapper:`
+// is one — is inlined into whichever library reads it, so the entrypoint's
+// constant pool ends up referring to a procedure in the demo's own file. A
+// reload that carries only the entrypoint then has to re-resolve that
+// reference against a library it does not contain, and the guest renders
+// `Lookup failed: <wrapper> in @methods in file:...` instead of the demo.
+// Behind a getter there is nothing to inline and nothing to re-resolve.
+Demo get fwDemo => ${entry.annotation};
+
+Widget Function() get fwBuilder => fw$index.${entry.symbol};
+''';
+  }
+
+  /// The demo file's own import and export directives, with relative URIs
+  /// rewritten to resolve from [outputDir].
+  ///
+  /// Demo files live outside `lib/` and so have no `package:` URI of their own;
+  /// a carried `../utils/shell.dart` would not resolve from the generated
+  /// directory without this.
+  ///
+  /// Parsed rather than matched. The regex this replaced was line-oriented, so
+  /// a directive written across two lines — which `dart format` produces as
+  /// soon as a `show` clause makes it long enough — was carried as a fragment
+  /// or dropped. Everything a directive can carry (`show`, `hide`, `as`,
+  /// `deferred`, configurable imports) is kept here by rewriting only the URI
+  /// literals inside the directive's own source and leaving the rest alone.
+  /// `part` is deliberately not carried: a part belongs to its own library.
+  List<String> carriedImports(String source) {
+    var unit = parseString(
+      content: File(source).readAsStringSync(),
+      throwIfDiagnostics: false,
+    ).unit;
+
+    var carried = <String>[];
+    for (var directive in unit.directives) {
+      if (directive is! NamespaceDirective) continue;
+      var uri = directive.uri.stringValue;
+      // `package:flutterware/ui_catalog.dart` is emitted unconditionally below.
+      if (uri == null || uri == 'package:flutterware/ui_catalog.dart') continue;
+
+      var text = directive.toSource();
+      for (var literal in [
+        directive.uri,
+        for (var configuration in directive.configurations) configuration.uri,
+      ]) {
+        var written = literal.stringValue;
+        // A `package:`/`dart:` URI means the same thing from anywhere.
+        if (written == null || written.contains(':')) continue;
+        var target = p.normalize(p.join(p.dirname(source), written));
+        text = text.replaceFirst(literal.toSource(), "'${relative(target)}'");
+      }
+      carried.add(text);
+    }
+    return carried;
+  }
+
+  /// Always `/`-separated: this ends up inside a URI literal, where a Windows
+  /// separator is an escape rather than a path.
+  String relative(String target) =>
+      p.split(p.relative(target, from: outputDir)).join('/');
+}

--- a/app/lib/src/catalog/entrypoint_generator.dart
+++ b/app/lib/src/catalog/entrypoint_generator.dart
@@ -1,10 +1,9 @@
 import 'dart:io';
 
-import 'package:analyzer/dart/analysis/utilities.dart';
-import 'package:analyzer/dart/ast/ast.dart';
 import 'package:path/path.dart' as p;
 
 import 'catalog_entry.dart';
+import 'catalog_wrapper.dart';
 
 /// Writes the guest's entrypoint: one wrapper file per entry ever visited, plus
 /// an accumulating `main.dart` that selects the active one.
@@ -35,6 +34,13 @@ class EntrypointGenerator {
   /// rendering, so a headless harness can assert what the guest actually shows
   /// rather than only that a reload reported success.
   final bool emitProbe;
+
+  /// The wrapper files themselves, written the same way the web build writes
+  /// them — see [CatalogWrapperWriter] for why that sharing is structural.
+  late final _wrappers = CatalogWrapperWriter(
+    outputDir: outputDir,
+    projectRoot: projectRoot,
+  );
 
   final _wrapperIndex = <String, int>{};
 
@@ -120,99 +126,8 @@ class EntrypointGenerator {
     _wrapperIndex[entry.id] = index;
     _visited.add(entry);
     var wrapper = File(p.join(outputDir, 'entry_$index.dart'));
-    wrapper.writeAsStringSync(_wrapper(entry, index));
+    wrapper.writeAsStringSync(_wrappers.source(entry, index));
     return [wrapper.uri];
-  }
-
-  String _wrapper(CatalogEntry entry, int index) {
-    var source = p.join(projectRoot, entry.path);
-    // The demo's own imports, and only the demo's. A shell used to contribute
-    // its imports too, because the generated call named an axis's enum by type
-    // and that type is in scope where the shell is written rather than where
-    // the demo is. Axes are declared inside the shell now, so nothing the shell
-    // knows about has to be nameable from here — which is what removes the one
-    // case where two files' import sets were merged and could collide.
-    var carried = _carriedImports(source);
-    return '''
-// GENERATED — do not edit.
-// Imports carried from the demo file: the annotation is written in *its* scope,
-// so anything the annotation names has to resolve here too.
-${carried.join('\n')}
-// Unconditional: the getters below are typed, and a demo file is not obliged
-// to import widgets itself.
-import 'package:flutter/widgets.dart';
-import 'package:flutterware/ui_catalog.dart';
-
-// The demo file twice, and both are load-bearing. Prefixed, because fwBuilder
-// has to name the entry unambiguously. Unprefixed, because the annotation may
-// name something the demo file *declares* rather than imports — a wrapper
-// written beside the demo it wraps is the ordinary case — and a file does not
-// import itself, so nothing else would put that in scope.
-//
-// Together these reproduce the demo's own scope, which is the one the
-// annotation was written in. The gap that remains is privacy: a `_kName` in the
-// annotation is visible where it was written and not here.
-import '${_relative(source)}';
-import '${_relative(source)}' as fw$index;
-
-// The annotation, evaluated as Dart rather than interpreted statically.
-// `transform()` returns a plain Preview and drops id/figma/formFactor, so the
-// annotation itself is kept alongside it.
-//
-// Getters, not consts. A const holding a function tear-off — every `wrapper:`
-// is one — is inlined into whichever library reads it, so the entrypoint's
-// constant pool ends up referring to a procedure in the demo's own file. A
-// reload that carries only the entrypoint then has to re-resolve that
-// reference against a library it does not contain, and the guest renders
-// `Lookup failed: <wrapper> in @methods in file:...` instead of the demo.
-// Behind a getter there is nothing to inline and nothing to re-resolve.
-Demo get fwDemo => ${entry.annotation};
-
-Widget Function() get fwBuilder => fw$index.${entry.symbol};
-''';
-  }
-
-  /// The demo file's own import and export directives, with relative URIs
-  /// rewritten to resolve from [outputDir].
-  ///
-  /// Demo files live outside `lib/` and so have no `package:` URI of their own;
-  /// a carried `../utils/shell.dart` would not resolve from the generated
-  /// directory without this.
-  ///
-  /// Parsed rather than matched. The regex this replaced was line-oriented, so
-  /// a directive written across two lines — which `dart format` produces as
-  /// soon as a `show` clause makes it long enough — was carried as a fragment
-  /// or dropped. Everything a directive can carry (`show`, `hide`, `as`,
-  /// `deferred`, configurable imports) is kept here by rewriting only the URI
-  /// literals inside the directive's own source and leaving the rest alone.
-  /// `part` is deliberately not carried: a part belongs to its own library.
-  List<String> _carriedImports(String source) {
-    var unit = parseString(
-      content: File(source).readAsStringSync(),
-      throwIfDiagnostics: false,
-    ).unit;
-
-    var carried = <String>[];
-    for (var directive in unit.directives) {
-      if (directive is! NamespaceDirective) continue;
-      var uri = directive.uri.stringValue;
-      // `package:flutterware/ui_catalog.dart` is emitted unconditionally below.
-      if (uri == null || uri == 'package:flutterware/ui_catalog.dart') continue;
-
-      var text = directive.toSource();
-      for (var literal in [
-        directive.uri,
-        for (var configuration in directive.configurations) configuration.uri,
-      ]) {
-        var written = literal.stringValue;
-        // A `package:`/`dart:` URI means the same thing from anywhere.
-        if (written == null || written.contains(':')) continue;
-        var target = p.normalize(p.join(p.dirname(source), written));
-        text = text.replaceFirst(literal.toSource(), "'${_relative(target)}'");
-      }
-      carried.add(text);
-    }
-    return carried;
   }
 
   String _entrypoint(CatalogEntry active) {
@@ -355,7 +270,4 @@ class _CatalogHost extends StatelessWidget {
     );
   });
 ''';
-
-  String _relative(String target) =>
-      p.split(p.relative(target, from: outputDir)).join('/');
 }

--- a/app/lib/src/catalog/headless_catalog.dart
+++ b/app/lib/src/catalog/headless_catalog.dart
@@ -20,8 +20,8 @@ import 'package:flutterware/src/ui_catalog/axis.dart';
 // ignore: implementation_imports
 import 'package:flutterware/src/ui_catalog/knob.dart';
 
+import '../embedder/frame_capture.dart';
 import '../embedder/protocol.dart';
-import '../embedder/raw_frame.dart';
 import 'catalog_params.dart';
 import 'debug_flags.dart';
 import 'devices.dart';
@@ -691,7 +691,15 @@ class _GuestSession {
     patience: InspectPatience.headless,
   );
 
-  final _captures = <String, Completer<void>>{};
+  /// The capture exchange, shared with the GUI's live engine — see
+  /// [FrameCapture].
+  late final _capture = FrameCapture(
+    send: (message) async {
+      _connection.add(encodeMessage(message));
+      await _connection.flush();
+    },
+    workDir: _workDir,
+  );
 
   static Future<_GuestSession> start({
     required String hostPath,
@@ -770,15 +778,9 @@ class _GuestSession {
 
   void _onData(List<int> chunk) {
     for (var message in _reader.addBytes(chunk)) {
-      if (message is CapturedMessage) {
-        _captures.remove(message.path)?.complete();
-      } else if (message is ErrorMessage) {
-        for (var pending in _captures.values) {
-          if (!pending.isCompleted) {
-            pending.completeError(StateError(message.message));
-          }
-        }
-        _captures.clear();
+      if (_capture.acknowledge(message)) continue;
+      if (message is ErrorMessage) {
+        _capture.failAll(StateError(message.message));
       }
     }
   }
@@ -1028,118 +1030,15 @@ class _GuestSession {
     /// Logical-to-physical, for turning either of the above into pixels.
     double pixelRatio = 1,
   }) async {
-    var rawFrame = p.join(_workDir, 'screenshot.rawframe');
-    var raw = File(rawFrame);
-    if (raw.existsSync()) raw.deleteSync();
-
-    var done = _captures[rawFrame] = Completer<void>();
-    _connection.add(encodeMessage(CaptureMessage(rawFrame)));
-    await _connection.flush();
-    await done.future.timeout(const Duration(seconds: 30));
-
-    var image = decodeRawFrame(raw.readAsBytesSync());
-    // Annotate before cropping, so a box on a node partly outside the crop is
-    // clipped with the picture rather than drawn against its edge.
-    if (annotate.isNotEmpty) image = _annotate(image, annotate, pixelRatio);
-    if (crop != null) image = _crop(image, crop, pixelRatio);
+    var image = await _capture.capture(
+      crop: crop,
+      annotate: annotate,
+      pixelRatio: pixelRatio,
+    );
     var file = File(output);
     file.parent.createSync(recursive: true);
     file.writeAsBytesSync(img.encodePng(image));
-    raw.deleteSync();
     return file;
-  }
-
-  /// One node per distinct box, outermost kept.
-  ///
-  /// Most of a summary tree lays nothing out of its own: a provider, a builder
-  /// and the widget under them share one rect, so drawing every node draws the
-  /// same rectangle six times and stacks six labels on one corner. The first
-  /// version did exactly that and was unreadable — which is the difference
-  /// between a feature that exists and one that answers the question.
-  ///
-  /// Outermost wins because it is the shorter id and the one a caller is more
-  /// likely to have meant; the inner ones are still in the tree for anyone who
-  /// wants them.
-  static List<InspectNode> _distinctBoxes(List<InspectNode> nodes) {
-    var seen = <String>{};
-    return [
-      for (var node in nodes)
-        if (node.layout case var l?)
-          if (seen.add('${l.x},${l.y},${l.width},${l.height}')) node,
-    ];
-  }
-
-  /// The frame, cut to one node's box.
-  ///
-  /// Cropped out of the real composited frame rather than re-rendered in
-  /// isolation, which is what `ext.flutter.inspector.screenshot` would do: a
-  /// widget photographed away from its surroundings is a different picture, and
-  /// usually not the one the question was about.
-  ///
-  /// Clamped to the frame, because a node may legitimately sit partly outside
-  /// it — that is what an overflow *is* — and a crop that threw would refuse to
-  /// show the one case worth looking at.
-  static img.Image _crop(img.Image image, InspectLayout rect, double ratio) {
-    var x = (rect.x * ratio).round().clamp(0, image.width - 1);
-    var y = (rect.y * ratio).round().clamp(0, image.height - 1);
-    return img.copyCrop(
-      image,
-      x: x,
-      y: y,
-      width: (rect.width * ratio).round().clamp(1, image.width - x),
-      height: (rect.height * ratio).round().clamp(1, image.height - y),
-    );
-  }
-
-  /// A box and an id over each node.
-  ///
-  /// The point is the id: an agent reads a tree, gets `0/1/2`, and then gets a
-  /// picture with `0/1/2` written on the thing it names. Without that the tree
-  /// and the screenshot are two observations of the same frame with nothing
-  /// joining them.
-  static img.Image _annotate(
-    img.Image image,
-    List<InspectNode> nodes,
-    double ratio,
-  ) {
-    for (var node in _distinctBoxes(nodes)) {
-      if (node.layout case var layout?) {
-        var x = (layout.x * ratio).round();
-        var y = (layout.y * ratio).round();
-        var w = (layout.width * ratio).round();
-        var h = (layout.height * ratio).round();
-        img.drawRect(
-          image,
-          x1: x,
-          y1: y,
-          x2: x + w - 1,
-          y2: y + h - 1,
-          color: img.ColorRgb8(255, 0, 128),
-        );
-        var label = node.id.isEmpty ? 'root' : node.id;
-        // A filled strip behind it: these are drawn over a rendered UI, and
-        // magenta-on-whatever-was-there is not always legible.
-        var labelX = x + 2;
-        var labelY = y < 16 ? y + 2 : y - 15;
-        img.fillRect(
-          image,
-          x1: labelX - 1,
-          y1: labelY - 1,
-          x2: labelX + label.length * 8,
-          y2: labelY + 14,
-          color: img.ColorRgb8(255, 0, 128),
-        );
-        img.drawString(
-          image,
-          label,
-          font: img.arial14,
-          x: labelX,
-          y: labelY,
-          color: img.ColorRgb8(255, 255, 255),
-        );
-      }
-    }
-    return image;
   }
 
   Future<void> close() async {

--- a/app/lib/src/catalog/web_app_generator.dart
+++ b/app/lib/src/catalog/web_app_generator.dart
@@ -1,0 +1,202 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+
+import 'catalog_entry.dart';
+import 'catalog_tree.dart';
+import 'catalog_wrapper.dart';
+
+/// Writes a standalone Flutter app that browses the whole catalog, for
+/// `flutter build web` to turn into a page.
+///
+/// The old catalog was a widget you put in your own `main.dart`, so building it
+/// for the web was building your app. Entries are discovered now and rendered
+/// one at a time into a guest engine, so there is no such app any more — this
+/// writes one.
+///
+/// **It hosts the old [UICatalog] widget**, and that is not a stopgap. The
+/// tree, the search, the device frames and the parameters panel all already
+/// work against the model the new demos produce: a demo declares its knobs by
+/// calling `context.uiCatalog.parameters.*`, which is the same API the old
+/// catalog reads, and `DetailView` owns an `EditableParameters` and installs
+/// the provider itself. Knobs travel over the VM service in the GUI only
+/// because the panel is in another process; here the panel and the demo are one
+/// isolate and there is no wire at all.
+///
+/// What it does *not* carry over is the top bar's axes: a `CatalogShell` still
+/// declares them, and with nothing driving `CatalogAxes` they answer with the
+/// defaults the shell wrote.
+class WebAppGenerator {
+  WebAppGenerator({
+    required this.outputDir,
+    required this.projectRoot,
+    required this.title,
+  });
+
+  /// Where the generated sources go. Cleared on each run, so it must not be a
+  /// directory anything else owns.
+  final String outputDir;
+
+  /// Resolves each entry's [CatalogEntry.path].
+  final String projectRoot;
+
+  /// What the page calls itself, in the menu's header.
+  final String title;
+
+  late final _wrappers = CatalogWrapperWriter(
+    outputDir: outputDir,
+    projectRoot: projectRoot,
+  );
+
+  String get entrypointPath => p.join(outputDir, 'main.dart');
+
+  /// Writes a wrapper per entry and the `main.dart` that browses them.
+  ///
+  /// Returns the entrypoint's path, which is what `flutter build web -t` takes.
+  String generate(List<CatalogEntry> entries) {
+    var dir = Directory(outputDir);
+    // Cleared rather than merged into: an entry deleted since the last build
+    // would otherwise keep its wrapper on disk, and a stale wrapper naming a
+    // demo that no longer exists fails the build with a resolution error
+    // pointing at generated code.
+    if (dir.existsSync()) dir.deleteSync(recursive: true);
+    dir.createSync(recursive: true);
+
+    var index = <String, int>{};
+    for (var (i, entry) in entries.indexed) {
+      index[entry.id] = i;
+      File(
+        p.join(outputDir, 'entry_$i.dart'),
+      ).writeAsStringSync(_wrappers.source(entry, i));
+    }
+
+    File(entrypointPath).writeAsStringSync(_main(entries, index));
+    return entrypointPath;
+  }
+
+  String _main(List<CatalogEntry> entries, Map<String, int> index) {
+    var imports = StringBuffer();
+    for (var i = 0; i < entries.length; i++) {
+      imports.writeln("import 'entry_$i.dart' as fw$i;");
+    }
+
+    // The same tree the panel draws, from the same function, so an entry sits
+    // in the same place on the page as it does in the GUI. Building a second
+    // arrangement here would be two answers to "where is this demo".
+    var tree = buildCatalogTree(entries);
+
+    return '''
+// GENERATED — do not edit.
+import 'package:flutter/widgets.dart';
+import 'package:flutterware/ui_catalog.dart';
+
+$imports
+void main() {
+  runApp(
+    UICatalog(
+      title: ${_literal(title)},
+      catalog: () => _catalog,
+      // A pass-through, because in this model the chrome is the entry's own:
+      // `@Demo(wrapper:)` supplies the MaterialApp, exactly as it does for the
+      // guest, whose host adds nothing either. An entry with no wrapper still
+      // has the catalog's own MaterialApp above it for a Directionality and a
+      // theme.
+      appBuilder: (context, child) => child,
+    ),
+  );
+}
+
+// A getter, never a top-level final: the leaves below are widgets, and widgets
+// built once and handed back on every build are the ones that do not rebuild
+// when a knob moves.
+Map<String, dynamic> get _catalog => ${_map(tree, index, 1)};
+
+/// One entry, wrapped the way the guest wraps it.
+///
+/// Wrapper only — not `size`, `theme` or `brightness`. That is what
+/// `_CatalogHost` in the guest's entrypoint applies, and the two have to agree:
+/// an entry that looks one way in the panel and another on the page is worse
+/// than one that ignores an annotation in both.
+Widget _entry(Demo demo, Widget Function() builder) {
+  var wrapper = demo.transform().wrapper;
+  var child = builder();
+  return wrapper == null ? child : wrapper(child);
+}
+''';
+  }
+
+  /// The nested map [UICatalog] reads: a `Map` is a folder, anything else is a
+  /// leaf.
+  String _map(List<CatalogNode> nodes, Map<String, int> index, int depth) {
+    var pad = '  ' * depth;
+    var inner = '  ' * (depth + 1);
+    if (nodes.isEmpty) return '<String, dynamic>{}';
+    // The map is keyed by what a row *says*, and two rows are allowed to say
+    // the same thing — discovery rejects a duplicate id, not a duplicate name,
+    // so `demo/a.dart` and `demo/b.dart` may both declare `@Demo(name:
+    // 'Default')`. A folder may also share a name with an entry beside it.
+    // Emitted as-is that is a repeated key in a map literal: the last one wins
+    // at run time and the others are simply not on the page, which is the one
+    // failure this generator must not have — the panel keys its tree by id and
+    // shows them all.
+    var taken = <String>{};
+    var buffer = StringBuffer('<String, dynamic>{\n');
+    for (var node in nodes) {
+      switch (node) {
+        case CatalogBranch(:var children):
+          buffer.writeln(
+            '$inner${_literal(_uniqueKey(node.label, null, taken))}: '
+            '${_map(children, index, depth + 1)},',
+          );
+        case CatalogLeaf(:var entry):
+          var i = index[entry.id]!;
+          var key = _uniqueKey(node.label, entry, taken);
+          buffer.writeln(
+            '$inner${_literal(key)}: _entry(fw$i.fwDemo, fw$i.fwBuilder),',
+          );
+      }
+    }
+    buffer.write('$pad}');
+    return buffer.toString();
+  }
+
+  /// [label], or something derived from it that no sibling has taken yet.
+  ///
+  /// The suffix is chosen to be worth reading rather than merely unique: the
+  /// symbol is what tells two same-named demos apart in the source, and it is
+  /// what `fw` prints. Two files declaring the same name *and* the same symbol
+  /// fall back to the entry id, which discovery guarantees is unique — so this
+  /// always terminates, and a branch with no entry behind it counts up.
+  static String _uniqueKey(
+    String label,
+    CatalogEntry? entry,
+    Set<String> taken,
+  ) {
+    if (taken.add(label)) return label;
+    if (entry != null) {
+      for (var candidate in [
+        '$label (${entry.symbol})',
+        '$label (${entry.id})',
+      ]) {
+        if (taken.add(candidate)) return candidate;
+      }
+    }
+    for (var n = 2; ; n++) {
+      if (taken.add('$label ($n)')) return '$label ($n)';
+    }
+  }
+
+  /// A single-quoted Dart string literal.
+  ///
+  /// Escaped rather than raw: an entry's display name is written by a human in
+  /// an annotation and may hold a quote or a `$`, and a raw string cannot
+  /// escape its own delimiter.
+  static String _literal(String value) {
+    var escaped = value
+        .replaceAll(r'\', r'\\')
+        .replaceAll("'", r"\'")
+        .replaceAll(r'$', r'\$')
+        .replaceAll('\n', r'\n');
+    return "'$escaped'";
+  }
+}

--- a/app/lib/src/catalog/web_build.dart
+++ b/app/lib/src/catalog/web_build.dart
@@ -1,0 +1,186 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+
+import 'catalog_entry.dart';
+import 'web_app_generator.dart';
+
+/// Builds the catalog as a browsable web page.
+///
+/// Two steps, and the second is just `flutter build web`: [WebAppGenerator]
+/// writes an app that browses every entry, and the tool compiles it. Nothing
+/// here talks to the compiler daemon or the embedder — a page is not a frame
+/// somebody captured, it is the demos themselves running in a browser.
+///
+/// **Built from the target package**, not from a generated package of its own.
+/// The package's `web/index.html`, its assets and its fonts are all declared
+/// there, and a build run from anywhere else would have to reproduce them —
+/// which is how a catalog page ends up missing exactly the images the demos are
+/// about.
+class WebCatalogBuilder {
+  WebCatalogBuilder({
+    required this.flutterExecutable,
+    required this.packageRoot,
+    required this.title,
+  });
+
+  final String flutterExecutable;
+
+  /// The package whose demos these are. `flutter build web` runs here.
+  final String packageRoot;
+
+  final String title;
+
+  /// Where the generated app is written. Under `build/`, because it is build
+  /// output: regenerated every time and never worth committing.
+  String get sourceDir => p.join(packageRoot, 'build', 'catalog', 'web_src');
+
+  /// Where the page goes when nobody says. Package-relative, and spelled with
+  /// `/` because it is also what the dialog puts in a text field and what the
+  /// action's help says.
+  static const defaultOutput = 'build/catalog/web';
+
+  static String defaultOutputIn(String packageRoot) =>
+      p.join(packageRoot, 'build', 'catalog', 'web');
+
+  /// Generates the app and compiles it.
+  ///
+  /// [onOutput] receives the tool's own lines as they arrive — a web build is
+  /// tens of seconds and a caller with nothing to show for that is a caller
+  /// nobody believes is working.
+  Future<WebCatalogBuild> build({
+    required List<CatalogEntry> entries,
+    String? output,
+    String? baseHref,
+    void Function(String line)? onOutput,
+  }) async {
+    if (entries.isEmpty) {
+      throw StateError(
+        'There are no catalog entries in $packageRoot to build a page from.',
+      );
+    }
+    _requireWebSupport();
+
+    var target = WebAppGenerator(
+      outputDir: sourceDir,
+      projectRoot: packageRoot,
+      title: title,
+    ).generate(entries);
+
+    var outputDir = output == null
+        ? defaultOutputIn(packageRoot)
+        : (p.isAbsolute(output) ? output : p.join(packageRoot, output));
+
+    var stopwatch = Stopwatch()..start();
+    var exitCode = await _run([
+      'build',
+      'web',
+      '--target',
+      p.relative(target, from: packageRoot),
+      '--output',
+      outputDir,
+      if (baseHref != null) ...['--base-href', baseHref],
+    ], onOutput);
+    stopwatch.stop();
+
+    if (_cancelled) {
+      // Said plainly rather than as a non-zero exit code: a build that was
+      // stopped on purpose is not a build that broke.
+      throw StateError('The web build was cancelled.');
+    }
+    if (exitCode != 0) {
+      throw StateError(
+        'flutter build web failed (exit $exitCode). The generated sources are '
+        'in $sourceDir — the error above points into them.',
+      );
+    }
+
+    return WebCatalogBuild(
+      output: outputDir,
+      indexHtml: p.join(outputDir, 'index.html'),
+      entryCount: entries.length,
+      duration: stopwatch.elapsed,
+    );
+  }
+
+  /// Refuses early, and with the command that fixes it.
+  ///
+  /// `flutter build web` needs the package to have a `web/` directory; without
+  /// one the tool's own message is about a missing target rather than about
+  /// web not being enabled. Creating it here is not this command's business —
+  /// it writes four files into the user's project, and a build command that
+  /// quietly does that is one you cannot run to find out whether it would.
+  void _requireWebSupport() {
+    if (Directory(p.join(packageRoot, 'web')).existsSync()) return;
+    throw StateError(
+      'This package has no web/ directory, so Flutter cannot build it for the '
+      'web. Enable it once with:\n'
+      '  cd $packageRoot && flutter create --platforms=web .',
+    );
+  }
+
+  /// The compile in flight, so somebody can end it. Null when none is.
+  Process? _process;
+  var _cancelled = false;
+
+  /// Ends the build, if one is running.
+  ///
+  /// A `flutter build web` is tens of seconds, and a child started with
+  /// `Process.start` is **not** killed when the Dart parent exits on macOS. Left
+  /// alone it keeps writing into the user's project after the window is gone —
+  /// and the next build calls [WebAppGenerator.generate], which deletes
+  /// `web_src` recursively, so the orphan's sources vanish underneath it and it
+  /// fails pointing at generated files that no longer exist.
+  Future<void> cancel() async {
+    _cancelled = true;
+    _process?.kill();
+    // SIGTERM only reaches the tool itself; its own children are its business.
+    // The tool handles it, which is what `flutter build` does on a ^C.
+    _process = null;
+  }
+
+  Future<int> _run(
+    List<String> arguments,
+    void Function(String)? onOutput,
+  ) async {
+    var process = _process = await Process.start(
+      flutterExecutable,
+      arguments,
+      workingDirectory: packageRoot,
+    );
+    // Cancelled between the decision to start and the start itself.
+    if (_cancelled) process.kill();
+    // Both streams, interleaved: the tool writes progress to stdout and its
+    // compile errors to stderr, and a caller shown only one of them either
+    // watches a build say nothing or reads a failure with no context.
+    var lines = <Future<void>>[
+      for (var stream in [process.stdout, process.stderr])
+        stream
+            .transform(const Utf8Decoder(allowMalformed: true))
+            .transform(const LineSplitter())
+            .forEach((line) => onOutput?.call(line)),
+    ];
+    var exitCode = await process.exitCode;
+    await Future.wait(lines);
+    _process = null;
+    return exitCode;
+  }
+}
+
+/// What a finished build produced.
+class WebCatalogBuild {
+  WebCatalogBuild({
+    required this.output,
+    required this.indexHtml,
+    required this.entryCount,
+    required this.duration,
+  });
+
+  /// The directory to serve. Absolute.
+  final String output;
+
+  final String indexHtml;
+  final int entryCount;
+  final Duration duration;
+}

--- a/app/lib/src/catalog/web_build_dialog.dart
+++ b/app/lib/src/catalog/web_build_dialog.dart
@@ -1,0 +1,461 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import '../plugins/native/ui_catalog_core.dart';
+import '../plugins/native/ui_catalog_results.dart';
+import '../ui/design/design.dart';
+import '../ui/theme.dart';
+import 'web_build.dart';
+
+/// Configures a web build, runs it, and shows what the tool says while it does.
+///
+/// **It calls [UiCatalogCore.buildWeb] directly rather than going through
+/// `Session.invoke`.** The behaviour is still the core's — `fw` reaches the same
+/// method by its own route, and the `build-web` action is that route. What the
+/// action cannot carry is the thing this exists for: a build takes tens of
+/// seconds, and `Job` has no log or progress event to put those lines in (see
+/// `session/job.dart`, which says so and declines to guess a shape for them).
+/// A dialog that showed a spinner for half a minute and then a path would be a
+/// worse answer than the CLI already gives.
+Future<void> showWebBuildDialog(
+  BuildContext context, {
+  required UiCatalogCore core,
+  required String package,
+  required ServeBuild serve,
+}) => showDialog<void>(
+  context: context,
+  // A build outlives a careless click outside the dialog, and the log is the
+  // only place its output exists.
+  barrierDismissible: false,
+  builder: (context) =>
+      _WebBuildDialog(core: core, package: package, serve: serve),
+);
+
+/// The same build, spelled for a terminal.
+///
+/// Shown in the dialog for discovery: the button and `fw` reach one method on
+/// the core, and nothing on screen says so. Somebody who wants this in a
+/// script, or in CI, should not have to learn from the docs that it is
+/// possible.
+///
+/// Only what is not already the default is included — a command line carrying
+/// flags that change nothing teaches the flags rather than the command.
+///
+/// A function rather than a method so a test can check the flags against the
+/// ones the action declares. This string is an instruction to a user: a flag
+/// renamed on the action and not here is a command that fails when they run it.
+String webBuildCommand({
+  required String pluginId,
+  required String package,
+  required bool nameThePackage,
+  String output = '',
+  String baseHref = '',
+}) => [
+  'dart run flutterware run ${pluginId.split('.').last} $webBuildActionId',
+  if (nameThePackage) '--package=${_shellArg(package)}',
+  if (output.isNotEmpty && output != WebCatalogBuilder.defaultOutput)
+    '--output=${_shellArg(output)}',
+  if (baseHref.isNotEmpty) '--base-href=${_shellArg(baseHref)}',
+].join(' ');
+
+/// Quoted when a shell would otherwise split it.
+String _shellArg(String value) =>
+    value.contains(RegExp(r'\s')) ? "'$value'" : value;
+
+/// Puts a built directory on a local port and answers with its URL.
+///
+/// A callback rather than something this file does, because the server has to
+/// outlive the dialog: you close this the moment the tab is open. The plugin
+/// owns them and ends them with the worktree.
+typedef ServeBuild = Future<Uri> Function(String output, {String basePath});
+
+class _WebBuildDialog extends StatefulWidget {
+  const _WebBuildDialog({
+    required this.core,
+    required this.package,
+    required this.serve,
+  });
+
+  final UiCatalogCore core;
+  final String package;
+  final ServeBuild serve;
+
+  @override
+  State<_WebBuildDialog> createState() => _WebBuildDialogState();
+}
+
+class _WebBuildDialogState extends State<_WebBuildDialog> {
+  final _output = TextEditingController(text: WebCatalogBuilder.defaultOutput);
+  final _baseHref = TextEditingController();
+
+  final _log = <String>[];
+  final _logScroll = ScrollController();
+
+  var _running = false;
+  CatalogWebBuildResult? _built;
+  String? _error;
+
+  /// Where the last build is being served, once something has asked. Kept so
+  /// the URL stays on screen and a second look does not need a second click.
+  Uri? _served;
+
+  /// The base href the finished build was compiled with — not what the field
+  /// says now, which the user may have edited since.
+  String? _builtBaseHref;
+
+  @override
+  void initState() {
+    super.initState();
+    // The echoed command below is built from these, so it has to be rebuilt as
+    // they are typed — a command line that lags the form it claims to mirror
+    // is worse than none.
+    _output.addListener(_onFieldChanged);
+    _baseHref.addListener(_onFieldChanged);
+  }
+
+  void _onFieldChanged() => setState(() {});
+
+  @override
+  void dispose() {
+    _output
+      ..removeListener(_onFieldChanged)
+      ..dispose();
+    _baseHref
+      ..removeListener(_onFieldChanged)
+      ..dispose();
+    _logScroll.dispose();
+    super.dispose();
+  }
+
+  String get _command => webBuildCommand(
+    pluginId: widget.core.id,
+    package: widget.package,
+    // With several packages declared the action refuses without it, so there
+    // it is part of the command rather than a decoration on it.
+    nameThePackage: widget.core.packages.length > 1,
+    output: _output.text.trim(),
+    baseHref: _baseHref.text.trim(),
+  );
+
+  Future<void> _build() async {
+    setState(() {
+      _running = true;
+      _built = null;
+      _error = null;
+      _served = null;
+      _log.clear();
+    });
+    var baseHref = _baseHref.text.trim();
+    try {
+      var result = await widget.core.buildWeb(
+        package: widget.package,
+        output: _output.text.trim().isEmpty ? null : _output.text.trim(),
+        baseHref: baseHref.isEmpty ? null : baseHref,
+        onOutput: _append,
+      );
+      if (mounted) {
+        setState(() {
+          _built = result;
+          _builtBaseHref = baseHref.isEmpty ? null : baseHref;
+        });
+      }
+    } catch (e) {
+      // Shown rather than thrown: the failure a user hits most is "web is not
+      // enabled for this package", whose message carries the command that fixes
+      // it, and that belongs on screen next to the button they just pressed.
+      if (mounted) setState(() => _error = '$e');
+    } finally {
+      if (mounted) setState(() => _running = false);
+    }
+  }
+
+  Future<void> _open() async {
+    var built = _built;
+    if (built == null) return;
+    try {
+      // Mounted where the build was told it would be. A page built with
+      // `--base-href=/catalog/` carries that in its `<base>`, so served at the
+      // root it loads and then asks for every asset one directory up.
+      var url = await widget.serve(
+        built.output,
+        basePath: _builtBaseHref ?? '/',
+      );
+      if (mounted) setState(() => _served = url);
+      await launchUrl(url);
+    } catch (e) {
+      if (mounted) setState(() => _error = '$e');
+    }
+  }
+
+  void _append(String line) {
+    if (!mounted) return;
+    setState(() {
+      _log.add(line);
+      // The tool is verbose on a cold build and nothing above the last screen
+      // is ever read; keeping it all would grow the dialog's memory for the
+      // life of the session.
+      if (_log.length > 400) _log.removeRange(0, _log.length - 400);
+    });
+    // After the frame that added the line, so the extent it scrolls to is the
+    // one that includes it.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (_logScroll.hasClients) {
+        _logScroll.jumpTo(_logScroll.position.maxScrollExtent);
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    var colors = context.colors;
+    return AlertDialog(
+      title: Text(
+        widget.package == '.'
+            ? 'Build a web page'
+            : 'Build a web page — ${widget.package}',
+      ),
+      content: SizedBox(
+        width: 560,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Compiles every demo into a page you can browse — the widgets '
+              'themselves, with their knobs, not pictures of them.',
+              style: context.type.caption.copyWith(color: colors.mut),
+            ),
+            const Gap(FwSpacing.xl),
+            _Field(
+              label: 'Write to',
+              controller: _output,
+              enabled: !_running,
+              hint: WebCatalogBuilder.defaultOutput,
+            ),
+            const Gap(FwSpacing.lg),
+            _Field(
+              label: 'Base href',
+              controller: _baseHref,
+              enabled: !_running,
+              hint: 'optional — /catalog/ to serve from a subdirectory',
+            ),
+            const Gap(FwSpacing.lg),
+            _CommandLine(command: _command),
+            if (_log.isNotEmpty) ...[
+              const Gap(FwSpacing.xl),
+              _Log(lines: _log, controller: _logScroll),
+            ],
+            if (_error case var error?) ...[
+              const Gap(FwSpacing.lg),
+              _Message(text: error, color: colors.red),
+            ],
+            if (_built case var built?) ...[
+              const Gap(FwSpacing.lg),
+              _Message(
+                text:
+                    '${built.entries} '
+                    '${built.entries == 1 ? 'entry' : 'entries'} → '
+                    '${built.output}  '
+                    '(${(built.durationMs / 1000).toStringAsFixed(1)}s)',
+                color: colors.grn,
+              ),
+              if (_served case var url?) ...[
+                const Gap(FwSpacing.xs),
+                // Left on screen after the tab opens: the server outlives this
+                // dialog, and without the URL written down the only way back to
+                // a page you closed is to build it again.
+                _Message(
+                  text: 'Serving at $url — until this worktree is closed.',
+                  color: colors.mut,
+                ),
+              ],
+            ],
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: _running ? null : () => Navigator.of(context).pop(),
+          child: Text(_built == null ? 'Cancel' : 'Close'),
+        ),
+        TextButton(
+          onPressed: _running || _built == null ? null : _build,
+          child: const Text('Build again'),
+        ),
+        // The primary action once there is something to look at: building a
+        // page you then have to go and find is most of the work and none of
+        // the point.
+        FilledButton(
+          onPressed: _running
+              ? null
+              : _built == null
+              ? _build
+              : () => unawaited(_open()),
+          child: Text(
+            _running
+                ? 'Building…'
+                : _built == null
+                ? 'Build'
+                : _served == null
+                ? 'Open in browser'
+                : 'Open again',
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _Field extends StatelessWidget {
+  const _Field({
+    required this.label,
+    required this.controller,
+    required this.enabled,
+    required this.hint,
+  });
+
+  final String label;
+  final TextEditingController controller;
+  final bool enabled;
+  final String hint;
+
+  @override
+  Widget build(BuildContext context) => Row(
+    crossAxisAlignment: CrossAxisAlignment.center,
+    children: [
+      SizedBox(width: 90, child: Text(label, style: context.type.bodySmall)),
+      Expanded(
+        child: TextField(
+          controller: controller,
+          enabled: enabled,
+          style: context.type.bodySmall.copyWith(fontFamily: 'monospace'),
+          decoration: InputDecoration(
+            isDense: true,
+            hintText: hint,
+            border: const OutlineInputBorder(),
+          ),
+        ),
+      ),
+    ],
+  );
+}
+
+/// The same build as a command, with a way to take it.
+///
+/// Deliberately not a disabled-looking hint: it is the real invocation, and the
+/// point is that somebody reads it once and knows this is scriptable.
+class _CommandLine extends StatefulWidget {
+  const _CommandLine({required this.command});
+
+  final String command;
+
+  @override
+  State<_CommandLine> createState() => _CommandLineState();
+}
+
+class _CommandLineState extends State<_CommandLine> {
+  Timer? _copied;
+
+  @override
+  void dispose() {
+    _copied?.cancel();
+    super.dispose();
+  }
+
+  void _copy() {
+    unawaited(Clipboard.setData(ClipboardData(text: widget.command)));
+    _copied?.cancel();
+    setState(() {});
+    _copied = Timer(const Duration(milliseconds: 1400), () {
+      if (mounted) setState(() {});
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    var colors = context.colors;
+    var justCopied = _copied?.isActive ?? false;
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.fromLTRB(
+        FwSpacing.md,
+        FwSpacing.sm,
+        FwSpacing.xs,
+        FwSpacing.sm,
+      ),
+      decoration: BoxDecoration(
+        color: colors.panel,
+        border: Border.all(color: colors.line),
+      ),
+      child: Row(
+        children: [
+          Expanded(
+            child: SelectableText(
+              widget.command,
+              style: context.type.micro.copyWith(
+                fontFamily: 'monospace',
+                color: colors.mut,
+              ),
+            ),
+          ),
+          const Gap(FwSpacing.sm),
+          IconButton(
+            icon: Icon(justCopied ? Icons.check : Icons.content_copy, size: 14),
+            padding: EdgeInsets.zero,
+            constraints: const BoxConstraints.tightFor(width: 22, height: 22),
+            tooltip: 'Copy the command',
+            onPressed: _copy,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// The tool's own output, as it arrives.
+class _Log extends StatelessWidget {
+  const _Log({required this.lines, required this.controller});
+
+  final List<String> lines;
+  final ScrollController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    var colors = context.colors;
+    return Container(
+      height: 180,
+      width: double.infinity,
+      padding: const EdgeInsets.all(FwSpacing.md),
+      decoration: BoxDecoration(
+        color: colors.panel,
+        border: Border.all(color: colors.line),
+      ),
+      child: SingleChildScrollView(
+        controller: controller,
+        child: SelectableText(
+          lines.join('\n'),
+          style: context.type.micro.copyWith(fontFamily: 'monospace'),
+        ),
+      ),
+    );
+  }
+}
+
+class _Message extends StatelessWidget {
+  const _Message({required this.text, required this.color});
+
+  final String text;
+  final Color color;
+
+  /// Selectable, because both messages are things you paste somewhere: the
+  /// failure carries the `flutter create` that fixes it, and the success
+  /// carries a path.
+  @override
+  Widget build(BuildContext context) => SelectableText(
+    text,
+    style: context.type.bodySmall.copyWith(color: color),
+  );
+}

--- a/app/lib/src/catalog/web_server.dart
+++ b/app/lib/src/catalog/web_server.dart
@@ -1,0 +1,141 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:shelf/shelf.dart';
+import 'package:shelf/shelf_io.dart' as io;
+
+/// Serves a built catalog page, so the thing that was just compiled can be
+/// looked at.
+///
+/// A Flutter web build cannot be opened as a `file:` URL — it fetches its own
+/// manifests and its CanvasKit payload, and every one of those requests is
+/// cross-origin from a file. So there has to be a server, and this is the
+/// smallest one that works.
+///
+/// **Hand-rolled rather than `shelf_static`.** The CLI compiles this app on the
+/// user's machine at first run, so a dependency is a thing everyone installing
+/// flutterware has to fetch and build. What is needed here is one directory,
+/// read-only, on loopback, with content types — not the package's symlink
+/// policy, directory listings and cache validators.
+class CatalogWebServer {
+  CatalogWebServer._(this._server, this.root, this.basePath);
+
+  final HttpServer _server;
+
+  /// The directory being served, absolute.
+  final String root;
+
+  /// The path the page is mounted at. `/` unless it was built with a
+  /// `--base-href`, which is a promise about where it will be served from.
+  final String basePath;
+
+  Uri get url => Uri(
+    scheme: 'http',
+    host: '127.0.0.1',
+    port: _server.port,
+    path: basePath,
+  );
+
+  /// Binds an ephemeral port on loopback.
+  ///
+  /// **Loopback, never `anyIPv4`.** A catalog is unreleased UI: it is a picture
+  /// of what a product is about to look like, and binding it to every interface
+  /// publishes that to whatever network the machine is on. Someone who wants
+  /// that can copy the directory to a host that is meant to be public.
+  ///
+  /// [basePath] must match the `--base-href` the page was built with. A build
+  /// with a base href writes `<base href="/catalog/">` into its index, so every
+  /// asset it asks for is under that prefix — served at the root instead, the
+  /// page loads and then fetches nothing it needs.
+  static Future<CatalogWebServer> serve(
+    String root, {
+    String basePath = '/',
+  }) async {
+    var absolute = p.absolute(root);
+    if (!Directory(absolute).existsSync()) {
+      throw ArgumentError.value(root, 'root', 'is not a directory');
+    }
+    var prefix = normaliseBasePath(basePath);
+    var server = await io.serve(
+      _handlerFor(absolute, prefix),
+      InternetAddress.loopbackIPv4,
+      0,
+    );
+    return CatalogWebServer._(server, absolute, prefix);
+  }
+
+  Future<void> close() => _server.close(force: true);
+
+  /// A mount point with both slashes, which is the form [basePath] is compared
+  /// and matched in. Exposed so a caller deciding whether an existing server
+  /// still fits compares the same thing this stored.
+  static String normaliseBasePath(String basePath) {
+    var prefix = basePath.isEmpty ? '/' : basePath;
+    if (!prefix.startsWith('/')) prefix = '/$prefix';
+    return prefix.endsWith('/') ? prefix : '$prefix/';
+  }
+
+  static Handler _handlerFor(String root, String prefix) => (request) {
+    // `Request.url` is always relative — no leading slash — so the prefix is
+    // compared without one.
+    var relativePrefix = prefix.substring(1);
+    var path = request.url.path;
+    if (relativePrefix.isNotEmpty) {
+      if (!path.startsWith(relativePrefix)) {
+        return Response.notFound('This page is served at $prefix');
+      }
+      path = path.substring(relativePrefix.length);
+    }
+
+    var requested = path.isEmpty ? 'index.html' : path;
+    var file = File(p.join(root, requested));
+
+    // `..` in a URL is the whole of the traversal risk here. Resolving first
+    // and then checking containment catches it however it was spelled, which
+    // string matching on the request does not.
+    var resolved = p.normalize(file.absolute.path);
+    if (!p.equals(resolved, root) && !p.isWithin(root, resolved)) {
+      return Response.forbidden('Outside the served directory.');
+    }
+
+    if (!file.existsSync()) return Response.notFound('Not found: $requested');
+
+    return Response.ok(
+      file.openRead(),
+      headers: {
+        'content-type': _contentType(resolved),
+        // A rebuild writes over this directory while the tab is open, and the
+        // next thing anyone does is reload it. A cached response would show
+        // them the build they were trying to replace.
+        'cache-control': 'no-store',
+      },
+      context: {'shelf.io.buffer_output': false},
+    );
+  };
+
+  /// Enough of a table for what `flutter build web` emits.
+  ///
+  /// A wrong type here is not cosmetic: a `.js` served as text/plain does not
+  /// execute, and `.wasm` served as anything else fails
+  /// `instantiateStreaming` — both of which present as a blank page.
+  static String _contentType(String path) => switch (p.extension(path)) {
+    '.html' => 'text/html; charset=utf-8',
+    '.js' || '.mjs' => 'text/javascript; charset=utf-8',
+    '.json' || '.map' => 'application/json; charset=utf-8',
+    '.css' => 'text/css; charset=utf-8',
+    '.wasm' => 'application/wasm',
+    '.png' => 'image/png',
+    '.jpg' || '.jpeg' => 'image/jpeg',
+    '.gif' => 'image/gif',
+    '.webp' => 'image/webp',
+    '.svg' => 'image/svg+xml',
+    '.ico' => 'image/x-icon',
+    '.ttf' => 'font/ttf',
+    '.otf' => 'font/otf',
+    '.woff' => 'font/woff',
+    '.woff2' => 'font/woff2',
+    // Covers `.bin`, `.symbols`, `.dat`, and whatever the engine adds next. A
+    // byte stream the browser does not try to interpret is the safe default.
+    _ => 'application/octet-stream',
+  };
+}

--- a/app/lib/src/embedder/embedded_engine.dart
+++ b/app/lib/src/embedder/embedded_engine.dart
@@ -5,9 +5,14 @@ import 'dart:io';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/painting.dart';
 import 'package:flutter/services.dart';
+import 'package:image/image.dart' as img;
 import 'package:path/path.dart' as p;
 
+// ignore: implementation_imports
+import 'package:flutterware/src/inspect/node.dart';
+
 import '../utils/run_dir.dart';
+import 'frame_capture.dart';
 import 'protocol.dart';
 
 enum EmbeddedEnginePhase { building, running, error }
@@ -65,6 +70,25 @@ class EmbeddedEngine extends ChangeNotifier {
   /// The guest's VM-service URI, which it prints on stdout at startup. Needed
   /// to hot-reload the live guest.
   Future<String> get vmServiceUri => _vmServiceUri.future;
+
+  /// Photographs the guest — the same exchange the headless pipeline uses.
+  ///
+  /// Worth having on the *live* engine specifically: this frame is the demo as
+  /// the person driving it left it, which nothing rendered fresh can reproduce.
+  /// It is also the only way to get one from here, since the texture belongs to
+  /// the compositor rather than to Flutter and `toImage` cannot read it.
+  late final _capture = FrameCapture(
+    send: (message) async {
+      var conn = _conn;
+      if (conn == null || phase != EmbeddedEnginePhase.running) {
+        throw StateError('the guest is not running');
+      }
+      conn.add(encodeMessage(message));
+      await conn.flush();
+    },
+    // Per engine, so two panels capturing at once do not write one path.
+    workDir: p.join(flutterwareRunDir(), 'cap-$name'),
+  );
 
   String get _dartExecutable => p.join(flutterSdkRoot, 'bin', 'dart');
 
@@ -173,9 +197,13 @@ class EmbeddedEngine extends ChangeNotifier {
           });
         }
       case ErrorMessage():
+        // Before failing the engine: a guest that has errored will not finish
+        // writing a frame, and a caller left on the capture timeout learns
+        // thirty seconds later, in less detail, what this already says.
+        _capture.failAll(StateError(message.message));
         _fail(message.message);
       case CapturedMessage():
-        break; // Awaited by whoever asked for the capture, not here.
+        _capture.acknowledge(message);
       case ResizeMessage():
       case PointerEventMessage():
       case KeyEventMessage():
@@ -299,9 +327,34 @@ class EmbeddedEngine extends ChangeNotifier {
     );
   }
 
+  /// The frame the guest draws next, as PNG bytes.
+  ///
+  /// PNG rather than an image, because both callers — the clipboard and the
+  /// save dialog — want encoded bytes, and the one that does not is welcome to
+  /// decode them.
+  ///
+  /// Pass [crop] to cut it to a node's box, in the guest's logical coordinates:
+  /// the space [InspectLayout] reports, which is why a node's rect from the
+  /// inspect panel crops its own picture with no transform.
+  Future<Uint8List> capturePng({
+    InspectLayout? crop,
+    List<InspectNode> annotate = const [],
+    double pixelRatio = 1,
+  }) async {
+    var image = await _capture.capture(
+      crop: crop,
+      annotate: annotate,
+      pixelRatio: pixelRatio,
+    );
+    return img.encodePng(image);
+  }
+
   @override
   void dispose() {
     _disposed = true;
+    // Nothing outstanding survives the guest, and a caller waiting on the
+    // 30-second timeout would otherwise outlive the panel it belongs to.
+    _capture.failAll(StateError('the panel was closed'));
     if (_conn != null && phase == EmbeddedEnginePhase.running) {
       _conn!.add(encodeMessage(const ShutdownMessage()));
     }

--- a/app/lib/src/embedder/frame_capture.dart
+++ b/app/lib/src/embedder/frame_capture.dart
@@ -1,0 +1,258 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:image/image.dart' as img;
+import 'package:path/path.dart' as p;
+
+// The node types, not the umbrella `ui_catalog.dart`: that one reaches
+// `package:flutter/widgets.dart`, and this file is on `fw`'s import graph
+// through the headless pipeline.
+// ignore: implementation_imports
+import 'package:flutterware/src/inspect/node.dart';
+
+import 'protocol.dart';
+import 'raw_frame.dart';
+
+/// Asks a guest for the frame it composited, and turns it into a picture.
+///
+/// Both halves of the exchange live here on purpose. A capture is requested by
+/// *path*: the guest writes a `.rawframe` and answers with [CapturedMessage]
+/// naming it, so a caller holding the send without the ack has a file it cannot
+/// know is finished. Splitting them is how you get a half-written frame.
+///
+/// Shared by the headless pipeline and by the GUI's live engine, because they
+/// are the same exchange over different sockets. The live one is the only way
+/// to photograph a demo *as somebody left it* — the dropdown they opened, the
+/// row they scrolled to — since no fresh guest performs their clicks.
+class FrameCapture {
+  FrameCapture({required this.send, required this.workDir});
+
+  /// Hands one message to the guest and returns once it is on the wire.
+  ///
+  /// Flushing is the caller's, not this class's, because only the caller knows
+  /// what it is writing to. It has to happen though: a request still sitting in
+  /// a socket buffer waits for an ack the guest was never asked for.
+  final Future<void> Function(EmbedderMessage message) send;
+
+  /// Where the raw frame lands on its way to being decoded.
+  ///
+  /// Each file is deleted as soon as it has been read, so nothing accumulates —
+  /// but a frame is tens of megabytes while it exists, which is why this is a
+  /// scratch directory rather than anywhere a user looks.
+  final String workDir;
+
+  /// Outstanding captures, by the path each was requested at.
+  ///
+  /// The completer carries a *failure* rather than completing with an error, and
+  /// that is deliberate. A guest can report an error between the write and the
+  /// flush — the window is small and it is a socket — and `completeError` on a
+  /// future nothing is awaiting yet delivers to the zone instead, where it
+  /// surfaces as an unhandled exception and takes the app down rather than
+  /// failing this call. A value cannot be orphaned whenever it arrives.
+  final _pending = <String, Completer<Object?>>{};
+
+  /// Settles the capture [message] acknowledges.
+  ///
+  /// Returns false for anything that is not an ack, so a socket handler can
+  /// offer it every message and go on with the ones this does not want.
+  bool acknowledge(EmbedderMessage message) {
+    if (message is! CapturedMessage) return false;
+    _pending.remove(message.path)?.complete(null);
+    return true;
+  }
+
+  /// Fails everything outstanding.
+  ///
+  /// A guest that has reported an error is not going to finish writing a frame,
+  /// and a caller left on the timeout below learns thirty seconds later, in
+  /// less detail, what [error] already said.
+  void failAll(Object error) {
+    for (var pending in _pending.values) {
+      if (!pending.isCompleted) pending.complete(error);
+    }
+    _pending.clear();
+  }
+
+  /// Captures run one at a time, and that is a property of the guest rather
+  /// than a convenience here.
+  ///
+  /// The host keeps **one** armed capture path: `kMsgCapture` does
+  /// `free(g_capture_path); g_capture_path = path;` (`native/host.c`). A second
+  /// request therefore does not queue behind the first, it *replaces* it — the
+  /// first frame is never written, and whoever asked for it waits out the
+  /// timeout for a file that is not coming. Overlapping callers are ordinary:
+  /// the copy button and its ⌘⇧C shortcut are two of them, and an agent
+  /// screenshotting while a panel is open is another.
+  Future<void> _turn = Future.value();
+
+  /// The frame the guest composites next, decoded, annotated and cropped.
+  ///
+  /// Next rather than last: the engine renders nothing when nothing changed, so
+  /// the host arms the request and forces a frame. On a static scene that frame
+  /// is identical to the one on screen.
+  ///
+  /// Waits for any capture already in flight — see [_turn]. [name] only names
+  /// the scratch file; it does **not** make two captures independent, because
+  /// nothing downstream of here can be.
+  Future<img.Image> capture({
+    InspectLayout? crop,
+    List<InspectNode> annotate = const [],
+
+    /// Logical-to-physical, for turning either of the above into pixels.
+    double pixelRatio = 1,
+    String name = 'screenshot',
+    Duration timeout = const Duration(seconds: 30),
+  }) {
+    var result = _turn.then(
+      (_) => _capture(
+        crop: crop,
+        annotate: annotate,
+        pixelRatio: pixelRatio,
+        name: name,
+        timeout: timeout,
+      ),
+    );
+    // The queue must not inherit this one's failure, or one bad capture would
+    // fail every capture after it. Swallowed here only — `result` still throws
+    // to the caller, and having a listener from this moment is also what keeps
+    // an ignored failure off the zone.
+    _turn = result.then((_) {}, onError: (_) {});
+    return result;
+  }
+
+  Future<img.Image> _capture({
+    required InspectLayout? crop,
+    required List<InspectNode> annotate,
+    required double pixelRatio,
+    required String name,
+    required Duration timeout,
+  }) async {
+    Directory(workDir).createSync(recursive: true);
+    var path = p.join(workDir, '$name.rawframe');
+    var file = File(path);
+    // A stale file from a capture that timed out would otherwise be decoded as
+    // if it were this one's answer.
+    if (file.existsSync()) file.deleteSync();
+
+    var done = _pending[path] = Completer<Object?>();
+    Object? failure;
+    try {
+      await send(CaptureMessage(path));
+      failure = await done.future.timeout(timeout);
+
+      // `Object`, because it is whatever the socket handler was given — an
+      // `ErrorMessage`'s text arrives wrapped in a StateError today, and this
+      // rethrows what it was handed rather than reclassifying it.
+      // ignore: only_throw_errors
+      if (failure != null) throw failure;
+
+      var image = decodeRawFrame(file.readAsBytesSync());
+      // Annotate before cropping, so a box on a node partly outside the crop is
+      // clipped with the picture rather than drawn against its edge.
+      if (annotate.isNotEmpty) {
+        image = annotateNodes(image, annotate, pixelRatio);
+      }
+      return crop == null ? image : cropToNode(image, crop, pixelRatio);
+    } finally {
+      _pending.remove(path);
+      // Whatever happened. A frame is tens of megabytes uncompressed, and on
+      // the failure paths the guest may write it after we stopped waiting — so
+      // the one place that reliably has both the path and the last word is
+      // here, not the success path this used to sit on.
+      if (file.existsSync()) file.deleteSync();
+    }
+  }
+}
+
+/// The frame, cut to one node's box.
+///
+/// Cropped out of the real composited frame rather than re-rendered in
+/// isolation, which is what `ext.flutter.inspector.screenshot` would do: a
+/// widget photographed away from its surroundings is a different picture, and
+/// usually not the one the question was about.
+///
+/// Clamped to the frame, because a node may legitimately sit partly outside it
+/// — that is what an overflow *is* — and a crop that threw would refuse to show
+/// the one case worth looking at.
+img.Image cropToNode(img.Image image, InspectLayout rect, double ratio) {
+  var x = (rect.x * ratio).round().clamp(0, image.width - 1);
+  var y = (rect.y * ratio).round().clamp(0, image.height - 1);
+  return img.copyCrop(
+    image,
+    x: x,
+    y: y,
+    width: (rect.width * ratio).round().clamp(1, image.width - x),
+    height: (rect.height * ratio).round().clamp(1, image.height - y),
+  );
+}
+
+/// A box and an id over each node.
+///
+/// The point is the id: an agent reads a tree, gets `0/1/2`, and then gets a
+/// picture with `0/1/2` written on the thing it names. Without that the tree
+/// and the screenshot are two observations of the same frame with nothing
+/// joining them.
+img.Image annotateNodes(
+  img.Image image,
+  List<InspectNode> nodes,
+  double ratio,
+) {
+  for (var node in _distinctBoxes(nodes)) {
+    if (node.layout case var layout?) {
+      var x = (layout.x * ratio).round();
+      var y = (layout.y * ratio).round();
+      var w = (layout.width * ratio).round();
+      var h = (layout.height * ratio).round();
+      img.drawRect(
+        image,
+        x1: x,
+        y1: y,
+        x2: x + w - 1,
+        y2: y + h - 1,
+        color: img.ColorRgb8(255, 0, 128),
+      );
+      var label = node.id.isEmpty ? 'root' : node.id;
+      // A filled strip behind it: these are drawn over a rendered UI, and
+      // magenta-on-whatever-was-there is not always legible.
+      var labelX = x + 2;
+      var labelY = y < 16 ? y + 2 : y - 15;
+      img.fillRect(
+        image,
+        x1: labelX - 1,
+        y1: labelY - 1,
+        x2: labelX + label.length * 8,
+        y2: labelY + 14,
+        color: img.ColorRgb8(255, 0, 128),
+      );
+      img.drawString(
+        image,
+        label,
+        font: img.arial14,
+        x: labelX,
+        y: labelY,
+        color: img.ColorRgb8(255, 255, 255),
+      );
+    }
+  }
+  return image;
+}
+
+/// One node per distinct box, outermost kept.
+///
+/// Most of a summary tree lays nothing out of its own: a provider, a builder
+/// and the widget under them share one rect, so drawing every node draws the
+/// same rectangle six times and stacks six labels on one corner. The first
+/// version did exactly that and was unreadable — which is the difference
+/// between a feature that exists and one that answers the question.
+///
+/// Outermost wins because it is the shorter id and the one a caller is more
+/// likely to have meant; the inner ones are still in the tree for anyone who
+/// wants them.
+List<InspectNode> _distinctBoxes(List<InspectNode> nodes) {
+  var seen = <String>{};
+  return [
+    for (var node in nodes)
+      if (node.layout case var l?)
+        if (seen.add('${l.x},${l.y},${l.width},${l.height}')) node,
+  ];
+}

--- a/app/lib/src/plugins/native/ui_catalog_core.dart
+++ b/app/lib/src/plugins/native/ui_catalog_core.dart
@@ -25,6 +25,7 @@ import '../../catalog/inspect_client.dart';
 import '../../catalog/live_session.dart';
 import '../../catalog/protocol.dart';
 import '../../catalog/headless_catalog.dart';
+import '../../catalog/web_build.dart';
 import '../plugin_core.dart';
 import 'ui_catalog_address.dart';
 import 'ui_catalog_results.dart';
@@ -32,6 +33,14 @@ import '../plugin_host.dart';
 
 /// The registered id — also what `tool/flutterware.dart` declares.
 const uiCatalogPluginId = 'flutterware.ui_catalog';
+
+/// The action that compiles a browsable page.
+///
+/// Named once because two places spell it: the declaration below, and the
+/// command the GUI's build dialog shows so the same thing can be run from a
+/// terminal. A rename that reached only one of them would put a command that
+/// fails in front of a user.
+const webBuildActionId = 'build-web';
 
 /// Where a package keeps its demos when it does not say otherwise.
 const _defaultRoot = 'demo';
@@ -121,6 +130,11 @@ class UiCatalogCore extends PluginCore {
       if (host.workspace.declaredAt(path) != null) path,
   ];
 
+  /// The web build in flight per package, so it can be refused a second time
+  /// and killed when the worktree goes — see [dispose]. A `flutter build web`
+  /// child is not reaped when the Dart process exits.
+  final _builds = <String, WebCatalogBuilder>{};
+
   final _scans = <String, ScanResult>{};
   final _failures = <String, String>{};
   final _scanning = <String>{};
@@ -134,6 +148,20 @@ class UiCatalogCore extends PluginCore {
 
   /// The scan failure for [path], for a panel that wants to show it directly.
   String? failureFor(String path) => _failures[path];
+
+  /// Ends anything still running, which for this plugin means a web build.
+  ///
+  /// Called by the [Session] when the worktree closes. Without it a compile
+  /// started from the dialog outlives the window it belongs to and keeps writing
+  /// into the user's project.
+  @override
+  void dispose() {
+    for (var builder in _builds.values) {
+      unawaited(builder.cancel());
+    }
+    _builds.clear();
+    super.dispose();
+  }
 
   /// Scans [path], unless it already has been. Idempotent.
   ///
@@ -177,6 +205,13 @@ class UiCatalogCore extends PluginCore {
         () => CatalogScanner(projectRoot: root, roots: [entryRoot]).scan(),
       );
       _scans[path] = result;
+      // A scan that worked supersedes one that did not. Without this the
+      // failure outlives its cause for the life of the process: the sidebar
+      // keeps the error badge after the demo is fixed, `track` keeps declining
+      // to look again because it treats a recorded failure as "already
+      // scanned", and `build-web` keeps refusing with the stale message while
+      // holding a perfectly good entry list.
+      _failures.remove(path);
     } catch (e) {
       _failures[path] = '$e';
     } finally {
@@ -673,6 +708,47 @@ class UiCatalogCore extends PluginCore {
           ),
         ],
       ),
+      PluginAction(
+        webBuildActionId,
+        'Build a web page',
+        returns: CatalogWebBuildResult,
+        description:
+            'Compile the whole catalog into a browsable page — the demos '
+            'themselves running in a browser, with their knobs, not pictures '
+            'of them. Needs the package to have web enabled; says so, with the '
+            'command, when it does not.',
+        parameters: [
+          ActionParameter(
+            'package',
+            'Package',
+            kind: ActionParameterKind.choice,
+            required: false,
+            description:
+                'Which declared package; the only one when there is one',
+            options: [
+              for (var path in packages)
+                ActionOption(path, label: path == '.' ? 'root' : path),
+            ],
+          ),
+          const ActionParameter(
+            'output',
+            'Write to',
+            required: false,
+            description:
+                'Where the page goes. Package-relative unless absolute; '
+                'defaults to `build/catalog/web`.',
+          ),
+          const ActionParameter(
+            'base-href',
+            'Base href',
+            required: false,
+            description:
+                'What `flutter build web --base-href` takes, for serving the '
+                'page from a subdirectory rather than the root of a host. Must '
+                'begin and end with a slash — `/catalog/`.',
+          ),
+        ],
+      ),
     ],
     view: _view,
   );
@@ -786,6 +862,8 @@ class UiCatalogCore extends PluginCore {
         return _inspect(arguments);
       case 'audit':
         return _audit(arguments);
+      case webBuildActionId:
+        return _buildWeb(arguments);
       default:
         return super.invoke(actionId, arguments: arguments);
     }
@@ -815,6 +893,133 @@ class UiCatalogCore extends PluginCore {
       packages: [for (var path in paths) _packageEntries(path)],
     );
   }
+
+  /// Compiles one package's catalog into a browsable page.
+  ///
+  /// Unlike every other action here this runs no daemon and no guest: a page is
+  /// the demos themselves, compiled for a browser, not pictures of them. What
+  /// it needs from this class is only the scan — which entries there are — and
+  /// which package they belong to.
+  ///
+  /// [onOutput] is how a caller follows a build that takes tens of seconds; the
+  /// CLI hands it straight to its own printer and the GUI to a dialog.
+  Future<CatalogWebBuildResult> buildWeb({
+    String? package,
+    String? output,
+    String? baseHref,
+    void Function(String line)? onOutput,
+  }) async {
+    var packagePath = _requireOnePackage(package);
+    await _scan(packagePath);
+    if (_failures[packagePath] case var failure?) {
+      throw StateError('$packagePath could not be scanned: $failure');
+    }
+
+    // One at a time per package. Two builds share a generated source directory,
+    // and `WebAppGenerator.generate` deletes it recursively before writing — so
+    // a second build started while the first is compiling pulls the first's
+    // sources out from under it, and the first fails pointing at files that no
+    // longer exist.
+    if (_builds.containsKey(packagePath)) {
+      throw StateError(
+        'A web build is already running for $packagePath. Wait for it, or '
+        'close the worktree to stop it.',
+      );
+    }
+
+    var packageRoot = p.join(host.worktree.path, packagePath);
+    var builder = _builds[packagePath] = WebCatalogBuilder(
+      flutterExecutable: host.workspace.flutterSdk.flutter,
+      packageRoot: packageRoot,
+      // The package rather than the plugin: a page says what it is a catalog
+      // *of*, and "UI catalog" on a repo with three of them says nothing.
+      title: packagePath == '.' ? host.worktree.name : packagePath,
+    );
+    WebCatalogBuild built;
+    try {
+      built = await builder.build(
+        entries: _scans[packagePath]?.entries ?? const [],
+        output: output,
+        baseHref: baseHref,
+        onOutput: onOutput,
+      );
+    } finally {
+      _builds.remove(packagePath);
+    }
+
+    return CatalogWebBuildResult(
+      package: packagePath,
+      output: _shortened(built.output),
+      indexHtml: _shortened(built.indexHtml),
+      entries: built.entryCount,
+      durationMs: built.duration.inMilliseconds,
+    );
+  }
+
+  Future<CatalogWebBuildResult> _buildWeb(Map<String, Object?> arguments) {
+    String? text(String name) {
+      var value = arguments[name];
+      if (value == null) return null;
+      if (value is! String) {
+        throw ArgumentError.value(value, name, 'must be a string');
+      }
+      return value.isEmpty ? null : value;
+    }
+
+    var baseHref = text('base-href');
+    // Checked here rather than left to the tool, which fails after the whole
+    // compile with a message about a value this action accepted.
+    if (baseHref != null &&
+        (!baseHref.startsWith('/') || !baseHref.endsWith('/'))) {
+      throw ArgumentError.value(
+        baseHref,
+        'base-href',
+        'must begin and end with a slash — `/catalog/`',
+      );
+    }
+
+    return buildWeb(
+      package: text('package'),
+      output: text('output'),
+      baseHref: baseHref,
+    );
+  }
+
+  /// The one package an action can act on, which is not the same question
+  /// [_requestedPackages] answers.
+  ///
+  /// A build writes one page from one package's demos. Defaulting to "all of
+  /// them" would either concatenate catalogues that are deliberately separate
+  /// or silently build the first — so a repo with several is asked, once,
+  /// rather than guessed at.
+  String _requireOnePackage(String? requested) {
+    if (requested != null) {
+      if (!packages.contains(requested)) {
+        throw ArgumentError.value(
+          requested,
+          'package',
+          'not declared for this plugin. Declared: ${packages.join(', ')}',
+        );
+      }
+      return requested;
+    }
+    if (packages.length == 1) return packages.single;
+    if (packages.isEmpty) {
+      throw StateError('No packages are declared for the UI catalog.');
+    }
+    throw ArgumentError.value(
+      null,
+      'package',
+      'this plugin has more than one package, so a build has to say which: '
+          '${packages.join(', ')}',
+    );
+  }
+
+  /// Worktree-relative where it is inside the worktree, so the value survives
+  /// being read on another machine — the same rule [Artifact.path] follows.
+  String _shortened(String path) => p.isWithin(host.worktree.path, path)
+      ? p.relative(path, from: host.worktree.path)
+      : path;
 
   /// Which packages an action was pointed at: the named one, or all declared.
   List<String> _requestedPackages(Map<String, Object?> arguments) {

--- a/app/lib/src/plugins/native/ui_catalog_plugin.dart
+++ b/app/lib/src/plugins/native/ui_catalog_plugin.dart
@@ -9,6 +9,8 @@ import '../../address/address_scope.dart';
 import '../../catalog/catalog_devices.dart';
 import '../../catalog/catalog_session.dart';
 import '../../catalog/catalog_view.dart';
+import '../../catalog/web_build_dialog.dart';
+import '../../catalog/web_server.dart';
 import '../native_plugin.dart';
 import 'ui_catalog_address.dart';
 import 'ui_catalog_core.dart';
@@ -34,7 +36,37 @@ class UiCatalogPlugin extends NativePlugin<UiCatalogCore> {
 
   final _sessions = <String, CatalogSession>{};
 
+  /// A server per served directory, so a rebuild of the same page reuses the
+  /// port a browser tab already has open — the tab reloads onto the new build
+  /// rather than pointing at a server that has gone.
+  final _servers = <String, CatalogWebServer>{};
+
   List<String> get packages => core.packages;
+
+  /// Serves a built page and answers with the URL, starting a server only if
+  /// this directory has not got one.
+  ///
+  /// Owned here rather than by the dialog that asks for it: the dialog is
+  /// closed the moment you have the URL, and a server that died with it would
+  /// leave the tab it just opened showing a connection error. The worktree is
+  /// the right lifetime — see [dispose].
+  Future<Uri> serveBuild(String output, {String basePath = '/'}) async {
+    var directory = p.isAbsolute(output)
+        ? output
+        : p.join(host.worktree.path, output);
+    var existing = _servers[directory];
+    // Rebound when the base href changed: the same directory built for a
+    // different mount point is a different page as far as a browser is
+    // concerned, and the old server would answer 404 for all of it.
+    if (existing != null &&
+        existing.basePath == CatalogWebServer.normaliseBasePath(basePath)) {
+      return existing.url;
+    }
+    await existing?.close();
+    var server = await CatalogWebServer.serve(directory, basePath: basePath);
+    _servers[directory] = server;
+    return server.url;
+  }
 
   /// The live compile loop for [path], started on first ask — which is the
   /// panel mounting.
@@ -72,8 +104,32 @@ class UiCatalogPlugin extends NativePlugin<UiCatalogCore> {
   @override
   Widget buildPanel(BuildContext context) => _CatalogPanel(this);
 
-  /// Closing the worktree is what ends the compile loops — nothing shorter
-  /// does, which is the whole point of the plugin owning them.
+  /// One command, on the row for the package it would build.
+  ///
+  /// On the row rather than in the panel because that is what it is *of*: a
+  /// page is one package's whole catalog, and the panel is always looking at
+  /// one entry of it.
+  @override
+  List<PluginChildCommand> childCommands(
+    BuildContext context,
+    String childId,
+  ) => [
+    PluginChildCommand(
+      label: 'Build a web page…',
+      icon: Icons.language,
+      onSelected: (context) => unawaited(
+        showWebBuildDialog(
+          context,
+          core: core,
+          package: childId,
+          serve: serveBuild,
+        ),
+      ),
+    ),
+  ];
+
+  /// Closing the worktree is what ends the compile loops and the servers —
+  /// nothing shorter does, which is the whole point of the plugin owning them.
   @override
   void dispose() {
     for (var session in _sessions.values) {
@@ -82,6 +138,10 @@ class UiCatalogPlugin extends NativePlugin<UiCatalogCore> {
         ..dispose();
     }
     _sessions.clear();
+    for (var server in _servers.values) {
+      unawaited(server.close());
+    }
+    _servers.clear();
     super.dispose();
   }
 }

--- a/app/lib/src/plugins/native/ui_catalog_results.dart
+++ b/app/lib/src/plugins/native/ui_catalog_results.dart
@@ -550,3 +550,41 @@ class CatalogAuditFailure {
 
   Map<String, Object?> toJson() => _$CatalogAuditFailureToJson(this);
 }
+
+/// `build-web` — where the browsable page was written.
+///
+/// A directory rather than an [Artifact]: an artifact carries one file and a
+/// MIME type, and a Flutter web build is a tree whose entry point happens to be
+/// `index.html`. Naming both is what lets a caller serve the first and open the
+/// second without guessing the relationship.
+@JsonSerializable(
+  explicitToJson: true,
+  includeIfNull: false,
+  createFactory: false,
+)
+class CatalogWebBuildResult implements PluginResult {
+  CatalogWebBuildResult({
+    required this.package,
+    required this.output,
+    required this.indexHtml,
+    required this.entries,
+    required this.durationMs,
+  });
+
+  final String package;
+
+  /// The directory to serve, worktree-relative where it is inside the worktree
+  /// — a path that survives being read on another machine.
+  final String output;
+
+  /// The page to open, relative to the same root as [output].
+  final String indexHtml;
+
+  /// How many entries the page can show.
+  final int entries;
+
+  final int durationMs;
+
+  @override
+  Map<String, Object?> toJson() => _$CatalogWebBuildResultToJson(this);
+}

--- a/app/lib/src/plugins/native/ui_catalog_results.g.dart
+++ b/app/lib/src/plugins/native/ui_catalog_results.g.dart
@@ -135,3 +135,13 @@ Map<String, dynamic> _$CatalogAuditEntryToJson(CatalogAuditEntry instance) =>
 Map<String, dynamic> _$CatalogAuditFailureToJson(
   CatalogAuditFailure instance,
 ) => <String, dynamic>{'package': instance.package, 'error': instance.error};
+
+Map<String, dynamic> _$CatalogWebBuildResultToJson(
+  CatalogWebBuildResult instance,
+) => <String, dynamic>{
+  'package': instance.package,
+  'output': instance.output,
+  'indexHtml': instance.indexHtml,
+  'entries': instance.entries,
+  'durationMs': instance.durationMs,
+};

--- a/app/lib/src/plugins/native_plugin.dart
+++ b/app/lib/src/plugins/native_plugin.dart
@@ -61,6 +61,19 @@ abstract class NativePlugin<C extends PluginCore> extends ChangeNotifier {
   /// something did.
   Widget buildPanel(BuildContext context);
 
+  /// Commands offered on one of this plugin's sidebar rows, behind a ⋮ that
+  /// appears on hover. Empty for most plugins, and then no ⋮ is drawn.
+  ///
+  /// [childId] is the [PluginChild.id] the row stands for — a package path, for
+  /// every plugin that has children today.
+  ///
+  /// Built during the row's build, so a command may close over [context] to put
+  /// something on screen when it is chosen.
+  List<PluginChildCommand> childCommands(
+    BuildContext context,
+    String childId,
+  ) => const [];
+
   /// Schedules a change notification, coalescing bursts into one.
   ///
   /// Prefer this over [notifyListeners]. A plugin's work starts when a widget
@@ -92,6 +105,34 @@ abstract class NativePlugin<C extends PluginCore> extends ChangeNotifier {
     unawaited(_changes.cancel());
     super.dispose();
   }
+}
+
+/// One command on a sidebar child's ⋮ menu.
+///
+/// **Deliberately not a [PluginAction].** An action is behaviour every renderer
+/// can reach by name; these are the GUI's own affordances — a form to fill in
+/// first, a log to watch while it runs, somewhere to go when it finishes. None
+/// of that survives being described to `fw`.
+///
+/// It is not a way to put behaviour in a panel either. What a command drives
+/// still belongs on the [PluginCore], where `fw` and MCP reach the same method
+/// by their own route; the difference is only that the GUI can hand it a
+/// progress callback, which an invocation across a process cannot carry.
+class PluginChildCommand {
+  const PluginChildCommand({
+    required this.label,
+    required this.onSelected,
+    this.icon,
+    this.danger = false,
+  });
+
+  final String label;
+  final IconData? icon;
+
+  /// Destroys data. The row is tinted for it.
+  final bool danger;
+
+  final void Function(BuildContext context) onSelected;
 }
 
 /// Builds a plugin's panel over the core the session already resolved.

--- a/app/lib/src/session/action_shapes.generated.dart
+++ b/app/lib/src/session/action_shapes.generated.dart
@@ -1485,6 +1485,29 @@ final resultShapes = <String, ResultShape>{
       },
     ],
   }),
+  'CatalogWebBuildResult': ResultShape.fromJson(<String, Object?>{
+    'type': 'CatalogWebBuildResult',
+    'fields': <Object?>[
+      <String, Object?>{'name': 'package', 'type': 'String'},
+      <String, Object?>{
+        'name': 'output',
+        'type': 'String',
+        'doc':
+            'The directory to serve, worktree-relative where it is inside the worktree — a path that survives being read on another machine.',
+      },
+      <String, Object?>{
+        'name': 'indexHtml',
+        'type': 'String',
+        'doc': 'The page to open, relative to the same root as [output].',
+      },
+      <String, Object?>{
+        'name': 'entries',
+        'type': 'int',
+        'doc': 'How many entries the page can show.',
+      },
+      <String, Object?>{'name': 'durationMs', 'type': 'int'},
+    ],
+  }),
   'DependencyEntry': ResultShape.fromJson(<String, Object?>{
     'type': 'DependencyEntry',
     'fields': <Object?>[

--- a/app/lib/src/shell/shell_view.dart
+++ b/app/lib/src/shell/shell_view.dart
@@ -13,6 +13,7 @@ import '../utils/hot_reload.dart';
 import '../utils/value_stream_builder.dart';
 import 'shell_controller.dart';
 import 'shell_search.dart';
+import 'sidebar_row.dart';
 import 'worktree.dart';
 import 'worktree_home.dart';
 
@@ -27,16 +28,6 @@ const _tabInset = 6.0;
 /// How much of a tab a worktree's name may claim before it is ellipsised.
 const _tabLabelMaxWidth = 180.0;
 const _sidebarWidth = 232.0;
-
-/// Maps a plugin [Tone] to a palette colour. The single place tones become
-/// pixels — everywhere else they stay data.
-Color toneColor(FwPalette colors, Tone tone) => switch (tone) {
-  Tone.neutral => colors.mut2,
-  Tone.good => colors.grn,
-  Tone.info => colors.info,
-  Tone.warn => colors.amber,
-  Tone.error => colors.red,
-};
 
 class ShellApp extends StatelessWidget {
   const ShellApp(this.shell, {super.key});
@@ -747,7 +738,15 @@ class _Sidebar extends StatelessWidget {
                     // summary.
                     if (shell.selectedPluginId == plugin.id)
                       for (var child in plugin.core.report.children)
-                        _ChildRow(shell, plugin.id, child),
+                        SidebarChildRow(
+                          label: child.label,
+                          status: child.status,
+                          selected:
+                              shell.selectedPluginId == plugin.id &&
+                              shell.selectedChildId == child.id,
+                          commands: plugin.childCommands(context, child.id),
+                          onTap: () => shell.selectChild(plugin.id, child.id),
+                        ),
                   ],
               ],
             ),
@@ -872,84 +871,6 @@ class _PluginRow extends StatelessWidget {
       selected: shell.selectedPluginId == plugin.id,
       onTap: () => shell.selectPlugin(plugin.id),
       status: report.status,
-    );
-  }
-}
-
-/// One package of a plugin, hung off a rail rather than boxed. Selecting it is
-/// what raises that package's work.
-class _ChildRow extends StatelessWidget {
-  const _ChildRow(this.shell, this.pluginId, this.child);
-
-  final ShellController shell;
-  final String pluginId;
-  final PluginChild child;
-
-  @override
-  Widget build(BuildContext context) {
-    var colors = context.colors;
-    var selected =
-        shell.selectedPluginId == pluginId && shell.selectedChildId == child.id;
-
-    return _Hoverable(
-      onTap: () => shell.selectChild(pluginId, child.id),
-      builder: (context, hovered) => Container(
-        // The rail is always drawn — only its colour changes — so the row keeps
-        // its geometry and nothing below it moves on selection.
-        margin: const EdgeInsets.only(left: FwSpacing.xxl),
-        decoration: BoxDecoration(
-          color: hovered && !selected
-              ? colors.hoverOverlay
-              : Colors.transparent,
-          border: Border(
-            left: BorderSide(
-              color: selected
-                  ? colors.accent
-                  : hovered
-                  ? colors.mut3
-                  : colors.line,
-              width: 2,
-            ),
-          ),
-        ),
-        padding: const EdgeInsets.fromLTRB(
-          FwSpacing.lg,
-          FwSpacing.sm,
-          FwSpacing.xl,
-          FwSpacing.sm,
-        ),
-        child: Row(
-          children: [
-            Expanded(
-              child: Text(
-                child.label,
-                overflow: TextOverflow.ellipsis,
-                style: context.type.bodySmall.copyWith(
-                  color: selected ? colors.ink : colors.mut,
-                ),
-              ),
-            ),
-            if (!child.status.isEmpty) ...[
-              const Gap(FwSpacing.sm),
-              // Flexible, so a long status cannot take the whole row and leave
-              // the `Expanded` label with nothing — a row that says
-              // "10 assets · 347 kB · 2 problems" and not *which package* is
-              // worse than one that says neither. Loose fit: a short status
-              // still takes only what it needs and the label keeps the rest.
-              Flexible(
-                child: Text(
-                  child.status.message,
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                  style: context.type.micro.copyWith(
-                    color: toneColor(colors, child.status.tone),
-                  ),
-                ),
-              ),
-            ],
-          ],
-        ),
-      ),
     );
   }
 }

--- a/app/lib/src/shell/sidebar_row.dart
+++ b/app/lib/src/shell/sidebar_row.dart
@@ -1,0 +1,212 @@
+import 'package:flutter/material.dart';
+import 'package:flutterware/plugins.dart';
+
+import '../plugins/native_plugin.dart';
+import '../ui/menu.dart';
+import '../ui/popover.dart';
+import '../ui/tappable.dart';
+import '../ui/theme.dart';
+
+/// How much of the rail a status may claim before it ellipsises.
+///
+/// A constant rather than a fraction: the sidebar is a fixed 232 wide, and this
+/// leaves a readable name beside the longest status any plugin writes today —
+/// the asset inspector's "10 assets · 347 kB · 2 problems".
+const _statusMaxWidth = 100.0;
+
+/// One package of a plugin, hung off a rail rather than boxed. Selecting it is
+/// what raises that package's work.
+///
+/// Takes what it draws, not the controller that knows it: the shell reads
+/// selection and hands over commands, so this can be put in the catalog and
+/// looked at in every state without a session behind it. See
+/// `tool/catalog/demos/sidebar_row.dart`.
+class SidebarChildRow extends StatelessWidget {
+  const SidebarChildRow({
+    super.key,
+    required this.label,
+    required this.status,
+    required this.selected,
+    required this.onTap,
+    this.commands = const [],
+  });
+
+  final String label;
+  final Status status;
+  final bool selected;
+  final VoidCallback onTap;
+
+  /// What the ⋮ offers. Empty draws no ⋮ at all.
+  final List<PluginChildCommand> commands;
+
+  @override
+  Widget build(BuildContext context) {
+    var colors = context.colors;
+
+    return _Hoverable(
+      onTap: onTap,
+      builder: (context, hovered) => Container(
+        // The rail is always drawn — only its colour changes — so the row keeps
+        // its geometry and nothing below it moves on selection.
+        margin: const EdgeInsets.only(left: FwSpacing.xxl),
+        decoration: BoxDecoration(
+          color: hovered && !selected
+              ? colors.hoverOverlay
+              : Colors.transparent,
+          border: Border(
+            left: BorderSide(
+              color: selected
+                  ? colors.accent
+                  : hovered
+                  ? colors.mut3
+                  : colors.line,
+              width: 2,
+            ),
+          ),
+        ),
+        padding: const EdgeInsets.fromLTRB(
+          FwSpacing.lg,
+          FwSpacing.sm,
+          FwSpacing.xl,
+          FwSpacing.sm,
+        ),
+        child: Row(
+          children: [
+            // The row reads left to right — name, status — and the ⋮ sits at
+            // the far edge. Two things are needed for that, and they are easy
+            // to confuse:
+            //
+            // The **Expanded** takes all the slack, so the ⋮ after it is pinned
+            // to the right rather than trailing whatever the status ended at.
+            // The **loose Flexibles inside it** each take only their own width,
+            // so the status sits against the name instead of being pushed to
+            // the middle by a label that had filled half the row.
+            Expanded(
+              child: Row(
+                children: [
+                  // The name yields and the status does not, which is the way
+                  // round it has to be. A flexible child is *clamped* to its
+                  // share of the row whether or not the other one wanted it, so
+                  // a flexible status was truncated to "buildi…" beside a
+                  // three-letter package name with the rest of the row empty.
+                  // Non-flexible, it takes its own width and the name takes
+                  // what is left.
+                  Flexible(
+                    child: Text(
+                      label,
+                      overflow: TextOverflow.ellipsis,
+                      style: context.type.bodySmall.copyWith(
+                        color: selected ? colors.ink : colors.mut,
+                      ),
+                    ),
+                  ),
+                  if (!status.isEmpty) ...[
+                    const Gap(FwSpacing.sm),
+                    // Capped, because "does not yield" cannot mean "takes the
+                    // whole row": a row reading "10 assets · 347 kB · 2
+                    // problems" and not *which package* is worse than one that
+                    // says neither. Past this it ellipsises and the name keeps
+                    // the rest.
+                    ConstrainedBox(
+                      constraints: const BoxConstraints(
+                        maxWidth: _statusMaxWidth,
+                      ),
+                      child: Text(
+                        status.message,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: context.type.micro.copyWith(
+                          color: toneColor(colors, status.tone),
+                        ),
+                      ),
+                    ),
+                  ],
+                ],
+              ),
+            ),
+            if (commands.isNotEmpty) ...[
+              // Clear of the status. At 14px the glyph is mostly whitespace, so
+              // set flush against a word it reads as punctuation on the end of
+              // it rather than as a control of its own.
+              const Gap(FwSpacing.sm),
+              // Only under the pointer, and holding its box either way: a ⋮ on
+              // every row is a column of dots down the sidebar, and a ⋮ that
+              // appears by *widening* the row shifts the status you were
+              // reading on the way to it.
+              //
+              // Square and explicit, so the tap target is the box rather than
+              // the glyph — `Tappable` is opaque and adds no padding of its
+              // own, which leaves 14px of dots to hit otherwise.
+              SizedBox(
+                width: 18,
+                height: 18,
+                child: hovered || selected
+                    ? _ChildCommandsButton(commands)
+                    : null,
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// The ⋮ on a sidebar child row.
+class _ChildCommandsButton extends StatelessWidget {
+  const _ChildCommandsButton(this.commands);
+
+  final List<PluginChildCommand> commands;
+
+  @override
+  Widget build(BuildContext context) {
+    return Menu(
+      side: PopoverSide.bottom,
+      align: PopoverAlign.end,
+      entries: [
+        for (var command in commands)
+          MenuItem(
+            command.label,
+            icon: command.icon,
+            danger: command.danger,
+            // Captured from the *row*, not from the menu: the popover is gone
+            // by the time this runs, and a dialog pushed onto a dead context
+            // throws.
+            onSelected: () => command.onSelected(context),
+          ),
+      ],
+      builder: (context, controller) => Tappable(
+        onTap: controller.toggle,
+        child: Center(
+          child: Icon(Icons.more_vert, size: 14, color: context.colors.mut),
+        ),
+      ),
+    );
+  }
+}
+
+/// Hover tracking for a whole row, handed to the builder.
+class _Hoverable extends StatefulWidget {
+  const _Hoverable({required this.onTap, required this.builder});
+
+  final VoidCallback onTap;
+  final Widget Function(BuildContext context, bool hovered) builder;
+
+  @override
+  State<_Hoverable> createState() => _HoverableState();
+}
+
+class _HoverableState extends State<_Hoverable> {
+  var _hovered = false;
+
+  @override
+  Widget build(BuildContext context) => MouseRegion(
+    cursor: SystemMouseCursors.click,
+    onEnter: (_) => setState(() => _hovered = true),
+    onExit: (_) => setState(() => _hovered = false),
+    child: GestureDetector(
+      onTap: widget.onTap,
+      child: widget.builder(context, _hovered),
+    ),
+  );
+}

--- a/app/lib/src/ui/theme.dart
+++ b/app/lib/src/ui/theme.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutterware/plugins.dart';
 
 import 'design/design.dart';
 
@@ -154,3 +155,13 @@ ThemeData buildAppTheme(FwTokens tokens) {
     ),
   );
 }
+
+/// Maps a plugin [Tone] to a palette colour. The single place tones become
+/// pixels — everywhere else they stay data.
+Color toneColor(FwPalette colors, Tone tone) => switch (tone) {
+  Tone.neutral => colors.mut2,
+  Tone.good => colors.grn,
+  Tone.info => colors.info,
+  Tone.warn => colors.amber,
+  Tone.error => colors.red,
+};

--- a/app/lib/src/utils/image_clipboard.dart
+++ b/app/lib/src/utils/image_clipboard.dart
@@ -1,0 +1,37 @@
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+
+/// Puts a picture on the system clipboard.
+///
+/// Flutter's own [Clipboard] carries text and nothing else, so this goes
+/// through a channel of our own — `macos/Runner/ClipboardImagePlugin.swift`
+/// says why that beat taking a package for it.
+///
+/// macOS only, and not as a stopgap: the preview being copied is composited by
+/// the embedder host, which is Metal and IOSurface throughout, so anywhere else
+/// there is no picture to copy in the first place. [isSupported] is what a
+/// button asks so it can disable itself rather than fail under the pointer.
+class ImageClipboard {
+  static const _channel = MethodChannel('flutterware/clipboard');
+
+  static bool get isSupported => Platform.isMacOS;
+
+  /// Replaces the clipboard's contents with [png].
+  ///
+  /// Throws where there is no implementation rather than returning quietly: a
+  /// caller that skipped [isSupported] should find out, and a copy that reports
+  /// success and puts nothing on the clipboard is discovered at the paste.
+  static Future<void> setPng(Uint8List png) async {
+    if (!isSupported) {
+      throw UnsupportedError(
+        'Copying an image is implemented on macOS, which is also the only '
+        'platform the catalog preview runs on.',
+      );
+    }
+    var written = await _channel.invokeMethod<bool>('setImage', {'png': png});
+    if (written != true) {
+      throw StateError('the clipboard refused the image');
+    }
+  }
+}

--- a/app/macos/Runner.xcodeproj/project.pbxproj
+++ b/app/macos/Runner.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		33CC11132044BFA00003C045 /* MainFlutterWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33CC11122044BFA00003C045 /* MainFlutterWindow.swift */; };
 		78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */ = {isa = PBXBuildFile; productRef = 78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */; };
 		A1B2C3D4E5F6071829304152 /* EmbedderTexturePlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F6071829304153 /* EmbedderTexturePlugin.swift */; };
+		A1B2C3D4E5F6071829304154 /* ClipboardImagePlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F6071829304155 /* ClipboardImagePlugin.swift */; };
 		B9F22E02A996EF37B43016B3 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0970144B6605BC51B1A21A46 /* Pods_Runner.framework */; };
 		F3833350F12D37F74A1A48C2 /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1ECE84B6703BEC2BD4E2C7E8 /* Pods_RunnerTests.framework */; };
 /* End PBXBuildFile section */
@@ -90,6 +91,7 @@
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
 		97AB6D73C3FBDDFF0809BE94 /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
 		A1B2C3D4E5F6071829304153 /* EmbedderTexturePlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmbedderTexturePlugin.swift; sourceTree = "<group>"; };
+		A1B2C3D4E5F6071829304155 /* ClipboardImagePlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipboardImagePlugin.swift; sourceTree = "<group>"; };
 		AE2994B9B8BBACC228D8C3F7 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 		CFC2A25E8B377369B46F2FD1 /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -184,6 +186,7 @@
 				33CC10F02044A3C60003C045 /* AppDelegate.swift */,
 				33CC11122044BFA00003C045 /* MainFlutterWindow.swift */,
 				A1B2C3D4E5F6071829304153 /* EmbedderTexturePlugin.swift */,
+				A1B2C3D4E5F6071829304155 /* ClipboardImagePlugin.swift */,
 				33E51913231747F40026EE4D /* DebugProfile.entitlements */,
 				33E51914231749380026EE4D /* Release.entitlements */,
 				33CC11242044D66E0003C045 /* Resources */,
@@ -433,6 +436,7 @@
 			files = (
 				33CC11132044BFA00003C045 /* MainFlutterWindow.swift in Sources */,
 				A1B2C3D4E5F6071829304152 /* EmbedderTexturePlugin.swift in Sources */,
+				A1B2C3D4E5F6071829304154 /* ClipboardImagePlugin.swift in Sources */,
 				33CC10F12044A3C60003C045 /* AppDelegate.swift in Sources */,
 				335BBD1B22A9A15E00E9071D /* GeneratedPluginRegistrant.swift in Sources */,
 			);

--- a/app/macos/Runner/ClipboardImagePlugin.swift
+++ b/app/macos/Runner/ClipboardImagePlugin.swift
@@ -1,0 +1,61 @@
+import AppKit
+import FlutterMacOS
+
+/// Puts an image on the system clipboard.
+///
+/// Flutter's own `Clipboard` carries text and nothing else, so copying a
+/// catalog preview has no framework route. The alternative was a package that
+/// builds through cargokit — and since the CLI compiles this app on the user's
+/// machine at first run, that would make a Rust toolchain a requirement for
+/// installing flutterware. A pasteboard write is small enough to own.
+public class ClipboardImagePlugin: NSObject, FlutterPlugin {
+  public static func register(with registrar: FlutterPluginRegistrar) {
+    let channel = FlutterMethodChannel(
+      name: "flutterware/clipboard",
+      binaryMessenger: registrar.messenger)
+    registrar.addMethodCallDelegate(ClipboardImagePlugin(), channel: channel)
+  }
+
+  public func handle(_ call: FlutterMethodCall,
+                     result: @escaping FlutterResult) {
+    switch call.method {
+    case "setImage":
+      let args = call.arguments as? [String: Any] ?? [:]
+      guard let data = args["png"] as? FlutterStandardTypedData else {
+        result(FlutterError(code: "bad_args",
+                            message: "png bytes required", details: nil))
+        return
+      }
+      // Decoded first as a check on the bytes, and because TIFF below is
+      // derived from it. `writeObjects([image])` on its own is *not* enough:
+      // NSImage advertises only `.tiff` as a writable pasteboard type, so a
+      // target that reads `public.png` — several Electron and web-based editors
+      // do exactly that — would find nothing, while `writeObjects` still
+      // returned true and the copy reported success.
+      guard let image = NSImage(data: data.data) else {
+        result(FlutterError(code: "decode_failed",
+                            message: "the bytes are not a readable image",
+                            details: nil))
+        return
+      }
+      let pasteboard = NSPasteboard.general
+      // Clears the pasteboard as well as announcing the types. Both are needed:
+      // without the clear the new item joins whatever was already there and the
+      // paste target picks by its own preference order rather than getting what
+      // was just copied.
+      //
+      // PNG first, because the order here *is* the offered preference order and
+      // the PNG is the bytes we were handed — a target that can take either
+      // should get those rather than a re-encode.
+      pasteboard.declareTypes([.png, .tiff], owner: nil)
+      var wrote = pasteboard.setData(data.data, forType: .png)
+      // TIFF as well, for the targets that only ever learned that one.
+      if let tiff = image.tiffRepresentation {
+        wrote = pasteboard.setData(tiff, forType: .tiff) || wrote
+      }
+      result(NSNumber(value: wrote))
+    default:
+      result(FlutterMethodNotImplemented)
+    }
+  }
+}

--- a/app/macos/Runner/MainFlutterWindow.swift
+++ b/app/macos/Runner/MainFlutterWindow.swift
@@ -19,6 +19,8 @@ class MainFlutterWindow: NSWindow {
     RegisterGeneratedPlugins(registry: flutterViewController)
     EmbedderTexturePlugin.register(
       with: flutterViewController.registrar(forPlugin: "EmbedderTexturePlugin"))
+    ClipboardImagePlugin.register(
+      with: flutterViewController.registrar(forPlugin: "ClipboardImagePlugin"))
 
     super.awakeFromNib()
   }

--- a/app/test/catalog/web_app_generator_test.dart
+++ b/app/test/catalog/web_app_generator_test.dart
@@ -1,0 +1,180 @@
+import 'dart:io';
+
+import 'package:flutterware_app/src/catalog/catalog_entry.dart';
+import 'package:flutterware_app/src/catalog/web_app_generator.dart';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+/// The generated app is only ever read by `flutter build web`, which means a
+/// mistake here surfaces as a compile error inside generated code — a long way
+/// from the entry that caused it. These assert the shape directly.
+void main() {
+  late Directory root;
+  late WebAppGenerator generator;
+
+  const members = CatalogEntry(
+    path: 'demo/team/avatar_tile.dart',
+    symbol: 'avatarTileMembers',
+    name: 'Members',
+    group: 'Avatar tile',
+    annotation: "Demo(name: 'Members', group: 'Avatar tile')",
+  );
+  const empty = CatalogEntry(
+    path: 'demo/team/avatar_tile.dart',
+    symbol: 'avatarTileEmpty',
+    name: "Empty — nobody's here",
+    group: 'Avatar tile',
+    annotation: "Demo(name: 'Empty', group: 'Avatar tile')",
+  );
+  const settings = CatalogEntry(
+    path: 'demo/settings.dart',
+    symbol: 'settings',
+    name: 'Settings',
+    annotation: 'Demo()',
+  );
+
+  /// Another file, another symbol, the *same* display name — which discovery
+  /// allows, because it rejects a duplicate id and not a duplicate name.
+  const otherSettings = CatalogEntry(
+    path: 'demo/settings_wide.dart',
+    symbol: 'settingsWide',
+    name: 'Settings',
+    annotation: 'Demo()',
+  );
+
+  setUp(() {
+    root = Directory.systemTemp.createTempSync('fw_web_app_test');
+    Directory(p.join(root.path, 'demo', 'team')).createSync(recursive: true);
+    File(
+      p.join(root.path, 'demo', 'team', 'avatar_tile.dart'),
+    ).writeAsStringSync('''
+import 'package:flutter/material.dart';
+
+import '../shell.dart';
+
+Widget avatarTileMembers() => const Placeholder();
+Widget avatarTileEmpty() => const Placeholder();
+''');
+    File(p.join(root.path, 'demo', 'settings.dart')).writeAsStringSync('''
+import 'package:flutter/material.dart';
+
+Widget settings() => const Placeholder();
+''');
+    File(p.join(root.path, 'demo', 'settings_wide.dart')).writeAsStringSync('''
+import 'package:flutter/material.dart';
+
+Widget settingsWide() => const Placeholder();
+''');
+    generator = WebAppGenerator(
+      outputDir: p.join(root.path, 'build', 'web_src'),
+      projectRoot: root.path,
+      title: 'Example',
+    );
+  });
+
+  tearDown(() => root.deleteSync(recursive: true));
+
+  String generate(List<CatalogEntry> entries) {
+    generator.generate(entries);
+    return File(generator.entrypointPath).readAsStringSync();
+  }
+
+  test('every entry gets a wrapper, and the entrypoint imports them all', () {
+    var main = generate([members, empty, settings]);
+
+    for (var i = 0; i < 3; i++) {
+      expect(
+        File(
+          p.join(root.path, 'build', 'web_src', 'entry_$i.dart'),
+        ).existsSync(),
+        isTrue,
+        reason: 'entry_$i.dart should have been written',
+      );
+      expect(main, contains("import 'entry_$i.dart' as fw$i;"));
+    }
+  });
+
+  test('the map nests the way the panel tree does', () {
+    var main = generate([members, empty, settings]);
+
+    // `demo/` is the directory every entry shares, so it is dropped; the group
+    // survives as a level. This is `buildCatalogTree`'s arrangement, and the
+    // point of reusing it is that the page and the panel agree.
+    expect(main, contains("'Avatar tile': <String, dynamic>{"));
+    expect(main, contains("'Members': _entry(fw0.fwDemo, fw0.fwBuilder)"));
+    expect(main, contains("'Settings': _entry(fw2.fwDemo, fw2.fwBuilder)"));
+  });
+
+  test(
+    'a name with an apostrophe is escaped rather than breaking the file',
+    () {
+      var main = generate([members, empty, settings]);
+      // A display name is written by a human in an annotation. Unescaped, this
+      // one closes the literal and the generated file does not parse.
+      expect(main, contains(r"'Empty — nobody\'s here'"));
+    },
+  );
+
+  test('the wrapper is applied, and nothing else the annotation carries', () {
+    var main = generate([settings]);
+    // Parity with `_CatalogHost` in the guest's entrypoint, which also applies
+    // only `wrapper`. An entry that looked one way in the panel and another on
+    // the page would be worse than one ignoring an annotation in both.
+    expect(main, contains('var wrapper = demo.transform().wrapper;'));
+    expect(main, isNot(contains('preview.size')));
+  });
+
+  test('regenerating clears a wrapper whose entry is gone', () {
+    generate([members, empty, settings]);
+    var third = File(p.join(root.path, 'build', 'web_src', 'entry_2.dart'));
+    expect(third.existsSync(), isTrue);
+
+    generate([members]);
+
+    // Left behind, it would name a demo that no longer exists and fail the
+    // build inside generated code.
+    expect(third.existsSync(), isFalse);
+  });
+
+  test('two entries with one name both reach the page', () {
+    var main = generate([settings, otherSettings]);
+
+    // Emitted as-is this was `'Settings': …, 'Settings': …` — a repeated key in
+    // a map literal, where the last one wins and the other demo is simply not on
+    // the page. The panel keys its tree by id and shows both, so this was the
+    // page and the panel disagreeing about what exists.
+    expect(main, contains("'Settings': _entry(fw0.fwDemo, fw0.fwBuilder)"));
+    expect(
+      main,
+      contains("'Settings (settingsWide)': _entry(fw1.fwDemo, fw1.fwBuilder)"),
+    );
+  });
+
+  test('every key in a branch is distinct', () {
+    var main = generate([settings, otherSettings, members, empty]);
+
+    // Whatever the disambiguation looks like, this is the property that matters.
+    var keys = RegExp(
+      r"^\s+('(?:[^'\\]|\\.)*'):",
+      multiLine: true,
+    ).allMatches(main).map((m) => m.group(1)!).toList();
+    expect(keys, isNotEmpty);
+    expect(keys.toSet(), hasLength(keys.length), reason: 'keys: $keys');
+  });
+
+  test('an entry with no wrapper still reaches its builder', () {
+    generator.generate([settings]);
+    var wrapper = File(
+      p.join(root.path, 'build', 'web_src', 'entry_0.dart'),
+    ).readAsStringSync();
+
+    expect(wrapper, contains('Demo get fwDemo => Demo();'));
+    expect(
+      wrapper,
+      contains('Widget Function() get fwBuilder => fw0.settings;'),
+    );
+    // Carried from the demo file, with the relative URI rewritten to resolve
+    // from the generated directory rather than from the demo's own.
+    expect(wrapper, contains("import 'package:flutter/material.dart';"));
+  });
+}

--- a/app/test/catalog/web_build_command_test.dart
+++ b/app/test/catalog/web_build_command_test.dart
@@ -1,0 +1,196 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+import 'package:flutterware/plugins.dart';
+// ignore: implementation_imports
+import 'package:flutterware/src/log_client.dart';
+import 'package:flutterware_app/src/catalog/catalog_entry.dart';
+import 'package:flutterware_app/src/catalog/web_build.dart';
+import 'package:flutterware_app/src/catalog/web_build_dialog.dart';
+import 'package:flutterware_app/src/context.dart';
+import 'package:flutterware_app/src/plugins/native/ui_catalog_core.dart';
+import 'package:flutterware_app/src/plugins/plugin_host.dart';
+import 'package:flutterware_app/src/shell/workspace.dart';
+import 'package:flutterware_app/src/shell/worktree.dart';
+import 'package:flutterware_app/src/utils/flutter_sdk.dart';
+
+/// The command the build dialog shows.
+///
+/// It is an instruction to a user, so the thing worth testing is not its
+/// wording but whether it would *work*: the flags have to be the ones the
+/// action declares, and the defaults it leaves out have to be the ones the
+/// action actually defaults to.
+void main() {
+  String command({
+    String package = '.',
+    bool nameThePackage = false,
+    String output = '',
+    String baseHref = '',
+  }) => webBuildCommand(
+    pluginId: uiCatalogPluginId,
+    package: package,
+    nameThePackage: nameThePackage,
+    output: output,
+    baseHref: baseHref,
+  );
+
+  test('the bare form names the plugin the way the CLI resolves it', () {
+    // `fw` matches on the last dotted segment, not the full id.
+    expect(command(), 'dart run flutterware run ui_catalog build-web');
+  });
+
+  test('the default output is left off', () {
+    // Spelling out a value that changes nothing teaches the flag rather than
+    // the command.
+    expect(
+      command(output: WebCatalogBuilder.defaultOutput),
+      isNot(contains('--output')),
+    );
+    expect(command(output: 'docs/catalog'), contains('--output=docs/catalog'));
+  });
+
+  test('the package is named only where the action needs it', () {
+    expect(command(package: 'packages/ui'), isNot(contains('--package')));
+    expect(
+      command(package: 'packages/ui', nameThePackage: true),
+      contains('--package=packages/ui'),
+    );
+  });
+
+  test('a base href appears as written', () {
+    expect(command(baseHref: '/catalog/'), endsWith('--base-href=/catalog/'));
+  });
+
+  test('a path with a space is quoted', () {
+    // Unquoted this is two arguments and the command silently builds somewhere
+    // else.
+    expect(
+      command(output: 'my builds/web'),
+      contains("--output='my builds/web'"),
+    );
+  });
+
+  group('cancellation', () {
+    late Directory root;
+
+    setUp(() {
+      root = Directory.systemTemp.createTempSync('fw_web_cancel_test');
+      Directory(p.join(root.path, 'web')).createSync(recursive: true);
+      var demo = Directory(p.join(root.path, 'demo'))
+        ..createSync(recursive: true);
+      File(p.join(demo.path, 'a.dart')).writeAsStringSync('''
+import 'package:flutter/material.dart';
+
+Widget a() => const Placeholder();
+''');
+    });
+
+    tearDown(() => root.deleteSync(recursive: true));
+
+    const entry = CatalogEntry(
+      path: 'demo/a.dart',
+      symbol: 'a',
+      name: 'A',
+      annotation: 'Demo()',
+    );
+
+    test('a cancelled build says so rather than looking broken', () async {
+      // A stand-in for the compile: a child that ignores the build arguments
+      // and does not finish on its own, so the only way this call returns is
+      // the kill. `exec` so the signal reaches the sleep rather than a shell
+      // holding it.
+      var fake = File(p.join(root.path, 'fake_flutter'))
+        ..writeAsStringSync('#!/bin/sh\nexec sleep 30\n');
+      Process.runSync('chmod', ['+x', fake.path]);
+
+      var builder = WebCatalogBuilder(
+        flutterExecutable: fake.path,
+        packageRoot: root.path,
+        title: 'Example',
+      );
+      var building = builder.build(entries: const [entry]);
+
+      // After the process is up, so there is something to signal.
+      await Future<void>.delayed(const Duration(milliseconds: 200));
+      await builder.cancel();
+
+      // Not "exit 143": a build stopped on purpose is not a build that broke,
+      // and before this the child was never signalled at all — it outlived the
+      // app, kept writing into the project, and had its generated sources
+      // deleted under it by the next build.
+      await expectLater(
+        building,
+        throwsA(
+          isA<StateError>().having(
+            (e) => e.message,
+            'message',
+            contains('cancelled'),
+          ),
+        ),
+      );
+    });
+  });
+
+  group('against the action it claims to run', () {
+    late Directory root;
+
+    UiCatalogCore core() {
+      var worktree = Worktree(path: root.path);
+      return UiCatalogCore(
+        PluginHost(
+          id: uiCatalogPluginId,
+          label: 'UI catalog',
+          worktree: worktree,
+          workspace: Workspace(
+            root: worktree.path,
+            declared: [Pkg('.')],
+            discovered: const ['.'],
+            appContext: AppContext(logger: LogClient.print()),
+            flutterSdk: FlutterSdkPath('/tmp/flutter'),
+          ),
+          config: const {
+            'packages': [
+              {'path': '.'},
+            ],
+          },
+        ),
+      );
+    }
+
+    setUp(() {
+      root = Directory.systemTemp.createTempSync('fw_web_command_test');
+    });
+
+    tearDown(() => root.deleteSync(recursive: true));
+
+    test('every flag it prints is one the action declares', () {
+      var action = core().report.actions.firstWhere(
+        (a) => a.id == webBuildActionId,
+      );
+      var declared = {for (var p in action.parameters) p.id};
+
+      var printed = command(
+        package: 'packages/ui',
+        nameThePackage: true,
+        output: 'docs/catalog',
+        baseHref: '/catalog/',
+      );
+      var flags = RegExp(
+        r'--([a-z-]+)=',
+      ).allMatches(printed).map((m) => m.group(1)!).toSet();
+
+      expect(flags, isNotEmpty);
+      // A flag renamed on the action and not here is a command that fails the
+      // moment somebody copies it.
+      expect(declared, containsAll(flags));
+    });
+
+    test('the action it names exists', () {
+      expect(
+        core().report.actions.map((a) => a.id),
+        contains(webBuildActionId),
+      );
+    });
+  });
+}

--- a/app/test/catalog/web_server_test.dart
+++ b/app/test/catalog/web_server_test.dart
@@ -1,0 +1,136 @@
+import 'dart:io';
+
+import 'package:flutterware_app/src/catalog/web_server.dart';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+/// What a browser needs from the server, asserted with a real client.
+///
+/// Every failure here presents as a blank page — a Flutter web build that
+/// cannot fetch its own payload renders nothing and says nothing — so the
+/// assertions are about headers and status codes rather than about anything
+/// visible.
+void main() {
+  late Directory root;
+  late HttpClient client;
+  final servers = <CatalogWebServer>[];
+
+  Future<CatalogWebServer> serve({String basePath = '/'}) async {
+    var server = await CatalogWebServer.serve(root.path, basePath: basePath);
+    servers.add(server);
+    return server;
+  }
+
+  Future<HttpClientResponse> get(Uri url) async =>
+      (await client.getUrl(url)).close();
+
+  void write(String relative, String content) {
+    var file = File(p.join(root.path, relative));
+    file.parent.createSync(recursive: true);
+    file.writeAsStringSync(content);
+  }
+
+  setUp(() {
+    root = Directory.systemTemp.createTempSync('fw_web_server_test');
+    client = HttpClient();
+    write('index.html', '<!doctype html><title>catalog</title>');
+    write('main.dart.js', 'console.log(1);');
+    write('assets/AssetManifest.json', '{}');
+  });
+
+  tearDown(() async {
+    client.close(force: true);
+    for (var server in servers) {
+      await server.close();
+    }
+    servers.clear();
+    root.deleteSync(recursive: true);
+  });
+
+  test('the root serves the index', () async {
+    var server = await serve();
+    var response = await get(server.url);
+
+    expect(response.statusCode, 200);
+    expect(response.headers.contentType?.mimeType, 'text/html');
+  });
+
+  test('script and manifest come back as their own types', () async {
+    var server = await serve();
+
+    // A `.js` served as text/plain does not execute, and the page is blank
+    // with nothing in the console to say why.
+    var script = await get(server.url.resolve('main.dart.js'));
+    expect(script.statusCode, 200);
+    expect(script.headers.contentType?.mimeType, 'text/javascript');
+
+    var manifest = await get(server.url.resolve('assets/AssetManifest.json'));
+    expect(manifest.statusCode, 200);
+    expect(manifest.headers.contentType?.mimeType, 'application/json');
+  });
+
+  test('nothing is cached, so a rebuild is what a reload shows', () async {
+    var server = await serve();
+    var response = await get(server.url);
+
+    expect(response.headers.value('cache-control'), 'no-store');
+  });
+
+  test('a path climbing out of the directory is refused', () async {
+    write('../secret.txt', 'not yours');
+    var server = await serve();
+
+    // Sent raw rather than through `Uri.resolve`, which would normalise the
+    // `..` away on the client and never exercise the server.
+    var request = await client.get(
+      server.url.host,
+      server.url.port,
+      '/../secret.txt',
+    );
+    var response = await request.close();
+
+    expect(response.statusCode, anyOf(403, 404));
+  });
+
+  test('a missing file is a 404 rather than a hang', () async {
+    var server = await serve();
+    var response = await get(server.url.resolve('nope.js'));
+
+    expect(response.statusCode, 404);
+  });
+
+  group('with a base href', () {
+    test('the url carries the mount point', () async {
+      var server = await serve(basePath: '/catalog/');
+      expect(server.url.path, '/catalog/');
+    });
+
+    test('a slash is added at both ends if it was left off', () async {
+      var server = await serve(basePath: 'catalog');
+      expect(server.basePath, '/catalog/');
+    });
+
+    test('assets resolve under the prefix, and only there', () async {
+      var server = await serve(basePath: '/catalog/');
+
+      var index = await get(server.url);
+      expect(index.statusCode, 200);
+
+      var script = await get(server.url.resolve('main.dart.js'));
+      expect(script.statusCode, 200);
+
+      // The page's `<base href>` makes every asset request carry the prefix, so
+      // serving the same files at the root as well would mean two URLs for one
+      // page and a page that half-works from the wrong one.
+      var atRoot = await get(
+        Uri(
+          scheme: 'http',
+          host: server.url.host,
+          port: server.url.port,
+          path: '/main.dart.js',
+        ),
+      );
+      expect(atRoot.statusCode, 404);
+    });
+  });
+}

--- a/app/test/embedder/frame_capture_test.dart
+++ b/app/test/embedder/frame_capture_test.dart
@@ -1,0 +1,247 @@
+import 'dart:async';
+import 'dart:io';
+import 'dart:typed_data';
+
+// ignore: implementation_imports
+import 'package:flutterware/src/inspect/node.dart';
+import 'package:flutterware_app/src/embedder/frame_capture.dart';
+import 'package:flutterware_app/src/embedder/protocol.dart';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+/// The capture exchange, without a guest.
+///
+/// Worth testing here rather than only end to end: this is what the headless
+/// pipeline and the GUI's live engine now share, and the GUI half is the one no
+/// harness reaches — a panel's capture needs a window, a Metal device and
+/// somebody to have clicked something. What the two halves have in common is
+/// this handshake, and it is all reachable with a fake guest.
+///
+/// Writes a real file because that is what the protocol is: the guest is asked
+/// by path and answers with the path when the bytes have landed.
+Uint8List _rawFrame(int width, int height, {int? rowBytes}) {
+  var stride = rowBytes ?? width * 4;
+  var header = ByteData(12)
+    ..setUint32(0, width, Endian.little)
+    ..setUint32(4, height, Endian.little)
+    ..setUint32(8, stride, Endian.little);
+  return (BytesBuilder()
+        ..add(header.buffer.asUint8List())
+        // Opaque white, so an annotation's magenta is visible against it.
+        ..add(List.filled(stride * height, 255)))
+      .toBytes();
+}
+
+void main() {
+  late Directory work;
+
+  setUp(() {
+    work = Directory.systemTemp.createTempSync('fw_frame_capture_test');
+  });
+
+  tearDown(() {
+    if (work.existsSync()) work.deleteSync(recursive: true);
+  });
+
+  /// A guest that writes [frame] where it is told and acknowledges it.
+  FrameCapture obliging({Uint8List? frame, int width = 4, int height = 3}) {
+    late FrameCapture capture;
+    capture = FrameCapture(
+      workDir: p.join(work.path, 'cap'),
+      send: (message) async {
+        var path = (message as CaptureMessage).path;
+        File(path).writeAsBytesSync(frame ?? _rawFrame(width, height));
+        capture.acknowledge(CapturedMessage(path));
+      },
+    );
+    return capture;
+  }
+
+  test('the frame it was handed is the picture it returns', () async {
+    var image = await obliging(width: 4, height: 3).capture();
+
+    expect(image.width, 4);
+    expect(image.height, 3);
+  });
+
+  test('the scratch file does not survive the read', () async {
+    var capture = obliging();
+    await capture.capture(name: 'shot');
+
+    // Tens of megabytes per frame. One left behind is also one a later capture
+    // could decode as its own answer if the guest never replied.
+    expect(
+      File(p.join(work.path, 'cap', 'shot.rawframe')).existsSync(),
+      isFalse,
+    );
+  });
+
+  test(
+    'a stale file from a timed-out capture is not read as this one',
+    () async {
+      var dir = Directory(p.join(work.path, 'cap'))
+        ..createSync(recursive: true);
+      // A 9x9 frame nobody asked for, left by an earlier attempt.
+      File(
+        p.join(dir.path, 'screenshot.rawframe'),
+      ).writeAsBytesSync(_rawFrame(9, 9));
+
+      var image = await obliging(width: 4, height: 3).capture();
+
+      expect(image.width, 4, reason: 'the stale 9x9 frame should be gone');
+    },
+  );
+
+  test('a crop cuts to a node box, in physical pixels', () async {
+    var image = await obliging(width: 10, height: 10).capture(
+      // Logical coordinates at ratio 2 — the space `InspectLayout` reports, so a
+      // node rect from the panel crops its own picture untransformed.
+      crop: const InspectLayout(x: 1, y: 1, width: 3, height: 2),
+      pixelRatio: 2,
+    );
+
+    expect(image.width, 6);
+    expect(image.height, 4);
+  });
+
+  test('a crop reaching past the frame is clamped, not refused', () async {
+    // What an overflow *is*, and the one case most worth being able to see.
+    var image = await obliging(
+      width: 10,
+      height: 10,
+    ).capture(crop: const InspectLayout(x: 8, y: 8, width: 40, height: 40));
+
+    expect(image.width, 2);
+    expect(image.height, 2);
+  });
+
+  test('a guest that reports an error fails the capture with it', () async {
+    late FrameCapture capture;
+    capture = FrameCapture(
+      workDir: p.join(work.path, 'cap'),
+      send: (_) async => capture.failAll(StateError('the demo blew up')),
+    );
+
+    // Rather than leaving the caller on the 30-second timeout to be told less.
+    await expectLater(
+      capture.capture(timeout: const Duration(seconds: 30)),
+      throwsA(isA<StateError>()),
+    );
+  });
+
+  test('a guest that never answers times out rather than hanging', () async {
+    var capture = FrameCapture(
+      workDir: p.join(work.path, 'cap'),
+      send: (_) async {},
+    );
+
+    await expectLater(
+      capture.capture(timeout: const Duration(milliseconds: 50)),
+      throwsA(isA<TimeoutException>()),
+    );
+  });
+
+  test('an ack for another path settles nothing', () async {
+    var capture = FrameCapture(
+      workDir: p.join(work.path, 'cap'),
+      send: (_) async {},
+    );
+    var pending = capture.capture(timeout: const Duration(milliseconds: 200));
+
+    // Two captures can be outstanding on one guest — a panel open while an
+    // agent screenshots — so an ack settles the one it names and no other.
+    expect(
+      capture.acknowledge(const CapturedMessage('/somewhere/else')),
+      isTrue,
+    );
+
+    await expectLater(pending, throwsA(isA<TimeoutException>()));
+  });
+
+  test('overlapping captures run one after the other', () async {
+    // The host keeps one armed capture path and `free`s the previous one, so a
+    // second request in flight replaces the first and the first frame is never
+    // written. Both the copy button and its shortcut can ask, so the ordering
+    // has to be enforced here rather than by every caller remembering.
+    var armed = <String>[];
+    late FrameCapture capture;
+    capture = FrameCapture(
+      workDir: p.join(work.path, 'cap'),
+      send: (message) async {
+        var path = (message as CaptureMessage).path;
+        armed.add(path);
+        // A frame takes a moment to arrive; the point is what happens meanwhile.
+        await Future<void>.delayed(const Duration(milliseconds: 20));
+        File(path).writeAsBytesSync(_rawFrame(4, 3));
+        capture.acknowledge(CapturedMessage(path));
+      },
+    );
+
+    var both = await Future.wait([capture.capture(), capture.capture()]);
+
+    // Unserialised, the second `send` armed its path while the first was still
+    // waiting, and the first timed out after thirty seconds.
+    expect(armed, hasLength(2));
+    expect(both.every((image) => image.width == 4), isTrue);
+  });
+
+  test('a failed capture does not poison the one behind it', () async {
+    var attempt = 0;
+    late FrameCapture capture;
+    capture = FrameCapture(
+      workDir: p.join(work.path, 'cap'),
+      send: (message) async {
+        var path = (message as CaptureMessage).path;
+        if (attempt++ == 0) {
+          capture.failAll(StateError('the demo blew up'));
+          return;
+        }
+        File(path).writeAsBytesSync(_rawFrame(4, 3));
+        capture.acknowledge(CapturedMessage(path));
+      },
+    );
+
+    var first = capture.capture();
+    var second = capture.capture();
+
+    await expectLater(first, throwsA(isA<StateError>()));
+    // The queue carries order, not failure: one bad capture must not fail every
+    // capture after it.
+    expect((await second).width, 4);
+  });
+
+  test('the scratch file is gone after a failure too', () async {
+    var capture = FrameCapture(
+      workDir: p.join(work.path, 'cap'),
+      // Writes the frame and never acks, which is what a guest that stopped
+      // drawing looks like.
+      send: (message) async => File(
+        (message as CaptureMessage).path,
+      ).writeAsBytesSync(_rawFrame(64, 64)),
+    );
+
+    await expectLater(
+      capture.capture(timeout: const Duration(milliseconds: 50)),
+      throwsA(isA<TimeoutException>()),
+    );
+
+    // Tens of megabytes uncompressed. Deleted only on the success path, it
+    // stayed until some later capture happened to reuse the same name.
+    expect(
+      File(p.join(work.path, 'cap', 'screenshot.rawframe')).existsSync(),
+      isFalse,
+    );
+  });
+
+  test('anything that is not an ack is left for the caller to handle', () {
+    var capture = FrameCapture(
+      workDir: p.join(work.path, 'cap'),
+      send: (_) async {},
+    );
+
+    // Both engines offer this every message they read, so it has to say plainly
+    // which ones it took.
+    expect(capture.acknowledge(const ReadyMessage()), isFalse);
+    expect(capture.acknowledge(const ErrorMessage('boom')), isFalse);
+  });
+}

--- a/app/test/plugins/ui_catalog_plugin_test.dart
+++ b/app/test/plugins/ui_catalog_plugin_test.dart
@@ -27,6 +27,7 @@ void main() {
   UiCatalogCore catalog({
     String? entrypoint,
     List<String> packages = const ['.'],
+    String flutterSdkRoot = '/tmp/flutter',
   }) {
     var worktree = Worktree(path: root.path);
     return UiCatalogCore(
@@ -39,7 +40,7 @@ void main() {
           declared: [for (var path in packages) Pkg(path)],
           discovered: packages,
           appContext: AppContext(logger: LogClient.print()),
-          flutterSdk: FlutterSdkPath('/tmp/flutter'),
+          flutterSdk: FlutterSdkPath(flutterSdkRoot),
         ),
         config: {
           'packages': [
@@ -445,6 +446,125 @@ Widget added() => const Placeholder();
           arguments: {'entry': 'demo/counter.dart#counter', 'find': 12},
         ),
         throwsArgumentError,
+      );
+    });
+  });
+
+  group('build-web', () {
+    // Every case here is refused *before* anything is compiled. A web build is
+    // tens of seconds, so an argument that cannot work should cost none of it —
+    // and the one a user hits most, web not being enabled, is a property of the
+    // package rather than of what they typed.
+
+    test('refuses a package that is not declared', () async {
+      var subject = catalog();
+
+      expect(
+        subject.invoke('build-web', arguments: {'package': 'packages/nope'}),
+        throwsArgumentError,
+      );
+    });
+
+    test('asks which package when the plugin has several', () async {
+      var subject = catalog(packages: const ['.', 'packages/ui']);
+
+      // Not "build the first one": two catalogues are declared separately
+      // because they are separate, and picking silently produces a page of the
+      // wrong demos.
+      await expectLater(
+        subject.invoke('build-web'),
+        throwsA(
+          isA<ArgumentError>().having(
+            (e) => '$e',
+            'message',
+            allOf(contains('packages/ui'), contains('more than one')),
+          ),
+        ),
+      );
+    });
+
+    test('refuses a base href that is not a directory path', () async {
+      var subject = catalog();
+
+      // `--base-href` is checked here rather than left to the tool, which
+      // rejects it only after the whole compile has run.
+      await expectLater(
+        subject.invoke('build-web', arguments: {'base-href': '/catalog'}),
+        throwsA(
+          isA<ArgumentError>().having(
+            (e) => '$e',
+            'message',
+            contains('begin and end with a slash'),
+          ),
+        ),
+      );
+    });
+
+    test('refuses a second build, and teardown stops the first', () async {
+      // A fake SDK whose `flutter` ignores its arguments and does not finish, so
+      // the first build is genuinely in flight. With a real (missing) path it
+      // failed at `Process.start` and cleared the guard before the second call
+      // even ran, which made this race rather than test anything.
+      var bin = Directory(p.join(root.path, 'fakesdk', 'bin'))
+        ..createSync(recursive: true);
+      var flutter = File(p.join(bin.path, 'flutter'))
+        ..writeAsStringSync('#!/bin/sh\nexec sleep 30\n');
+      Process.runSync('chmod', ['+x', flutter.path]);
+      Directory(p.join(root.path, 'web')).createSync(recursive: true);
+
+      var subject = catalog(flutterSdkRoot: p.join(root.path, 'fakesdk'));
+      var first = subject.buildWeb();
+      // Long enough for the child to be up and the guard registered.
+      await Future<void>.delayed(const Duration(milliseconds: 300));
+
+      // Both builds share `build/catalog/web_src`, and the generator deletes it
+      // recursively before writing — so a second build started mid-compile pulls
+      // the first one's sources out from under it.
+      await expectLater(
+        subject.buildWeb(),
+        throwsA(
+          isA<StateError>().having(
+            (e) => e.message,
+            'message',
+            contains('already running'),
+          ),
+        ),
+      );
+
+      // And closing the worktree ends it. A `flutter build web` child is not
+      // reaped when the Dart process exits, so without this it outlives the
+      // window and keeps writing into the user's project.
+      subject.dispose();
+      await expectLater(
+        first,
+        throwsA(
+          isA<StateError>().having(
+            (e) => e.message,
+            'message',
+            contains('cancelled'),
+          ),
+        ),
+      );
+    });
+
+    test('says how to enable web when the package has none', () async {
+      var subject = catalog();
+
+      // The fixture has demos and no `web/`, which is the ordinary state of a
+      // package nobody has built for the web before. The message has to carry
+      // the command, because nothing else on screen will.
+      await expectLater(
+        subject.invoke('build-web'),
+        throwsA(
+          isA<StateError>().having(
+            (e) => e.message,
+            'message',
+            allOf(
+              contains('no web/ directory'),
+              contains('flutter create --platforms=web'),
+            ),
+          ),
+        ),
       );
     });
   });

--- a/app/test/plugins/ui_catalog_serving_test.dart
+++ b/app/test/plugins/ui_catalog_serving_test.dart
@@ -1,0 +1,128 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutterware/plugins.dart';
+// ignore: implementation_imports
+import 'package:flutterware/src/log_client.dart';
+import 'package:flutterware_app/src/context.dart';
+import 'package:flutterware_app/src/plugins/native/ui_catalog_plugin.dart';
+import 'package:flutterware_app/src/plugins/plugin_host.dart';
+import 'package:flutterware_app/src/shell/workspace.dart';
+import 'package:flutterware_app/src/shell/worktree.dart';
+import 'package:flutterware_app/src/utils/flutter_sdk.dart';
+import 'package:path/path.dart' as p;
+
+/// Who owns a served page, and for how long.
+///
+/// The plugin does, not the dialog that asked: the dialog is closed the moment
+/// the tab is open, and a server that went with it would leave that tab showing
+/// a connection error. The worktree is the lifetime, which is what [dispose]
+/// here stands for.
+void main() {
+  late Directory root;
+  late UiCatalogPlugin plugin;
+  var disposed = false;
+
+  /// `ChangeNotifier.dispose` is documented as single-use and asserts on a
+  /// second call, so the test that disposes early says so rather than leaving
+  /// tearDown to trip over it.
+  void dispose() {
+    if (disposed) return;
+    disposed = true;
+    plugin.dispose();
+  }
+
+  setUp(() {
+    disposed = false;
+    root = Directory.systemTemp.createTempSync('fw_catalog_serve_test');
+    Directory(p.join(root.path, 'build', 'catalog', 'web'))
+      ..createSync(recursive: true)
+      ..childFile('index.html').writeAsStringSync('<!doctype html>');
+
+    var worktree = Worktree(path: root.path);
+    plugin = UiCatalogPlugin(
+      UiCatalogCore(
+        PluginHost(
+          id: uiCatalogPluginId,
+          label: 'UI catalog',
+          worktree: worktree,
+          workspace: Workspace(
+            root: worktree.path,
+            declared: [Pkg('.')],
+            discovered: const ['.'],
+            appContext: AppContext(logger: LogClient.print()),
+            flutterSdk: FlutterSdkPath('/tmp/flutter'),
+          ),
+          config: const {
+            'packages': [
+              {'path': '.'},
+            ],
+          },
+        ),
+      ),
+    );
+  });
+
+  tearDown(() {
+    dispose();
+    root.deleteSync(recursive: true);
+  });
+
+  Future<bool> reachable(Uri url) async {
+    var client = HttpClient();
+    try {
+      var response = await (await client.getUrl(url)).close();
+      await response.drain<void>();
+      return response.statusCode == 200;
+    } on SocketException {
+      return false;
+    } finally {
+      client.close(force: true);
+    }
+  }
+
+  test('a relative output is resolved against the worktree', () async {
+    var url = await plugin.serveBuild('build/catalog/web');
+
+    expect(url.host, '127.0.0.1');
+    expect(await reachable(url), isTrue);
+  });
+
+  test('serving the same page twice keeps the port', () async {
+    var first = await plugin.serveBuild('build/catalog/web');
+    var second = await plugin.serveBuild('build/catalog/web');
+
+    // A rebuild writes over the same directory, and the tab that is already
+    // open is the one that should show it. A new port each time would leave
+    // that tab pointed at a server nobody is going to look at again.
+    expect(second, first);
+    expect(await reachable(first), isTrue);
+  });
+
+  test('a changed base href rebinds rather than answering 404', () async {
+    var atRoot = await plugin.serveBuild('build/catalog/web');
+    var atPrefix = await plugin.serveBuild(
+      'build/catalog/web',
+      basePath: '/catalog/',
+    );
+
+    expect(atPrefix.path, '/catalog/');
+    expect(await reachable(atPrefix), isTrue);
+    // The old mount is gone with the server that held it — the same files under
+    // a different base href are a different page to a browser, and keeping both
+    // would serve one of them broken.
+    expect(await reachable(atRoot), isFalse);
+  });
+
+  test('closing the worktree stops the server', () async {
+    var url = await plugin.serveBuild('build/catalog/web');
+    expect(await reachable(url), isTrue);
+
+    dispose();
+    expect(await reachable(url), isFalse);
+  });
+}
+
+extension on Directory {
+  File childFile(String name) => File(p.join(path, name));
+}

--- a/app/test/shell/child_commands_test.dart
+++ b/app/test/shell/child_commands_test.dart
@@ -1,0 +1,230 @@
+import 'dart:io';
+
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutterware/plugins.dart';
+// ignore: implementation_imports
+import 'package:flutterware/src/log_client.dart';
+import 'package:flutterware_app/src/context.dart';
+import 'package:flutterware_app/src/plugins/manifest_loader.dart';
+import 'package:flutterware_app/src/plugins/native_plugin.dart';
+import 'package:flutterware_app/src/plugins/plugin_core.dart';
+import 'package:flutterware_app/src/plugins/registry.dart';
+import 'package:flutterware_app/src/shell/shell_controller.dart';
+import 'package:flutterware_app/src/shell/shell_view.dart';
+import 'package:flutterware_app/src/shell/worktree_discovery.dart';
+import 'package:flutterware_app/src/utils/flutter_sdk.dart';
+
+/// The ⋮ on a sidebar child row.
+///
+/// Generic on purpose — the shell asks the plugin what it offers and draws
+/// whatever comes back — so these use a fake plugin rather than the catalog.
+/// What the catalog puts behind it is one command; what the shell has to get
+/// right is that the affordance exists, only where a plugin offers something,
+/// and hands the choice back.
+const _listing = 'worktree /repo\nbranch refs/heads/main\n';
+
+const _manifestJson =
+    '{"version":1,"plugins":['
+    '{"id":"a.deps","label":"Dependencies"},'
+    '{"id":"a.tests","label":"Tests"}]}';
+
+class _FakeCore extends PluginCore {
+  _FakeCore(super.host, {this.children = const []});
+
+  final List<PluginChild> children;
+
+  @override
+  PluginReport get report =>
+      PluginReport(id: host.id, label: host.label, children: children);
+}
+
+/// Offers a command on every child row, and records which row chose it.
+class _Commanding extends NativePlugin<_FakeCore> {
+  _Commanding(super.core);
+
+  static final chosen = <String>[];
+
+  @override
+  List<PluginChildCommand> childCommands(
+    BuildContext context,
+    String childId,
+  ) => [
+    PluginChildCommand(
+      label: 'Build a web page…',
+      onSelected: (_) => chosen.add(childId),
+    ),
+  ];
+
+  @override
+  Widget buildPanel(BuildContext context) => const SizedBox();
+}
+
+/// Offers nothing, which is what every plugin does until it opts in.
+class _Silent extends NativePlugin<_FakeCore> {
+  _Silent(super.core);
+
+  @override
+  Widget buildPanel(BuildContext context) => const SizedBox();
+}
+
+class _StubLoader implements ManifestLoader {
+  @override
+  Future<PluginManifest?> load(String path) async =>
+      PluginManifest.parse(_manifestJson);
+
+  @override
+  Future<({PluginManifest? manifest, String? error})> tryLoad(
+    String path,
+  ) async => (manifest: PluginManifest.parse(_manifestJson), error: null);
+
+  @override
+  String get dartExecutable => 'dart';
+}
+
+Future<ShellController> _pump(WidgetTester tester) async {
+  var shell = ShellController(
+    appContext: AppContext(logger: LogClient.print()),
+    flutterSdk: FlutterSdkPath('/tmp/flutter'),
+    registry: PluginRegistry({
+      'a.deps': panelFor<_FakeCore>(_Commanding.new),
+      'a.tests': panelFor<_FakeCore>(_Silent.new),
+    }),
+    coreRegistry: PluginCoreRegistry({
+      'a.deps': (h) => _FakeCore(
+        h,
+        children: const [
+          PluginChild(id: '.', label: 'root', status: Status.info('building')),
+          PluginChild(
+            id: 'packages/ui',
+            label: 'packages/ui',
+            status: Status.warn('10 assets · 347 kB · 2 problems'),
+          ),
+        ],
+      ),
+      'a.tests': (h) => _FakeCore(
+        h,
+        children: const [PluginChild(id: '.', label: 'root')],
+      ),
+    }),
+    manifestLoader: _StubLoader(),
+    discovery: WorktreeDiscovery(
+      runProcess: (_, _, {workingDirectory}) async =>
+          ProcessResult(0, 0, _listing, ''),
+    ),
+  );
+  await shell.start('/repo');
+  await tester.pumpWidget(ShellApp(shell));
+  await tester.pumpAndSettle();
+  return shell;
+}
+
+/// Moves the pointer onto [finder] and leaves it there — the ⋮ is drawn only
+/// under the pointer, so a test that merely taps where it would be taps the row.
+Future<void> _hover(WidgetTester tester, Finder finder) async {
+  var pointer = TestPointer(1, PointerDeviceKind.mouse);
+  await tester.sendEventToBinding(pointer.hover(tester.getCenter(finder)));
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  setUp(_Commanding.chosen.clear);
+
+  testWidgets('a row shows no ⋮ until the pointer is on it', (tester) async {
+    var shell = await _pump(tester);
+    shell.selectPlugin('a.deps');
+    await tester.pumpAndSettle();
+
+    // The selected row keeps its ⋮ — you have just clicked it, and a control
+    // that vanishes as you travel to it is one you cannot use.
+    expect(find.byIcon(Icons.more_vert), findsOneWidget);
+
+    await _hover(tester, find.text('packages/ui'));
+    expect(find.byIcon(Icons.more_vert), findsNWidgets(2));
+  });
+
+  testWidgets('a plugin offering nothing gets no ⋮', (tester) async {
+    var shell = await _pump(tester);
+    shell.selectPlugin('a.tests');
+    await tester.pumpAndSettle();
+
+    await _hover(tester, find.text('root'));
+    expect(find.byIcon(Icons.more_vert), findsNothing);
+  });
+
+  testWidgets('the ⋮ sits at the right edge, whatever the status says', (
+    tester,
+  ) async {
+    var shell = await _pump(tester);
+    shell.selectPlugin('a.deps');
+    await tester.pumpAndSettle();
+
+    // Two rows whose statuses are very different lengths. The ⋮ has to land in
+    // the same column on both: it used to follow the status text, because the
+    // label and the status split the row's free space between them and the
+    // half the status did not use became trailing space after the button.
+    await _hover(tester, find.text('packages/ui'));
+
+    var dots = find.byIcon(Icons.more_vert);
+    expect(dots, findsNWidgets(2));
+
+    var rights = [for (var i = 0; i < 2; i++) tester.getRect(dots.at(i)).right];
+    expect(rights[0], moreOrLessEquals(rights[1], epsilon: 0.5));
+
+    // And flush against the row's own right padding rather than floating.
+    var row = tester.getRect(find.text('packages/ui').hitTestable()).right;
+    expect(rights[1], greaterThan(row));
+  });
+
+  testWidgets('the status sits against the name, not in the middle', (
+    tester,
+  ) async {
+    var shell = await _pump(tester);
+    shell.selectPlugin('a.deps');
+    await tester.pumpAndSettle();
+
+    // The row reads `root  building  ⋮`. When the label was Expanded it filled its
+    // whole share first, which left the status stranded mid-row with the name
+    // nowhere near it.
+    var label = tester.getRect(find.text('root'));
+    var status = tester.getRect(find.text('building'));
+
+    // One gap between them, nothing else.
+    expect(status.left - label.right, lessThan(8.0));
+  });
+
+  testWidgets('a status that fits is not truncated to make room', (
+    tester,
+  ) async {
+    var shell = await _pump(tester);
+    shell.selectPlugin('a.deps');
+    await tester.pumpAndSettle();
+
+    // A flexible child is clamped to its *share* of the row whether or not the
+    // other child wanted it, so a flexible status came out as "buildi…" beside
+    // a four-letter name with the rest of the row empty. The catalog entry is
+    // what showed it; this is what keeps it shown.
+    var status = tester.renderObject<RenderParagraph>(find.text('building'));
+    expect(status.didExceedMaxLines, isFalse);
+  });
+
+  testWidgets('choosing a command says which row it was', (tester) async {
+    var shell = await _pump(tester);
+    shell.selectPlugin('a.deps');
+    await tester.pumpAndSettle();
+
+    await _hover(tester, find.text('packages/ui'));
+    // The second ⋮ is the hovered row's; the first belongs to the selected one.
+    await tester.tap(find.byIcon(Icons.more_vert).last);
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Build a web page…'));
+    await tester.pumpAndSettle();
+
+    // The child id, not the label: a command acts on the package the row
+    // stands for, and those differ for the root.
+    expect(_Commanding.chosen, ['packages/ui']);
+  });
+}

--- a/app/test/utils/image_clipboard_test.dart
+++ b/app/test/utils/image_clipboard_test.dart
@@ -1,0 +1,73 @@
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutterware_app/src/utils/image_clipboard.dart';
+
+/// What the Swift side is asked, and what it is believed when it answers.
+///
+/// The pasteboard write itself cannot be reached from a test — it is
+/// `NSPasteboard` in the app's own runner. What *can* drift without anything
+/// noticing is the contract between the two halves: a renamed method or a
+/// renamed argument key compiles on both sides and fails only under a pointer.
+/// That is what these pin.
+void main() {
+  const channel = MethodChannel('flutterware/clipboard');
+  var png = Uint8List.fromList([137, 80, 78, 71, 13, 10, 26, 10]);
+
+  late List<MethodCall> calls;
+
+  void answerWith(Object? Function(MethodCall call) handler) {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (call) async {
+          calls.add(call);
+          return handler(call);
+        });
+  }
+
+  setUp(() => calls = []);
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, null);
+  });
+
+  test('the bytes reach the platform under the name it reads them by', () async {
+    answerWith((_) => true);
+    await ImageClipboard.setPng(png);
+
+    expect(calls, hasLength(1));
+    expect(calls.single.method, 'setImage');
+    // A typed list, not a plain List<int>: the standard codec sends the latter
+    // as an int array, which `FlutterStandardTypedData` on the Swift side
+    // declines — and declines at run time, in the one path no test covers.
+    var argument = (calls.single.arguments as Map)['png'] as Uint8List;
+    expect(argument, png);
+  });
+
+  test(
+    'a platform that says it did not write is a failure, not a shrug',
+    () async {
+      answerWith((_) => false);
+      // The alternative is a copy that reports success and puts nothing on the
+      // clipboard, which is discovered at the paste — by then nowhere near here.
+      await expectLater(ImageClipboard.setPng(png), throwsA(isA<StateError>()));
+    },
+  );
+
+  test('an error from the platform is not swallowed', () async {
+    answerWith((_) => throw PlatformException(code: 'decode_failed'));
+    await expectLater(
+      ImageClipboard.setPng(png),
+      throwsA(isA<PlatformException>()),
+    );
+  });
+
+  test('support tracks where the preview can actually exist', () {
+    // The picture being copied is composited by the embedder host, which is
+    // Metal and IOSurface throughout. Anywhere else there is nothing to copy,
+    // so this is the real answer rather than a placeholder.
+    expect(ImageClipboard.isSupported, Platform.isMacOS);
+  });
+}

--- a/app/tool/catalog/demos/sidebar_row.dart
+++ b/app/tool/catalog/demos/sidebar_row.dart
@@ -1,0 +1,204 @@
+import 'package:flutter/material.dart';
+import 'package:flutterware/plugins.dart';
+import 'package:flutterware/ui_catalog.dart';
+import 'package:flutterware_app/src/plugins/native_plugin.dart';
+import 'package:flutterware_app/src/shell/sidebar_row.dart';
+import 'package:flutterware_app/src/ui/theme.dart';
+
+import 'command_palette.dart' show wrapInAppTheme;
+
+/// A package row in the shell's sidebar, in the states it is actually seen in.
+///
+/// The row it draws is `name · status · ⋮`, and the arrangement is the whole
+/// point of having a demo for something this small: the name and the status sit
+/// together on the left, and the ⋮ is pinned to the right edge so the dots form
+/// a column down the sidebar whatever the statuses say. Both have been wrong —
+/// the ⋮ used to follow the status text, and fixing that pushed the status into
+/// the middle of the row.
+///
+/// Stacked rather than one state per entry: the alignment claims above are
+/// about rows *relative to each other*, and a gallery that showed them one at a
+/// time could not have caught either bug.
+///
+/// No Figma behind this — it is flutterware's own chrome, and the arrangement
+/// was specified in review rather than drawn.
+/// The sidebar's real width. These rows are as wide as they are, and a demo
+/// that let them stretch to the window would not show the ellipsis that a long
+/// package name actually hits.
+const _sidebarWidth = 232.0;
+
+/// Enough commands to open a menu with, for the states that have a ⋮.
+List<PluginChildCommand> get _commands => [
+  PluginChildCommand(
+    label: 'Build a web page…',
+    icon: Icons.language,
+    onSelected: (_) {},
+  ),
+];
+
+@Demo(name: 'Every state', group: 'Sidebar row', wrapper: wrapInAppTheme)
+Widget sidebarRowStates() => const _Rail(
+  children: [
+    _Labelled(
+      'idle',
+      SidebarChildRow(
+        label: 'app',
+        status: Status.none,
+        selected: false,
+        onTap: _noop,
+      ),
+    ),
+    _Labelled(
+      'with a status',
+      SidebarChildRow(
+        label: 'examples/example',
+        status: Status.info('building'),
+        selected: false,
+        onTap: _noop,
+      ),
+    ),
+    _Labelled(
+      'selected — the ⋮ stays without the pointer',
+      _WithCommands(
+        label: 'examples/example',
+        status: Status.info('building'),
+        selected: true,
+      ),
+    ),
+    _Labelled(
+      'every tone',
+      Column(
+        children: [
+          SidebarChildRow(
+            label: 'packages/core',
+            status: Status.neutral('58 packages'),
+            selected: false,
+            onTap: _noop,
+          ),
+          SidebarChildRow(
+            label: 'packages/ui',
+            status: Status.warn('2 problems'),
+            selected: false,
+            onTap: _noop,
+          ),
+          SidebarChildRow(
+            label: 'packages/legacy',
+            status: Status.error('failed to scan'),
+            selected: false,
+            onTap: _noop,
+          ),
+        ],
+      ),
+    ),
+    _Labelled(
+      'the ⋮ lines up whatever the status says',
+      Column(
+        children: [
+          _WithCommands(
+            label: 'app',
+            status: Status.info('building'),
+            selected: true,
+          ),
+          _WithCommands(
+            label: 'examples/example',
+            status: Status.warn('10 assets · 347 kB · 2 problems'),
+            selected: true,
+          ),
+          _WithCommands(label: 'tools', status: Status.none, selected: true),
+        ],
+      ),
+    ),
+    _Labelled(
+      'a name too long for the rail keeps the status',
+      _WithCommands(
+        label: 'packages/design_system_foundations',
+        status: Status.info('building'),
+        selected: true,
+      ),
+    ),
+  ],
+);
+
+/// A row that offers commands, so the ⋮ is drawn.
+///
+/// Separate because [PluginChildCommand] holds a callback and so cannot be
+/// const, and the states above are otherwise all const.
+class _WithCommands extends StatelessWidget {
+  const _WithCommands({
+    required this.label,
+    required this.status,
+    required this.selected,
+  });
+
+  final String label;
+  final Status status;
+  final bool selected;
+
+  @override
+  Widget build(BuildContext context) => SidebarChildRow(
+    label: label,
+    status: status,
+    selected: selected,
+    commands: _commands,
+    onTap: _noop,
+  );
+}
+
+void _noop() {}
+
+/// The rail these rows live in, at the width they live at.
+class _Rail extends StatelessWidget {
+  const _Rail({required this.children});
+
+  final List<Widget> children;
+
+  @override
+  Widget build(BuildContext context) {
+    var colors = context.colors;
+    return ColoredBox(
+      color: colors.bg,
+      child: ListView(
+        padding: const EdgeInsets.symmetric(vertical: FwSpacing.xl),
+        children: [
+          for (var child in children)
+            Align(
+              alignment: Alignment.centerLeft,
+              child: SizedBox(width: _sidebarWidth, child: child),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+/// A caption above a state, so a screenshot of this entry says what each row is
+/// meant to be showing.
+class _Labelled extends StatelessWidget {
+  const _Labelled(this.caption, this.child);
+
+  final String caption;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) => Padding(
+    padding: const EdgeInsets.only(bottom: FwSpacing.xl),
+    child: Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Padding(
+          padding: const EdgeInsets.fromLTRB(
+            FwSpacing.lg,
+            0,
+            FwSpacing.lg,
+            FwSpacing.xs,
+          ),
+          child: Text(
+            caption,
+            style: context.type.micro.copyWith(color: context.colors.mut3),
+          ),
+        ),
+        child,
+      ],
+    ),
+  );
+}

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -564,3 +564,27 @@ unreachable: List<CatalogAuditFailure>   # Packages that could not be audited at
 |---|---|---|---|---|
 | `package` | choice | no | — | Which declared package; all of them when omitted |
 | `path` | string | no | — | A directory or one file — `demo/settings`, `demo/settings/tile.dart`. Either package-relative or worktree-relative; both are accepted because an entry id is the first and a shell tab-completes the second. |
+
+#### `build-web` — Build a web page
+
+Compile the whole catalog into a browsable page — the demos themselves running in a browser, with their knobs, not pictures of them. Needs the package to have web enabled; says so, with the command, when it does not.
+
+```sh
+fw run ui_catalog build-web [--package=…] [--output=…] [--base-href=…]
+```
+
+Returns `CatalogWebBuildResult`:
+
+```
+package: String
+output: String   # The directory to serve, worktree-relative where it is inside the worktree — a path that survives being read on another machine.
+indexHtml: String   # The page to open, relative to the same root as [output].
+entries: int   # How many entries the page can show.
+durationMs: int
+```
+
+| parameter | kind | required | default | |
+|---|---|---|---|---|
+| `package` | choice | no | — | Which declared package; the only one when there is one |
+| `output` | string | no | — | Where the page goes. Package-relative unless absolute; defaults to `build/catalog/web`. |
+| `base-href` | string | no | — | What `flutter build web --base-href` takes, for serving the page from a subdirectory rather than the root of a host. Must begin and end with a slash — `/catalog/`. |

--- a/examples/example/.gitignore
+++ b/examples/example/.gitignore
@@ -32,7 +32,6 @@
 /build/
 
 # Web related
-lib/generated_plugin_registrant.dart
 
 # Symbolication related
 app.*.symbols

--- a/examples/example/analysis_options.yaml
+++ b/examples/example/analysis_options.yaml
@@ -1,16 +1,6 @@
 include: ../../analysis_options.yaml
 
 analyzer:
-  errors:
-    # `assets/images/missing.png` is declared and absent on purpose — it is the
-    # fixture for the asset inspector's "declared, not on disk" finding. See
-    # assets/README.md. The analyzer spotting it is the correct behaviour; it
-    # just must not fail the build.
-    #
-    # Worth knowing: this rule covers `assets:` only. The equally deliberate
-    # missing font file beside it (`assets/fonts/Roboto-Italic.ttf`) produces no
-    # diagnostic at all, which is a good part of why that one is easy to ship.
-    asset_does_not_exist: ignore
   exclude:
     - build/**
     - android/**

--- a/examples/example/assets/README.md
+++ b/examples/example/assets/README.md
@@ -27,8 +27,15 @@ one of these "bugs" breaks the case it stands for.
 | `images/icons/star.png` | a directory declaration **does not recurse**. `assets/images/` is declared, this file is inside it, and it never reaches the bundle |
 | `images/badge.png` + `images/3.0x/badge.png` | a `3.0x` with no `2.0x` beside it |
 | `images/wordmark.png` | byte-identical to `logo.png` under a second key |
-| `assets/images/missing.png` (pubspec) | declared, not on disk |
-| `assets/fonts/Roboto-Italic.ttf` (pubspec) | the same, for a font entry — which fails differently, since the family still resolves for its other two weights |
+
+Every fixture above is a *file* that is wrong. There are deliberately no
+**declared-but-absent** fixtures — `missingFile` and `missingFontFile` — even
+though the audit reports both, and the reason is that this package has to stay
+buildable: `flutter build` treats a declared asset with no file as fatal, so one
+of those fixtures makes `fw run ui_catalog build-web` (and every other build of
+this example) impossible. Both findings are covered instead by
+`app/test/assets/asset_catalog_test.dart`, which can declare a missing file
+without having to compile anything.
 
 ## Provenance
 

--- a/examples/example/pubspec.yaml
+++ b/examples/example/pubspec.yaml
@@ -69,7 +69,6 @@ flutter:
   # is meant to expose. Several of these are wrong on purpose.
   assets:
     - assets/images/
-    - assets/images/missing.png
     - assets/icons/check.svg
     - path: assets/icons/heart.svg
     - assets/animations/
@@ -86,9 +85,6 @@ flutter:
         - asset: assets/fonts/Roboto-Regular.ttf
         - asset: assets/fonts/Roboto-Bold.ttf
           weight: 700
-        # Declared, and not on disk — the font half of assets/images/missing.png.
-        - asset: assets/fonts/Roboto-Italic.ttf
-          style: italic
   #
   # For details regarding fonts from package dependencies,
   # see https://flutter.dev/custom-fonts/#from-packages


### PR DESCRIPTION
Two asks, and they turned out to share a seam: the frame the guest composited.

## Copy or save the preview

`FrameCapture` lifts the capture exchange out of the headless pipeline so the GUI's live engine can use it too, and two buttons in the catalog's top bar (plus ⌘⇧C) photograph the running guest.

That is GUI-only for a real reason rather than an oversight: `fw` attaches over a VM service and has no frames to ask for, which is why the `screenshot` action already refuses `--live` for a picture. The panel is the only place holding the socket the frame comes over — so this is the only way to photograph a demo *as somebody left it*, with the dropdown they opened and the row they scrolled to. With a node selected in the Elements tab both buttons crop to it, out of the real composited frame.

Copy goes through a small `NSPasteboard` plugin of our own rather than a package that builds through cargokit: the CLI compiles `app/` on the user's machine at first run, so a dependency there would make a Rust toolchain a requirement for installing flutterware.

## The catalog as a web page

`build-web` compiles the demos themselves into a browsable page — with their knobs, not pictures of them.

`WebAppGenerator` writes an app hosting the **old `UICatalog` widget**, and that is not a stopgap. Its tree, search, device frames and parameters panel already render exactly the model new demos produce: a demo declares its knobs through `context.uiCatalog.parameters` either way. Knobs travel over the VM service in the GUI only because the panel is in another process; on a page the panel and the demo are one isolate and there is no wire at all. `CatalogWrapperWriter` is shared with the guest's entrypoint so both emit the same wrapper — what it encodes is the demo's own *scope*, and a second copy would drift silently into "renders in the panel, not on the page".

It builds from the target package so its `web/index.html`, assets and fonts come along; a package with no `web/` is refused up front with the `flutter create` that fixes it, rather than the build quietly writing four files into someone's project.

`build-web` is a `PluginAction`, so `fw` and MCP get it for nothing. The GUI reaches the same core method directly, because a build is tens of seconds and `Job` has no event to carry those lines yet. The dialog echoes the equivalent command line for discovery, and a test checks its flags against the ones the action declares — a command shown to a user that fails when they run it is worse than none.

`CatalogWebServer` serves the result on loopback and `Open in browser` opens it. Loopback rather than `anyIPv4` on purpose: a catalog is unreleased UI. It honours `--base-href`, because a page built for `/catalog/` and served at the root loads and then fetches nothing it needs.

## Along the way

- `SidebarChildRow` comes out of `shell_view.dart` taking plain data, which is what let it into the catalog — and the new entry immediately showed a status truncated to "buildi…" beside a four-letter name, because a loose `Flexible` is clamped to its share whether or not the sibling wanted it.
- `PluginChildCommand` is a generic ⋮ on any plugin's sidebar row; the catalog puts one command behind it.
- `examples/example` no longer declares two assets it does not ship. They were deliberate asset-inspector fixtures, but `flutter build` treats a missing declared asset as fatal, so they made the sample package impossible to build for the web at all. Both findings keep their coverage in `asset_catalog_test.dart`, which can declare a missing file without compiling anything.

## Verified

`fw run ui_catalog build-web` produces a real page, loaded in a browser at the root and under a `/catalog/` prefix: tree, live thumbnails, device frames, and a knob turned in-process with the demo rebuilding on it.

1298 app tests, 14 integration tests, 216 root tests, analyzer clean, `prepare_submit.dart` no-diff.

Six findings from a self-review are fixed in this branch. Three are worth naming because the reasons are structural:

- **Captures are serialised.** `native/host.c` keeps *one* armed capture path and `free`s the previous one, so a second request in flight replaces the first and the first frame is never written — the copy button and its shortcut could both ask. Concurrency was never possible downstream, so the queue belongs in `FrameCapture` rather than in every caller.
- **Generated map keys are unique per branch.** Discovery rejects a duplicate id, not a duplicate name, so two files may both declare `@Demo(name: 'Default')`. Emitted as-is that was a repeated key in a map literal: the last won and the other demo was simply not on the page, while the panel keyed by id and showed both.
- **A `flutter build web` child is killed on teardown, and a second build is refused.** Such a child is not reaped when the Dart process exits, and the generator deletes `web_src` recursively before writing — so an orphan had its own sources removed underneath it.

## Known gap

`CatalogShell` axes render at their defaults on the built page. `CatalogAxes` is a plain in-process singleton with `describe()`/`apply()`, so a top-bar strip needs no wire — it is a contained follow-up rather than a missing piece of plumbing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
